### PR TITLE
Refactor message delivery to IShardRegionResolver

### DIFF
--- a/src/Akka.Reminders.Tests/LocalReminderSpecs.cs
+++ b/src/Akka.Reminders.Tests/LocalReminderSpecs.cs
@@ -67,11 +67,9 @@ public class LocalReminderSpecs : Akka.Hosting.TestKit.TestKit
         var scheduleResult = await client.ScheduleSingleReminderAsync(key, when, message);
         scheduleResult.ResponseCode.Should().Be(ReminderScheduleResponseCode.Success);
 
-        // Assert - the reminder should be delivered to the registered shard region
-        var envelope = targetActor.ExpectMsg<ShardingEnvelope>(TimeSpan.FromSeconds(2));
-        envelope.EntityId.Should().Be("customer-123");
-        envelope.Message.Should().BeOfType<TestMessage>()
-            .Which.Content.Should().Be("Payment Retry");
+        // Assert - the reminder should be delivered directly (no ShardingEnvelope wrapping in tests)
+        var receivedMessage = await targetActor.ExpectMsgAsync<TestMessage>(TimeSpan.FromSeconds(2));
+        receivedMessage.Content.Should().Be("Payment Retry");
 
         Output?.WriteLine($"Reminder delivered successfully to {targetActor.Ref.Path}");
     }
@@ -101,16 +99,12 @@ public class LocalReminderSpecs : Akka.Hosting.TestKit.TestKit
             DateTimeOffset.UtcNow.AddMilliseconds(100),
             new TestMessage("Send Notification"));
 
-        // Assert - each reminder should be delivered to its respective shard region
-        var billingEnvelope = billingActor.ExpectMsg<ShardingEnvelope>(TimeSpan.FromSeconds(2));
-        billingEnvelope.EntityId.Should().Be("customer-123");
-        billingEnvelope.Message.Should().BeOfType<TestMessage>()
-            .Which.Content.Should().Be("Bill Customer");
+        // Assert - each reminder should be delivered directly to its respective shard region (no ShardingEnvelope wrapping in tests)
+        var billingMessage = await billingActor.ExpectMsgAsync<TestMessage>(TimeSpan.FromSeconds(2));
+        billingMessage.Content.Should().Be("Bill Customer");
 
-        var notificationEnvelope = notificationActor.ExpectMsg<ShardingEnvelope>(TimeSpan.FromSeconds(2));
-        notificationEnvelope.EntityId.Should().Be("user-456");
-        notificationEnvelope.Message.Should().BeOfType<TestMessage>()
-            .Which.Content.Should().Be("Send Notification");
+        var notificationMessage = await notificationActor.ExpectMsgAsync<TestMessage>(TimeSpan.FromSeconds(2));
+        notificationMessage.Content.Should().Be("Send Notification");
     }
 
     private record TestMessage(string Content);

--- a/src/Akka.Reminders.Tests/ReminderSchedulerRecoverySpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderSchedulerRecoverySpecs.cs
@@ -1,5 +1,4 @@
 using Akka.Actor;
-using Akka.Cluster.Sharding;
 using Akka.Hosting;
 using Akka.Hosting.TestKit;
 using Akka.Reminders.Sharding;
@@ -85,14 +84,14 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 
         // Assert - Verify reminders are loaded by checking they fire at the right times
         testScheduler.Advance(TimeSpan.FromSeconds(11));
-        var envelope1 = await testProbe.ExpectMsgAsync<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        Assert.Equal("message 1", envelope1.Message);
+        var message1 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        Assert.Equal("message 1", message1);
 
         testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
         testScheduler.Advance(TimeSpan.FromSeconds(10));
-        var envelope2 = await testProbe.ExpectMsgAsync<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        Assert.Equal("message 2", envelope2.Message);
+        var message2 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        Assert.Equal("message 2", message2);
     }
 
     [Fact]
