### PR TITLE
Simplify Akka dependency management and bump to 1.5.57

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,12 +1,11 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <!-- Nuget package versions -->
-    <AkkaHostingVersion>1.5.55.1</AkkaHostingVersion>
+    <!-- Akka.Hosting packages (github.com/akkadotnet/Akka.Hosting) -->
+    <AkkaHostingVersion>1.5.57</AkkaHostingVersion>
   </PropertyGroup>
-  <!-- App dependencies -->
+  <!-- Akka.Hosting packages - brings in core Akka transitively -->
   <ItemGroup>
-    <PackageVersion Include="Akka.Cluster" Version="1.5.57" />
     <PackageVersion Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />

--- a/src/Akka.Reminders.Sql/Akka.Reminders.Sql.csproj
+++ b/src/Akka.Reminders.Sql/Akka.Reminders.Sql.csproj
@@ -20,7 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.Cluster" />
     <EmbeddedResource Include="Scripts\SqlServer-Create.sql" />
     <EmbeddedResource Include="Scripts\PostgreSql-Create.sql" />
   </ItemGroup>

--- a/src/Akka.Reminders.Tests/Akka.Reminders.Tests.csproj
+++ b/src/Akka.Reminders.Tests/Akka.Reminders.Tests.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.Cluster" />
     <PackageReference Include="Akka.Cluster.Hosting" />
     <PackageReference Include="Akka.Hosting.TestKit" />
     <PackageReference Include="coverlet.collector" />

--- a/src/Akka.Reminders/Akka.Reminders.csproj
+++ b/src/Akka.Reminders/Akka.Reminders.csproj
@@ -15,7 +15,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Akka.Cluster" VersionOverride="1.5.56" />
       <PackageReference Include="Akka.Cluster.Hosting" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary

- Remove explicit `Akka.Cluster` package references from all projects - rely on transitive dependencies from `Akka.Cluster.Hosting` instead
- Use single `AkkaHostingVersion` variable in `Directory.Packages.props` for synchronized Akka.Hosting updates
- Bump Akka.Hosting packages from 1.5.55.1 to 1.5.57
- Fix version conflicts that were causing Dependabot PRs #43 and #44 to fail with NU1605 package downgrade errors

## Test plan

- [x] Build passes locally
- [x] All 114 tests pass
- [ ] CI passes