### PR TITLE
Include original command in ReminderScheduled response for retry support

### DIFF
--- a/src/Akka.Reminders.Sql/SqlReminderStorage.cs
+++ b/src/Akka.Reminders.Sql/SqlReminderStorage.cs
@@ -84,18 +84,13 @@ public sealed class SqlReminderStorage : IReminderStorage
 
             // Return the truncated reminder so it matches what's stored in the database
             return new ReminderProtocol.ReminderScheduled(
-                adjustedReminder.Entity,
-                adjustedReminder.Key,
-                adjustedReminder.When,
-                ReminderScheduleResponseCode.Success,
-                null);
+                adjustedReminder.ToScheduleReminder(),
+                ReminderScheduleResponseCode.Success);
         }
         catch (Exception ex)
         {
             return new ReminderProtocol.ReminderScheduled(
-                adjustedReminder.Entity,
-                adjustedReminder.Key,
-                adjustedReminder.When,
+                adjustedReminder.ToScheduleReminder(),
                 ReminderScheduleResponseCode.Error,
                 ex.Message);
         }

--- a/src/Akka.Reminders.Tests/ReminderSchedulerRecoverySpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderSchedulerRecoverySpecs.cs
@@ -214,7 +214,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 
         // Schedule a reminder for the future - send directly to scheduler, not through client
         var reminderTime = now.AddSeconds(30);