@@ -141,11 +140,11 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
 
         // Assert - Both overdue reminders should be delivered immediately
-        var messages = new List<object>();
-        var envelope1 = await testProbe.ExpectMsgAsync<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        messages.Add(envelope1.Message);
-        var envelope2 = await testProbe.ExpectMsgAsync<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        messages.Add(envelope2.Message);
+        var messages = new List<string>();
+        var message1 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        messages.Add(message1);
+        var message2 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        messages.Add(message2);
 
         Assert.Contains("overdue message 1", messages);
         Assert.Contains("overdue message 2", messages);
@@ -178,24 +177,24 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 
         // Assert - First occurrence
         testScheduler.Advance(TimeSpan.FromSeconds(6));
-        var envelope1 = await testProbe.ExpectMsgAsync<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        Assert.Equal("recurring message", envelope1.Message);
+        var message1 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        Assert.Equal("recurring message", message1);
 
         // Wait for next occurrence to be scheduled
         testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
         // Second occurrence
         testScheduler.Advance(TimeSpan.FromSeconds(5));
-        var envelope2 = await testProbe.ExpectMsgAsync<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        Assert.Equal("recurring message", envelope2.Message);
+        var message2 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        Assert.Equal("recurring message", message2);
 
         // Wait for next occurrence to be scheduled
         testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
         // Third occurrence
         testScheduler.Advance(TimeSpan.FromSeconds(5));
-        var envelope3 = await testProbe.ExpectMsgAsync<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        Assert.Equal("recurring message", envelope3.Message);
+        var message3 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        Assert.Equal("recurring message", message3);
     }
 
     [Fact]
@@ -246,8 +245,8 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         testScheduler.Advance(TimeSpan.FromSeconds(16)); // Total 31 seconds from start
         Output?.WriteLine($"Current time after second advance: {testScheduler.Now}");
 
-        var envelope = await testProbe.ExpectMsgAsync<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        Assert.Equal("future message", envelope.Message);
+        var message = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        Assert.Equal("future message", message);
     }
 
     [Fact]
@@ -302,13 +301,13 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
 
         // Assert - All overdue reminders should be processed
-        var messages = new List<object>();
-        var env1 = await testProbe.ExpectMsgAsync<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        messages.Add(env1.Message);
-        var env2 = await testProbe.ExpectMsgAsync<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        messages.Add(env2.Message);
-        var env3 = await testProbe.ExpectMsgAsync<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        messages.Add(env3.Message);
+        var messages = new List<string>();
+        var message1 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        messages.Add(message1);
+        var message2 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        messages.Add(message2);
+        var message3 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        messages.Add(message3);
 
         // Verify all messages were delivered (order may vary due to async processing)
         Assert.Contains("oldest message", messages);
@@ -353,16 +352,16 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 
         // Assert - Overdue reminder fires immediately
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
-        var envelope1 = await testProbe.ExpectMsgAsync<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        Assert.Equal("overdue message", envelope1.Message);
+        var message1 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        Assert.Equal("overdue message", message1);
 
         // Future reminder hasn't fired yet
         testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
         // Advance to future reminder time
         testScheduler.Advance(TimeSpan.FromSeconds(10));
-        var envelope2 = await testProbe.ExpectMsgAsync<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        Assert.Equal("future message", envelope2.Message);
+        var message2 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        Assert.Equal("future message", message2);
     }
 
     [Fact]
@@ -389,7 +388,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         Assert.Equal(ReminderScheduleResponseCode.Success, response.ResponseCode);
 
         testScheduler.Advance(TimeSpan.FromSeconds(6));
-        var envelope = await testProbe.ExpectMsgAsync<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        Assert.Equal("test message", envelope.Message);
+        var message = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        Assert.Equal("test message", message);
     }
 }

--- a/src/Akka.Reminders.Tests/ReminderSchedulerTimingSpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderSchedulerTimingSpecs.cs
@@ -1,5 +1,4 @@
 using Akka.Actor;
