### PR TITLE
Add Aaron.Akka.* package naming prefix

### DIFF
--- a/src/Akka.Reminders.Sql/Akka.Reminders.Sql.csproj
+++ b/src/Akka.Reminders.Sql/Akka.Reminders.Sql.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PackageId>Aaron.Akka.Reminders.Sql</PackageId>
     <Description>SQL Server and PostgreSQL storage implementation for Akka.Reminders.</Description>
     <PackageTags>akka;akkadotnet;akka.reminders;sql;sqlserver;postgresql;</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Akka.Reminders/Akka.Reminders.csproj
+++ b/src/Akka.Reminders/Akka.Reminders.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <PackageId>Aaron.Akka.Reminders</PackageId>
         <Description>Durable, re-entrant reminders system for Akka.Cluster.Sharding.</Description>
         <PackageTags>akka;akkadotnet;akka.cluster.sharding;akka.reminders;akka-reminders;</PackageTags>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
## Summary
- Updated NuGet package IDs to use `Aaron.Akka.*` prefix instead of `Akka.*`
- Avoids conflicts with reserved namespace on NuGet.org
- Assembly names remain unchanged for code compatibility

## Changes
- `Akka.Reminders` → `Aaron.Akka.Reminders` (NuGet package)
- `Akka.Reminders.Sql` → `Aaron.Akka.Reminders.Sql` (NuGet package)

## Verification
Tested with `dotnet pack` to confirm packages are generated with correct naming:
- `Aaron.Akka.Reminders.1.0.0.nupkg`
- `Aaron.Akka.Reminders.Sql.1.0.0.nupkg`

Assembly names (.dll files) remain as `Akka.Reminders` and `Akka.Reminders.Sql` for backward compatibility.