### PR TITLE
Add WithLocalReminders() for fast testing without cluster bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,11 +256,18 @@ For production environments, you may prefer to manually create the database sche
 For development and testing, use the built-in in-memory storage:
 
 ```csharp
+// Explicit convenience method (recommended)
+.WithReminders("reminder-host", reminders => reminders
+    .WithInMemoryStorage())
+
+// Or manually instantiate
 .WithReminders("reminder-host", reminders => reminders
     .WithStorage(_ => new InMemoryReminderStorage()))
 ```
 
 > ⚠️ **Warning:** In-memory storage is not durable and should only be used for development/testing.
+>
+> 💡 **Tip:** For unit tests, consider using `WithLocalReminders()` instead for instant startup without cluster bootstrap delays. See the [Testing](#testing) section for details.
 
 ### Reminder Settings
 
@@ -443,6 +450,73 @@ Reminders progress through the following states:
 - **Cancelled**: Manually cancelled by user
 
 ## Testing
+
+### Local Reminders for Fast Testing
+
+For unit and integration tests, use `WithLocalReminders()` to avoid the 30+ second ClusterSingleton bootstrap delay:
+
+```csharp
+using Akka.Hosting;
+using Akka.Reminders;
+
+public class ReminderTests : Akka.Hosting.TestKit.TestKit
+{
+    private readonly TestShardRegionResolver _resolver = new();
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        // Configure local reminders - starts instantly without cluster
+        builder.WithLocalReminders(reminders => reminders
+            .WithInMemoryStorage()
+            .WithResolver(_resolver)
+            .WithSettings(new ReminderSettings
+            {
+                MaxSlippage = TimeSpan.FromMilliseconds(100),
+                MaxDeliveryAttempts = 3
+            }));
+    }
+
+    [Fact]
+    public async Task Reminder_ShouldDeliver_ToRegisteredShardRegion()
+    {
+        // Arrange
+        var targetActor = CreateTestProbe("billing-actor");
+        _resolver.RegisterShardRegion("billing-shard", targetActor);
+
+        var client = Sys.ReminderClient().CreateClient("billing-shard", "customer-123");
+
+        // Act - Schedule reminder
+        await client.ScheduleSingleReminderAsync(
+            new ReminderKey("retry-payment"),
+            DateTimeOffset.UtcNow.AddMilliseconds(200),
+            new PaymentRetry());
+
+        // Assert - Reminder delivered
+        var envelope = targetActor.ExpectMsg<ShardingEnvelope>(TimeSpan.FromSeconds(2));
+        Assert.Equal("customer-123", envelope.EntityId);
+        Assert.IsType<PaymentRetry>(envelope.Message);
+    }
+}
+```
+
+**Key Differences:**
+
+| Feature | `WithReminders()` (Production) | `WithLocalReminders()` (Testing) |
+|---------|-------------------------------|----------------------------------|
+| **Startup Time** | 30+ seconds (ClusterSingleton bootstrap) | Instant (regular actor) |
+| **Clustering** | Required | Not required |
+| **Shard Resolver** | Uses real ClusterSharding | Manual registration via `TestShardRegionResolver` |
+| **Storage** | Configurable (SQL, in-memory) | Defaults to in-memory |
+| **Use Case** | Production deployments | Unit/integration tests |
+
+**Why Use Local Reminders?**
+
+- ✅ **No Cluster Bootstrap Delay**: Tests start instantly
+- ✅ **Simple Setup**: Register test probes as shard regions
+- ✅ **Full Functionality**: All reminder features work in local mode
+- ✅ **Better Test Isolation**: No shared cluster state between tests
+
+### Time-Based Testing with TestScheduler
 
 Akka.Reminders uses the `ITimeProvider` abstraction (mapped to `IScheduler`) for time operations, making it fully testable with `TestScheduler`:
 

--- a/src/Akka.Reminders.Tests/LocalReminderSpecs.cs
+++ b/src/Akka.Reminders.Tests/LocalReminderSpecs.cs
@@ -1,0 +1,117 @@
+using Akka.Actor;
+using Akka.Cluster.Sharding;
+using Akka.Hosting;
+using Akka.Reminders.Sharding;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Reminders.Tests;
+
+/// <summary>
+/// Demonstrates the use of WithLocalReminders for fast, non-clustered testing of reminder functionality.
+/// </summary>
+public class LocalReminderSpecs : Akka.Hosting.TestKit.TestKit
+{
+    private readonly TestShardRegionResolver _resolver;
+
+    public LocalReminderSpecs(ITestOutputHelper output) : base(output: output)
+    {
+        // Create a test shard region resolver that we can control
+        _resolver = new TestShardRegionResolver();
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        // Configure local reminders for fast testing without cluster bootstrap delays
+        builder.WithLocalReminders(reminders => reminders
+            .WithInMemoryStorage()
+            .WithResolver(_resolver)
+            .WithSettings(new ReminderSettings
+            {
+                MaxSlippage = TimeSpan.FromMilliseconds(100),
+                StorageTimeout = TimeSpan.FromSeconds(1),
+                MaxDeliveryAttempts = 3,
+                RetryBackoffBase = TimeSpan.FromMilliseconds(100)
+            }));
+    }
+
+    [Fact]
+    public void WithLocalReminders_ShouldStartInstantly_WithoutClusterBootstrapDelay()
+    {
+        // The fact that this test runs at all demonstrates that WithLocalReminders
+        // doesn't require the 30+ second cluster bootstrap delay.
+        // The TestKit fixture itself starts up nearly instantly.
+
+        // Assert - verify the reminder client is available
+        var extension = Sys.ReminderClient();
+        extension.Should().NotBeNull("ReminderClient extension should be registered");
+    }
+
+    [Fact]
+    public async Task WithLocalReminders_ShouldScheduleAndDeliverReminder_ToRegisteredShardRegion()
+    {
+        // Arrange
+        var targetActor = CreateTestProbe("billing-actor");
+        _resolver.RegisterShardRegion("billing-shard", targetActor);
+
+        var extension = Sys.ReminderClient();
+        var client = extension.CreateClient("billing-shard", "customer-123");
+
+        var key = new ReminderKey("retry-payment");
+        var message = new TestMessage("Payment Retry");
+        var when = DateTimeOffset.UtcNow.AddMilliseconds(200);
+
+        // Act - schedule a reminder
+        var scheduleResult = await client.ScheduleSingleReminderAsync(key, when, message);
+        scheduleResult.ResponseCode.Should().Be(ReminderScheduleResponseCode.Success);
+
+        // Assert - the reminder should be delivered to the registered shard region
+        var envelope = targetActor.ExpectMsg<ShardingEnvelope>(TimeSpan.FromSeconds(2));
+        envelope.EntityId.Should().Be("customer-123");
+        envelope.Message.Should().BeOfType<TestMessage>()
+            .Which.Content.Should().Be("Payment Retry");
+
+        Output?.WriteLine($"Reminder delivered successfully to {targetActor.Ref.Path}");
+    }
+
+    [Fact]
+    public async Task WithLocalReminders_ShouldSupportMultipleShardRegions()
+    {
+        // Arrange
+        var billingActor = CreateTestProbe("billing-actor");
+        var notificationActor = CreateTestProbe("notification-actor");
+
+        _resolver.RegisterShardRegion("billing-shard", billingActor);
+        _resolver.RegisterShardRegion("notification-shard", notificationActor);
+
+        var extension = Sys.ReminderClient();
+        var billingClient = extension.CreateClient("billing-shard", "customer-123");
+        var notificationClient = extension.CreateClient("notification-shard", "user-456");
+
+        // Act - schedule reminders to different shard regions
+        await billingClient.ScheduleSingleReminderAsync(
+            new ReminderKey("billing-reminder"),
+            DateTimeOffset.UtcNow.AddMilliseconds(100),
+            new TestMessage("Bill Customer"));
+
+        await notificationClient.ScheduleSingleReminderAsync(
+            new ReminderKey("notification-reminder"),
+            DateTimeOffset.UtcNow.AddMilliseconds(100),
+            new TestMessage("Send Notification"));
+
+        // Assert - each reminder should be delivered to its respective shard region
+        var billingEnvelope = billingActor.ExpectMsg<ShardingEnvelope>(TimeSpan.FromSeconds(2));
+        billingEnvelope.EntityId.Should().Be("customer-123");
+        billingEnvelope.Message.Should().BeOfType<TestMessage>()
+            .Which.Content.Should().Be("Bill Customer");
+
+        var notificationEnvelope = notificationActor.ExpectMsg<ShardingEnvelope>(TimeSpan.FromSeconds(2));
+        notificationEnvelope.EntityId.Should().Be("user-456");
+        notificationEnvelope.Message.Should().BeOfType<TestMessage>()
+            .Which.Content.Should().Be("Send Notification");
+    }
+
+    private record TestMessage(string Content);
+}

--- a/src/Akka.Reminders.Tests/ReminderClientSpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderClientSpecs.cs
@@ -348,21 +348,3 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
     #endregion
 }
 