-using Akka.Cluster.Sharding;
 using Akka.Configuration;
 using Akka.Hosting;
 using Akka.Hosting.TestKit;
@@ -93,8 +92,8 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         Output?.WriteLine($"TestScheduler.Now after second advance: {testScheduler.Now}");
 
         // Assert - Verify the reminder message was received
-        var envelope = testProbe.ExpectMsg<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        Assert.Equal("test message", envelope.Message);
+        var message = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        Assert.Equal("test message", message);
     }
 
     [Fact]
@@ -134,23 +133,23 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         Output?.WriteLine($"Advancing by 11 seconds...");
         testScheduler.Advance(TimeSpan.FromSeconds(11));
         Output?.WriteLine($"TestScheduler.Now after first advance: {testScheduler.Now}");
-        var envelope1 = testProbe.ExpectMsg<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        Assert.Equal("first", envelope1.Message);
+        var message1 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        Assert.Equal("first", message1);
         Output?.WriteLine($"Received first message");
 
         // Wait for processing to complete and next timer to be scheduled
         await AwaitConditionAsync(() => Task.FromResult(true), TimeSpan.FromMilliseconds(100));
 
         testScheduler.Advance(TimeSpan.FromSeconds(10));
-        var envelope2 = testProbe.ExpectMsg<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        Assert.Equal("second", envelope2.Message);
+        var message2 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        Assert.Equal("second", message2);
 
         // Wait for processing to complete and next timer to be scheduled
         await AwaitConditionAsync(() => Task.FromResult(true), TimeSpan.FromMilliseconds(100));
 
         testScheduler.Advance(TimeSpan.FromSeconds(10));
-        var envelope3 = testProbe.ExpectMsg<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        Assert.Equal("third", envelope3.Message);
+        var message3 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        Assert.Equal("third", message3);
     }
 
     [Fact]
@@ -185,8 +184,8 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         Output?.WriteLine($"Before first advance - TestScheduler.Now: {testScheduler.Now}");
         testScheduler.Advance(TimeSpan.FromSeconds(6));
         Output?.WriteLine($"After first advance - TestScheduler.Now: {testScheduler.Now}");
-        var envelope1 = testProbe.ExpectMsg<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        Assert.Equal("recurring message", envelope1.Message);
+        var message1 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        Assert.Equal("recurring message", message1);
         Output?.WriteLine($"Received first recurring message");
 
         // Allow async processing to complete, then verify deterministically
@@ -199,8 +198,8 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         Output?.WriteLine($"Before second advance - TestScheduler.Now: {testScheduler.Now}");
         testScheduler.Advance(interval);
         Output?.WriteLine($"After second advance - TestScheduler.Now: {testScheduler.Now}");
-        var envelope2 = testProbe.ExpectMsg<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        Assert.Equal("recurring message", envelope2.Message);
+        var message2 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        Assert.Equal("recurring message", message2);
 
         // Allow async processing to complete
         testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
@@ -209,8 +208,8 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
 
         // Verify third occurrence
         testScheduler.Advance(interval);
-        var envelope3 = testProbe.ExpectMsg<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        Assert.Equal("recurring message", envelope3.Message);
+        var message3 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        Assert.Equal("recurring message", message3);
     }
 
     [Fact]
@@ -270,7 +269,7 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
 
         // Assert
-        var envelope = testProbe.ExpectMsg<ShardingEnvelope>(TimeSpan.FromSeconds(5));
-        Assert.Equal("immediate message", envelope.Message);
+        var message = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+        Assert.Equal("immediate message", message);
     }
 }

--- a/src/Akka.Reminders/ReminderScheduler.cs
+++ b/src/Akka.Reminders/ReminderScheduler.cs
@@ -1,5 +1,4 @@
 ﻿using Akka.Actor;