-        firstScheduler.Tell(new ReminderProtocol.ScheduleSingleReminder(
+        firstScheduler.Tell(new ReminderProtocol.ScheduleReminder(
             new ReminderEntity("test-region", "entity-1"),
             new ReminderKey("future-reminder"),
             reminderTime,
@@ -378,7 +378,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         // Assert - Scheduler should initialize successfully
         // Schedule a new reminder to verify scheduler is working - send directly to scheduler
         var testScheduler = (TestScheduler)Sys.Scheduler;
-        scheduler.Tell(new ReminderProtocol.ScheduleSingleReminder(
+        scheduler.Tell(new ReminderProtocol.ScheduleReminder(
             new ReminderEntity("test-region", "entity-1"),
             new ReminderKey("test"),
             testScheduler.Now.AddSeconds(5),

--- a/src/Akka.Reminders/ReminderClient.cs
+++ b/src/Akka.Reminders/ReminderClient.cs
@@ -28,7 +28,7 @@ internal sealed class ReminderClient : IReminderClient
         object message,
         CancellationToken ct = default)
     {
-        var command = new ReminderProtocol.ScheduleSingleReminder(Entity, key, when, message, RepeatInterval: null);
+        var command = new ReminderProtocol.ScheduleReminder(Entity, key, when, message, RepeatInterval: null);
 
         try
         {
@@ -43,9 +43,7 @@ internal sealed class ReminderClient : IReminderClient
         {
             // Return a timeout error response
             return new ReminderProtocol.ReminderScheduled(
-                Entity,
-                key,
-                when,
+                command,
                 ReminderScheduleResponseCode.Error,
                 "Request timed out while communicating with reminder scheduler");
         }
@@ -53,9 +51,7 @@ internal sealed class ReminderClient : IReminderClient
         {
             // Return a generic error response
             return new ReminderProtocol.ReminderScheduled(
-                Entity,
-                key,
-                when,
+                command,
                 ReminderScheduleResponseCode.Error,
                 $"Error scheduling reminder: {ex.Message}");
         }
@@ -69,7 +65,7 @@ internal sealed class ReminderClient : IReminderClient
         object message,
         CancellationToken ct = default)
     {
-        var command = new ReminderProtocol.ScheduleSingleReminder(Entity, key, firstOccurrence, message, RepeatInterval: interval);
+        var command = new ReminderProtocol.ScheduleReminder(Entity, key, firstOccurrence, message, RepeatInterval: interval);
 
         try
         {
@@ -83,18 +79,14 @@ internal sealed class ReminderClient : IReminderClient
         catch (AskTimeoutException)
         {
             return new ReminderProtocol.ReminderScheduled(
-                Entity,
-                key,
-                firstOccurrence,
+                command,
                 ReminderScheduleResponseCode.Error,
                 "Request timed out while communicating with reminder scheduler");
         }
         catch (Exception ex)
         {
             return new ReminderProtocol.ReminderScheduled(
-                Entity,
-                key,
-                firstOccurrence,
+                command,
                 ReminderScheduleResponseCode.Error,
                 $"Error scheduling recurring reminder: {ex.Message}");
         }

--- a/src/Akka.Reminders/ReminderClientExtension.cs
+++ b/src/Akka.Reminders/ReminderClientExtension.cs
@@ -104,14 +104,12 @@ public sealed class ReminderClientExtension : IExtension
         object message,
         CancellationToken ct = default)
     {
-        var command = new ReminderProtocol.ScheduleSingleReminder(entity, key, when, message, RepeatInterval: null);
-        return SendToSchedulerAsync<ReminderProtocol.ScheduleSingleReminder, ReminderProtocol.ReminderScheduled>(
+        var command = new ReminderProtocol.ScheduleReminder(entity, key, when, message, RepeatInterval: null);
+        return SendToSchedulerAsync<ReminderProtocol.ScheduleReminder, ReminderProtocol.ReminderScheduled>(
             command,
             ct,
             errorMessage => new ReminderProtocol.ReminderScheduled(
-                entity,
-                key,
-                when,
+                command,
                 ReminderScheduleResponseCode.Error,
                 errorMessage));
     }
@@ -163,14 +161,12 @@ public sealed class ReminderClientExtension : IExtension
         object message,
         CancellationToken ct = default)
     {
-        var command = new ReminderProtocol.ScheduleSingleReminder(entity, key, firstOccurrence, message, RepeatInterval: interval);
-        return SendToSchedulerAsync<ReminderProtocol.ScheduleSingleReminder, ReminderProtocol.ReminderScheduled>(
+        var command = new ReminderProtocol.ScheduleReminder(entity, key, firstOccurrence, message, RepeatInterval: interval);
+        return SendToSchedulerAsync<ReminderProtocol.ScheduleReminder, ReminderProtocol.ReminderScheduled>(
             command,
             ct,
             errorMessage => new ReminderProtocol.ReminderScheduled(
-                entity,
-                key,
-                firstOccurrence,
+                command,
                 ReminderScheduleResponseCode.Error,
                 errorMessage));
     }

--- a/src/Akka.Reminders/ReminderProtocol.cs
+++ b/src/Akka.Reminders/ReminderProtocol.cs
@@ -63,7 +63,7 @@ public enum FetchRemindersResponseCode
 
 public static class ReminderProtocol
 {
-    public sealed record ScheduleSingleReminder(
+    public sealed record ScheduleReminder(
         ReminderEntity Entity,
         ReminderKey Key,
         DateTimeOffset When,
@@ -84,11 +84,23 @@ public static class ReminderProtocol
         string? Message = null) : IReminderResponse;
 
     public sealed record ReminderScheduled(
-        ReminderEntity Entity,
-        ReminderKey Key,
-        DateTimeOffset When,
+        ScheduleReminder OriginalCommand,
         ReminderScheduleResponseCode ResponseCode,
-        string? Message = null) : IReminderResponse;
+        string? Message = null) : IReminderResponse
+    {
+        /// <inheritdoc />
+        public ReminderEntity Entity => OriginalCommand.Entity;
+
+        /// <summary>
+        /// The key of the reminder that was scheduled.
+        /// </summary>
+        public ReminderKey Key => OriginalCommand.Key;
+
+        /// <summary>
+        /// When the reminder is scheduled to fire.
+        /// </summary>
+        public DateTimeOffset When => OriginalCommand.When;
+    }
 
     public sealed record GetReminders(ReminderEntity Entity) : IReminderQuery;
 
@@ -136,4 +148,12 @@ public sealed record ScheduledReminder(
     object Message,
     TimeSpan? RepeatInterval = null,
     int AttemptCount = 0,
-    string? LastFailureReason = null);
+    string? LastFailureReason = null)
+{
+    /// <summary>
+    /// Converts this scheduled reminder back to a <see cref="ReminderProtocol.ScheduleReminder"/> command.
+    /// Useful for retry scenarios where you need to resubmit the original command.
+    /// </summary>
+    public ReminderProtocol.ScheduleReminder ToScheduleReminder()
+        => new(Entity, Key, When, Message, RepeatInterval);
+}

--- a/src/Akka.Reminders/ReminderScheduler.cs
+++ b/src/Akka.Reminders/ReminderScheduler.cs
@@ -163,7 +163,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 RunTask(() => ProcessReminders(TimeProvider.Now + Settings.MaxSlippage));
                 break;
             }
-            case ReminderProtocol.ScheduleSingleReminder scheduleSingle:
+            case ReminderProtocol.ScheduleReminder scheduleSingle:
             {
                 _log.Debug("Scheduling reminder {0}", scheduleSingle);
                 RunTask(async () =>
@@ -176,8 +176,8 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                         var shardRegion = ShardRegionResolver.TryResolve(reminder.Entity);
                         if (shardRegion is null)
                         {
-                            Sender.Tell(new ReminderProtocol.ReminderScheduled(reminder.Entity, reminder.Key,
-                                TimeProvider.Now, ReminderScheduleResponseCode.ShardRegionNotFound,
+                            Sender.Tell(new ReminderProtocol.ReminderScheduled(scheduleSingle,
+                                ReminderScheduleResponseCode.ShardRegionNotFound,
                                 $"ShardRegion [{reminder.Entity.ShardRegionName}] not found"), ActorRefs.NoSender);
                             return;
                         }
@@ -203,8 +203,8 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                     catch (Exception ex)
                     {
                         _log.Error(ex, "Failed to schedule reminder {0}", scheduleSingle);
-                        Sender.Tell(new ReminderProtocol.ReminderScheduled(scheduleSingle.Entity, scheduleSingle.Key,
-                            TimeProvider.Now, ReminderScheduleResponseCode.Error, ex.Message), ActorRefs.NoSender);
+                        Sender.Tell(new ReminderProtocol.ReminderScheduled(scheduleSingle,
+                            ReminderScheduleResponseCode.Error, ex.Message), ActorRefs.NoSender);
                     }
                 });
                 break;

--- a/src/Akka.Reminders/Storage/InMemoryReminderStorage.cs
+++ b/src/Akka.Reminders/Storage/InMemoryReminderStorage.cs
@@ -25,9 +25,7 @@ public sealed class InMemoryReminderStorage : IReminderStorage
         _pendingReminders[key] = reminder;
 
         return Task.FromResult(new ReminderProtocol.ReminderScheduled(
-            reminder.Entity,
-            reminder.Key,
-            reminder.When,
+            reminder.ToScheduleReminder(),
             ReminderScheduleResponseCode.Success));
     }
 


### PR DESCRIPTION
## Summary

- Restructured `ReminderScheduled` to include the original `ScheduleReminder` command, making it easier to retry failed scheduling operations (e.g., connectivity issues between the scheduling actor and the singleton)
- Renamed `ScheduleSingleReminder` to `ScheduleReminder` since it already handles both single and recurring reminders via the optional `RepeatInterval` parameter
- Added `ToScheduleReminder()` method to `ScheduledReminder` for converting storage records back to commands

## Motivation

When scheduling fails due to transient issues (network partition, singleton unreachable, etc.), callers previously had to reconstruct the original command from the response fields. Now the full `OriginalCommand` is included in the response, containing all context needed for retry:
- Entity (shard region + entity ID)
- Key
- When
- Message payload
- Repeat interval (for recurring reminders)

## Test plan

- [x] All 114 existing tests pass
- [x] Build succeeds with no warnings