-/// <summary>
-/// Test implementation of IShardRegionResolver that allows us to control
-/// which shard regions are available during tests.
-/// </summary>
-internal class TestShardRegionResolver : IShardRegionResolver
-{
-    private readonly Dictionary<string, IActorRef> _shardRegions = new();
-
-    public void RegisterShardRegion(string regionName, IActorRef region)
-    {
-        _shardRegions[regionName] = region;
-    }
-
-    public IActorRef? TryResolve(ReminderEntity entity)
-    {
-        return _shardRegions.GetValueOrDefault(entity.ShardRegionName);
-    }
-}

--- a/src/Akka.Reminders/AkkaHostingExtensions.cs
+++ b/src/Akka.Reminders/AkkaHostingExtensions.cs
@@ -85,6 +85,62 @@ public static class AkkaHostingExtensions
 
         return builder;
     }
+
+    /// <summary>
+    /// Adds a local (non-clustered) reminder system to the actor system, designed for testing scenarios.
+    /// </summary>
+    /// <param name="builder">The Akka configuration builder.</param>
+    /// <param name="configure">Optional action to configure the local reminders system using a fluent builder.</param>
+    /// <returns>The builder for method chaining.</returns>
+    /// <remarks>
+    /// This method creates a reminder scheduler as a regular actor instead of a ClusterSingleton,
+    /// providing instant startup with no bootstrap delays. This is ideal for unit and integration tests.
+    /// You must register shard regions using the configuration builder for reminders to be delivered.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// // In a test
+    /// var targetActor = testKit.CreateTestProbe("billing-actor");
+    ///
+    /// builder.WithLocalReminders(reminders => reminders
+    ///     .WithInMemoryStorage()
+    ///     .WithShardRegion("billing-shard", targetActor)
+    ///     .WithSettings(new ReminderSettings
+    ///     {
+    ///         MaxSlippage = TimeSpan.FromMilliseconds(100),
+    ///         MaxDeliveryAttempts = 3
+    ///     }));
+    /// </code>
+    /// </example>
+    public static AkkaConfigurationBuilder WithLocalReminders(
+        this AkkaConfigurationBuilder builder,
+        Action<LocalReminderConfigurationBuilder>? configure = null)
+    {
+        var localBuilder = new LocalReminderConfigurationBuilder();
+        configure?.Invoke(localBuilder);
+
+        builder.WithActors((system, registry) =>
+        {
+            var extendedSystem = (ExtendedActorSystem)system;
+
+            // Create the storage and resolver instances from the local builder
+            var storage = localBuilder.GetStorageFactory()(system);
+            var resolver = localBuilder.GetResolver();
+            var settings = localBuilder.GetSettings();
+
+            // Create the reminder scheduler as a regular /system actor (NOT a singleton)
+            var schedulerProps = Props.Create(() => new ReminderScheduler(settings, resolver, storage, system.Scheduler));
+            var scheduler = extendedSystem.SystemActorOf(schedulerProps, "reminder-scheduler");
+
+            // Register the scheduler directly as the proxy (since there's no singleton indirection)
+            registry.Register<ReminderSchedulerProxy>(scheduler);
+
+            // Register the ReminderClient extension
+            system.WithExtension<ReminderClientExtension, ReminderClientProvider>();
+        });
+
+        return builder;
+    }
 }
 
 /// <summary>