-using Akka.Cluster.Sharding;
 using Akka.Reminders.Sharding;
 using Akka.Reminders.Storage;
 
@@ -387,9 +386,9 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
             else
             {
                 _log.Debug("Sending reminder {0} to {1}", reminder, shardRegion);
-                
-                // wrap the message inside a ShardingEnvelope since that's automatically routed correctly
-                shardRegion.Tell(new ShardingEnvelope(reminder.Entity.EntityId, reminder.Message));
+
+                // Use the resolver to deliver the message - it handles wrapping (e.g., ShardingEnvelope)
+                ShardRegionResolver.DeliverReminder(reminder.Entity, reminder.Message, Self);
                 completedReminders.Add(new CompletedReminder(reminder.Entity, reminder.Key, TimeProvider.Now, ReminderCompletionStatus.Delivered));
 
                 // Handle recurring reminders - schedule next occurrence

--- a/src/Akka.Reminders/Sharding/IShardRegionResolver.cs
+++ b/src/Akka.Reminders/Sharding/IShardRegionResolver.cs
@@ -11,7 +11,16 @@ namespace Akka.Reminders.Sharding;
 /// </remarks>
 public interface IShardRegionResolver
 {
-    public IActorRef? TryResolve(ReminderEntity entity);   
+    public IActorRef? TryResolve(ReminderEntity entity);
+
+    /// <summary>
+    /// Delivers a reminder message to the target entity.
+    /// Implementations handle the delivery mechanism (e.g., wrapping in ShardingEnvelope for cluster sharding).
+    /// </summary>
+    /// <param name="entity">The target entity for the reminder</param>
+    /// <param name="message">The reminder message to deliver</param>
+    /// <param name="sender">The sender of the message</param>
+    public void DeliverReminder(ReminderEntity entity, object message, IActorRef sender);
 }
 
 /// <summary>
@@ -39,6 +48,16 @@ public sealed class DefaultShardRegionResolver : IShardRegionResolver
         }
 
         return null;
+    }
+
+    public void DeliverReminder(ReminderEntity entity, object message, IActorRef sender)
+    {
+        var shardRegion = TryResolve(entity);
+        if (shardRegion != null)
+        {
+            // Wrap message in ShardingEnvelope for cluster sharding
+            shardRegion.Tell(new ShardingEnvelope(entity.EntityId, message), sender);
+        }
     }
 }
 
@@ -100,5 +119,15 @@ public sealed class TestShardRegionResolver : IShardRegionResolver
     public IActorRef? TryResolve(ReminderEntity entity)
     {
         return _shardRegions.GetValueOrDefault(entity.ShardRegionName);
+    }
+
+    public void DeliverReminder(ReminderEntity entity, object message, IActorRef sender)
+    {
+        var actor = TryResolve(entity);
+        if (actor != null)
+        {
+            // Deliver message directly without wrapping - test actors handle raw messages
+            actor.Tell(message, sender);
+        }
     }
 }


### PR DESCRIPTION
## Summary
Moves message delivery responsibility from `ReminderScheduler` to `IShardRegionResolver` implementations, enabling different delivery strategies for production and testing environments.

## Changes
- Add `DeliverReminder` method to `IShardRegionResolver` interface
- `DefaultShardRegionResolver` wraps messages in `ShardingEnvelope` for cluster sharding
- `TestShardRegionResolver` delivers raw messages directly without wrapping
- `ReminderScheduler` delegates message delivery to the resolver
- Update all test expectations to use async methods and expect raw messages
- Remove unused `Akka.Cluster.Sharding` import from test files

## Benefits
- **Separation of Concerns**: Message delivery mechanism is resolver's responsibility, not scheduler's
- **Testability**: Test resolver can deliver raw messages while production uses ShardingEnvelope
- **Flexibility**: Future resolvers can implement custom delivery strategies
- **Clean Architecture**: Each component has a single, well-defined responsibility

## Test Results
All 114 tests passing locally.