### PR TITLE
Fix workflow permissions and make NuGet push idempotent

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: write
+
 jobs:
   publish-nuget:
 
@@ -38,7 +41,7 @@ jobs:
       run:  dotnet pack /p:PackageVersion=${{ github.ref_name }} -c Release -o ./output
 
     - name: Push Packages
-      run: dotnet nuget push "output/*.nupkg" -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json
+      run: dotnet nuget push "output/*.nupkg" -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
 
     - name: release
       uses: actions/create-release@v1
@@ -46,7 +49,7 @@ jobs:
       with:
         draft: false
         prerelease: false
-        release_name: 'Akka.Hosting ${{ github.ref_name }}'
+        release_name: 'Akka.Reminders ${{ github.ref_name }}'
         tag_name: ${{ github.ref }}
         body_path: RELEASE_NOTES.md
       env:


### PR DESCRIPTION
## Summary
- Add `permissions: contents: write` to allow GitHub release creation
- Add `--skip-duplicate` flag to NuGet push command for idempotent retries
- Fix release name from "Akka.Hosting" to "Akka.Reminders"

## Problem
The publish workflow failed at the release creation step with "Resource not accessible by integration" error because the `GITHUB_TOKEN` lacked write permissions for releases.

## Solution
Added explicit `permissions` block to grant contents write access, which allows the workflow to create releases. Also made NuGet push idempotent so duplicate version uploads don't fail the workflow.

## Verification
This will fix workflow run failures like https://github.com/Aaronontheweb/akka-reminders/actions/runs/19091613486