--- a/src/Akka.Reminders/LocalReminderConfigurationBuilder.cs
+++ b/src/Akka.Reminders/LocalReminderConfigurationBuilder.cs
@@ -1,0 +1,141 @@
+using Akka.Actor;
+using Akka.Reminders.Sharding;
+using Akka.Reminders.Storage;
+
+namespace Akka.Reminders;
+
+/// <summary>
+/// Configuration builder for local (non-clustered) reminder functionality, designed for testing scenarios.
+/// </summary>
+/// <remarks>
+/// This builder configures reminders without requiring a cluster or ClusterSingleton, making it ideal
+/// for unit and integration tests. The reminder scheduler runs as a regular actor instead of a singleton,
+/// providing instant startup with no bootstrap delays.
+/// </remarks>
+public sealed class LocalReminderConfigurationBuilder
+{
+    private readonly Dictionary<string, IActorRef> _shardRegions = new();
+    private Func<ActorSystem, IReminderStorage>? _storageFactory;
+    private IShardRegionResolver? _resolver;
+    private ReminderSettings _settings = new();
+
+    /// <summary>
+    /// Registers a shard region that reminders can be delivered to during testing.
+    /// </summary>
+    /// <param name="regionName">The name of the shard region (must match the ShardRegionName in reminder entities).</param>
+    /// <param name="region">The actor reference that will receive reminder messages (typically a TestProbe or test actor).</param>
+    /// <returns>This builder instance for method chaining.</returns>
+    public LocalReminderConfigurationBuilder WithShardRegion(string regionName, IActorRef region)
+    {
+        _shardRegions[regionName] = region;
+        return this;
+    }
+
+    /// <summary>
+    /// Registers multiple shard regions at once.
+    /// </summary>
+    /// <param name="regions">A dictionary mapping shard region names to actor references.</param>
+    /// <returns>This builder instance for method chaining.</returns>
+    public LocalReminderConfigurationBuilder WithShardRegions(IReadOnlyDictionary<string, IActorRef> regions)
+    {
+        foreach (var (name, region) in regions)
+        {
+            _shardRegions[name] = region;
+        }
+        return this;
+    }
+
+    /// <summary>
+    /// Configures a custom shard region resolver for advanced testing scenarios.
+    /// </summary>
+    /// <param name="resolver">The custom resolver implementation.</param>
+    /// <returns>This builder instance for method chaining.</returns>
+    /// <remarks>
+    /// If you use this method, any shard regions registered via <see cref="WithShardRegion"/> or
+    /// <see cref="WithShardRegions"/> will be ignored.
+    /// </remarks>
+    public LocalReminderConfigurationBuilder WithResolver(IShardRegionResolver resolver)
+    {
+        _resolver = resolver;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the storage backend using a factory function.
+    /// </summary>
+    /// <param name="factory">A function that creates the storage implementation given an ActorSystem.</param>
+    /// <returns>This builder instance for method chaining.</returns>
+    public LocalReminderConfigurationBuilder WithStorage(Func<ActorSystem, IReminderStorage> factory)
+    {
+        _storageFactory = factory;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the storage backend to use a specific instance.
+    /// </summary>
+    /// <param name="storage">The storage implementation to use.</param>
+    /// <returns>This builder instance for method chaining.</returns>
+    public LocalReminderConfigurationBuilder WithStorage(IReminderStorage storage)
+    {
+        _storageFactory = _ => storage;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the storage backend to use a specific type.
+    /// </summary>
+    /// <typeparam name="TStorage">The type of storage implementation (must have a parameterless constructor).</typeparam>
+    /// <returns>This builder instance for method chaining.</returns>
+    public LocalReminderConfigurationBuilder WithStorage<TStorage>() where TStorage : IReminderStorage, new()
+    {
+        _storageFactory = _ => new TStorage();
+        return this;
+    }
+
+    /// <summary>
+    /// Explicitly configures in-memory storage (this is the default if no storage is specified).
+    /// </summary>
+    /// <returns>This builder instance for method chaining.</returns>
+    public LocalReminderConfigurationBuilder WithInMemoryStorage()
+    {
+        return WithStorage<InMemoryReminderStorage>();
+    }
+
+    /// <summary>
+    /// Configures the reminder settings.
+    /// </summary>
+    /// <param name="settings">The reminder settings to use.</param>
+    /// <returns>This builder instance for method chaining.</returns>
+    public LocalReminderConfigurationBuilder WithSettings(ReminderSettings settings)
+    {
+        _settings = settings;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the reminder settings using a configuration action.
+    /// </summary>
+    /// <param name="configure">An action that modifies the reminder settings.</param>
+    /// <returns>This builder instance for method chaining.</returns>
+    public LocalReminderConfigurationBuilder WithSettings(Action<ReminderSettings> configure)
+    {
+        configure(_settings);
+        return this;
+    }
+
+    internal Func<ActorSystem, IReminderStorage> GetStorageFactory()
+    {
+        return _storageFactory ?? (_ => new InMemoryReminderStorage());
+    }
+
+    internal IShardRegionResolver GetResolver()
+    {
+        return _resolver ?? new TestShardRegionResolver(_shardRegions);
+    }
+
+    internal ReminderSettings GetSettings()
+    {
+        return _settings;
+    }
+}

--- a/src/Akka.Reminders/ReminderConfigurationBuilder.cs
+++ b/src/Akka.Reminders/ReminderConfigurationBuilder.cs
@@ -49,6 +49,19 @@ public sealed class ReminderConfigurationBuilder
     }
 
     /// <summary>
+    /// Configures the storage backend to use in-memory storage (this is the default if no storage is specified).
+    /// </summary>
+    /// <returns>This builder for method chaining.</returns>
+    /// <remarks>
+    /// In-memory storage is ideal for testing and development scenarios where persistence is not required.
+    /// Note that in-memory storage is not distributed and state will be lost on restart.
+    /// </remarks>
+    public ReminderConfigurationBuilder WithInMemoryStorage()
+    {
+        return WithStorage<InMemoryReminderStorage>();
+    }
+
+    /// <summary>
     /// Configures the shard region resolver using a factory function.
     /// </summary>
     /// <param name="factory">Factory function to create the resolver instance.</param>

--- a/src/Akka.Reminders/Sharding/IShardRegionResolver.cs
+++ b/src/Akka.Reminders/Sharding/IShardRegionResolver.cs
@@ -46,14 +46,56 @@ public sealed class DefaultShardRegionResolver : IShardRegionResolver
 /// A test-only implementation of <see cref="IShardRegionResolver"/> that allows you to specify
 /// the ShardRegion for a given reminder entity.
 /// </summary>
+/// <remarks>
+/// This resolver is designed for testing scenarios where you want to control which actors
+/// receive reminder messages without requiring a full cluster setup. You can register
+/// shard regions manually using the constructor or the <see cref="RegisterShardRegion"/> method.
+/// </remarks>
 public sealed class TestShardRegionResolver : IShardRegionResolver
 {
-    private readonly IReadOnlyDictionary<string, IActorRef> _shardRegions;
+    private readonly Dictionary<string, IActorRef> _shardRegions;
 
+    /// <summary>
+    /// Creates a new <see cref="TestShardRegionResolver"/> with no registered shard regions.
+    /// </summary>
+    public TestShardRegionResolver()
+    {
+        _shardRegions = new Dictionary<string, IActorRef>();
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="TestShardRegionResolver"/> with the specified shard regions.
+    /// </summary>
+    /// <param name="shardRegions">A dictionary mapping shard region names to actor references.</param>
     public TestShardRegionResolver(IReadOnlyDictionary<string, IActorRef> shardRegions)
     {
-        _shardRegions = shardRegions;
+        _shardRegions = new Dictionary<string, IActorRef>(shardRegions);
     }
+
+    /// <summary>
+    /// Registers a shard region with the resolver.
+    /// </summary>
+    /// <param name="regionName">The name of the shard region.</param>
+    /// <param name="region">The actor reference for the shard region.</param>
+    public void RegisterShardRegion(string regionName, IActorRef region)
+    {
+        _shardRegions[regionName] = region;
+    }
+
+    /// <summary>
+    /// Removes a shard region registration from the resolver.
+    /// </summary>
+    /// <param name="regionName">The name of the shard region to remove.</param>
+    /// <returns>True if the region was removed, false if it wasn't registered.</returns>
+    public bool UnregisterShardRegion(string regionName)
+    {
+        return _shardRegions.Remove(regionName);
+    }
+
+    /// <summary>
+    /// Gets the registered shard region names.
+    /// </summary>
+    public IEnumerable<string> RegisteredRegions => _shardRegions.Keys;
 
     public IActorRef? TryResolve(ReminderEntity entity)
     {


### PR DESCRIPTION
Closes #20

## Summary

This PR adds a `WithLocalReminders()` extension method that enables fast, non-clustered reminder testing without the 30+ second ClusterSingleton bootstrap delay. This directly addresses the feature request in issue #20 for better unit testing support.

## What's Changed

### Core Features
- **WithLocalReminders()** extension method: Creates reminder scheduler as a regular actor instead of ClusterSingleton, eliminating 30+ second bootstrap delays
- **LocalReminderConfigurationBuilder**: Fluent API for configuring local (non-clustered) reminders with test-friendly shard region registration
- **Enhanced TestShardRegionResolver**: Moved to main library with mutable API (`RegisterShardRegion`, `UnregisterShardRegion`) for dynamic test configuration
- **WithInMemoryStorage()** convenience method: Explicit in-memory storage configuration for both `WithReminders()` and `WithLocalReminders()`

### Key Benefits
- **Instant Startup**: No ClusterSingleton bootstrap delay for tests
- **Simple Test Setup**: Register shard regions directly without cluster infrastructure  
- **Full Feature Parity**: All reminder functionality available in local mode
- **Backward Compatible**: Existing `WithReminders()` API unchanged

### Usage Example
```csharp
// In a test
var targetActor = CreateTestProbe("billing-actor");

builder.WithLocalReminders(reminders => reminders
    .WithInMemoryStorage()
    .WithShardRegion("billing-shard", targetActor)
    .WithSettings(new ReminderSettings
    {
        MaxSlippage = TimeSpan.FromMilliseconds(100),
        MaxDeliveryAttempts = 3
    }));

// Test runs immediately - no 30-second bootstrap delay!
```

## Testing
- Added `LocalReminderSpecs` with 3 comprehensive tests demonstrating:
  - Instant startup without cluster bootstrap
  - Reminder scheduling and delivery to registered shard regions
  - Support for multiple shard regions
- All 114 existing tests pass
- Build completes successfully

## Files Changed
- `AkkaHostingExtensions.cs`: Added `WithLocalReminders()` method
- `LocalReminderConfigurationBuilder.cs`: New fluent builder for local reminders
- `ReminderConfigurationBuilder.cs`: Added `WithInMemoryStorage()` convenience method
- `IShardRegionResolver.cs`: Enhanced `TestShardRegionResolver` with mutable API
- `LocalReminderSpecs.cs`: New test suite demonstrating usage
- `ReminderClientSpecs.cs`: Removed duplicate `TestShardRegionResolver` (now in main library)