### PR TITLE
Support ClusterSingletonProxy for non-host roles

### DIFF
--- a/src/Akka.Reminders.Tests/NonHostRoleClusterSpecs.cs
+++ b/src/Akka.Reminders.Tests/NonHostRoleClusterSpecs.cs
@@ -1,0 +1,171 @@
+using Akka.Actor;
+using Akka.Cluster.Hosting;
+using Akka.Cluster.Sharding;
+using Akka.Hosting;
+using Akka.Hosting.TestKit;
+using Akka.Reminders.Sharding;
+using Akka.Reminders.Storage;
+using FluentAssertions;
+using Xunit.Abstractions;
+
+namespace Akka.Reminders.Tests;
+
+/// <summary>
+/// Tests for nodes that don't have the reminder host role but still need to use reminders.
+/// Verifies that such nodes can start successfully with just a proxy (no singleton manager).
+/// See: https://github.com/Aaronontheweb/akka-reminders/issues/49
+/// </summary>
+public class NonHostRoleClusterSpecs : Akka.Hosting.TestKit.TestKit
+{
+    private const string ReminderHostRole = "reminder-host";
+    private const string OtherServiceRole = "other-service";
+    private const string ShardRegionName = "test-entity";
+
+    public NonHostRoleClusterSpecs(ITestOutputHelper output) : base(output: output)
+    {
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        // Configure a node that does NOT have the reminder-host role
+        // This simulates a service that needs to schedule reminders but shouldn't host the singleton
+        builder
+            .WithClustering(new ClusterOptions
+            {
+                // Intentionally NOT including "reminder-host" role
+                Roles = [OtherServiceRole],
+                SeedNodes = Array.Empty<string>()
+            })
+            .WithShardRegion<NonHostTestEntityShardRegion>(
+                ShardRegionName,
+                (_, _, resolver) => s => Props.Create(() => new NonHostTestEntity(s)),
+                new NonHostMessageExtractor(),
+                new ShardOptions
+                {
+                    Role = OtherServiceRole
+                })
+            // This should NOT throw even though this node doesn't have the reminder-host role
+            .WithReminders(ReminderHostRole, reminders => reminders
+                .WithStorage(_ => new InMemoryReminderStorage())
+                .WithSettings(new ReminderSettings
+                {
+                    MaxSlippage = TimeSpan.FromSeconds(1),
+                    StorageTimeout = TimeSpan.FromSeconds(10)
+                }));
+    }
+
+    [Fact]
+    public void NonHostNode_ShouldStartSuccessfully_WithProxyOnly()
+    {
+        // Arrange & Act - The system was already started in ConfigureAkka
+        // If we get here without an exception, the test passes
+
+        // Assert - Verify the cluster node has the correct role (not reminder-host)
+        var cluster = Akka.Cluster.Cluster.Get(Sys);
+        cluster.SelfRoles.Should().Contain(OtherServiceRole);
+        cluster.SelfRoles.Should().NotContain(ReminderHostRole);
+    }
+
+    [Fact]
+    public void NonHostNode_ShouldHaveProxyRegistered()
+    {
+        // Arrange
+        var registry = ActorRegistry.For(Sys);
+
+        // Act
+        var proxyRegistered = registry.TryGet<ReminderSchedulerProxy>(out var proxy);
+
+        // Assert
+        proxyRegistered.Should().BeTrue("the proxy should be registered even on non-host nodes");
+        proxy.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void NonHostNode_ShouldNotHaveSingletonManagerActor()
+    {
+        // Arrange & Act
+        // Try to resolve the singleton manager path - it should NOT exist on non-host nodes
+        var selection = Sys.ActorSelection("/system/reminder-scheduler");
+
+        // Assert - The actor should not exist (will throw or return ActorNotFound)
+        var probe = CreateTestProbe();
+        selection.Tell(new Identify("test"), probe);
+        var identity = probe.ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(3));
+
+        // ActorRef should be null since the singleton manager wasn't created
+        identity.Subject.Should().BeNull("the singleton manager should not be created on non-host nodes");
+    }
+
+    [Fact]
+    public void NonHostNode_ReminderClient_ShouldBeAvailable()
+    {
+        // Arrange & Act
+        var extension = Sys.ReminderClient();
+
+        // Assert
+        extension.Should().NotBeNull("ReminderClient extension should be available on non-host nodes");
+
+        // Creating a client should work
+        var client = extension.CreateClient(ShardRegionName, "test-entity-id");
+        client.Should().NotBeNull("creating a reminder client should succeed on non-host nodes");
+    }
+
+    [Fact]
+    public void NonHostNode_ProxyActor_ShouldExist()
+    {
+        // Arrange
+        var selection = Sys.ActorSelection("/system/reminder-scheduler-proxy");
+        var probe = CreateTestProbe();
+
+        // Act
+        selection.Tell(new Identify("test"), probe);
+        var identity = probe.ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(3));
+
+        // Assert
+        identity.Subject.Should().NotBeNull("the proxy actor should exist on non-host nodes");
+    }
+}
+
+/// <summary>
+/// Test entity for non-host role tests.
+/// </summary>
+internal sealed class NonHostTestEntity : ReceiveActor
+{
+    private readonly string _entityId;
+
+    public NonHostTestEntity(string entityId)
+    {
+        _entityId = entityId;
+
+        ReceiveAny(_ =>
+        {
+            // Just acknowledge receipt
+        });
+    }
+}
+
+/// <summary>
+/// Marker type for the non-host test entity shard region.
+/// </summary>
+internal sealed class NonHostTestEntityShardRegion { }
+
+/// <summary>
+/// Message extractor for non-host test entities.
+/// </summary>
+internal sealed class NonHostMessageExtractor : HashCodeMessageExtractor
+{
+    public NonHostMessageExtractor() : base(10)
+    {
+    }
+
+    public override string? EntityId(object message)
+    {
+        return message switch
+        {
+            EntityMessage env => env.EntityId,
+            _ => null
+        };
+    }
+
+    public override object EntityMessage(object message) => message;
+}

--- a/src/Akka.Reminders/AkkaHostingExtensions.cs
+++ b/src/Akka.Reminders/AkkaHostingExtensions.cs
@@ -1,5 +1,6 @@
 using Akka.Actor;
 using Akka.Cluster.Tools.Singleton;
+using Akka.Event;
 using Akka.Hosting;
 
 namespace Akka.Reminders;
@@ -39,29 +40,45 @@ public static class AkkaHostingExtensions
         // Add the setup to the actor system
         builder.AddSetup(setup);
 
-        // Start both the singleton manager and proxy as /system actors
+        // Start the singleton manager (if this node has the role) and proxy as /system actors
         builder.WithActors((system, registry) =>
         {
             var extendedSystem = (ExtendedActorSystem)system;
+            var log = Logging.GetLogger(system, typeof(AkkaHostingExtensions));
 
-            // Create the storage and resolver instances
-            var storage = setup.StorageFactory(system);
-            var resolver = setup.ShardRegionResolverFactory(system);
+            // Check if this node has the required role to host the singleton
+            var nodeRoles = system.Settings.Config.GetStringList("akka.cluster.roles");
+            var canHostSingleton = string.IsNullOrEmpty(setup.Role) || nodeRoles.Contains(setup.Role);
 
-            // Create singleton settings
-            var singletonSettings = ClusterSingletonManagerSettings.Create(system);
-            if (!string.IsNullOrEmpty(setup.Role))
+            if (canHostSingleton)
             {
-                singletonSettings = singletonSettings.WithRole(setup.Role);
+                // Create the storage and resolver instances
+                var storage = setup.StorageFactory(system);
+                var resolver = setup.ShardRegionResolverFactory(system);
+
+                // Create singleton settings
+                var singletonSettings = ClusterSingletonManagerSettings.Create(system);
+                if (!string.IsNullOrEmpty(setup.Role))
+                {
+                    singletonSettings = singletonSettings.WithRole(setup.Role);
+                }
+
+                // Create and start the singleton manager as a /system actor
+                var singletonProps = ClusterSingletonManager.Props(
+                    singletonProps: Props.Create(() => new ReminderScheduler(setup.Settings, resolver, storage, system.Scheduler)),
+                    terminationMessage: PoisonPill.Instance,
+                    settings: singletonSettings);
+
+                extendedSystem.SystemActorOf(singletonProps, "reminder-scheduler");
+                log.Info("Reminder scheduler singleton manager started - this node can host the reminder scheduler.");
             }
-
-            // Create and start the singleton manager as a /system actor
-            var singletonProps = ClusterSingletonManager.Props(
-                singletonProps: Props.Create(() => new ReminderScheduler(setup.Settings, resolver, storage, system.Scheduler)),
-                terminationMessage: PoisonPill.Instance,
-                settings: singletonSettings);
-
-            var singletonManager = extendedSystem.SystemActorOf(singletonProps, "reminder-scheduler");
+            else
+            {
+                log.Info(
+                    "Node does not have role '{0}' - reminder scheduler proxy will forward messages to singleton host. " +
+                    "This node cannot host the reminder scheduler but can still schedule and cancel reminders.",
+                    setup.Role);
+            }
 
             // Create proxy settings
             // NOTE: The proxy is created on ALL nodes, but needs to know which role hosts the singleton


### PR DESCRIPTION
## Summary

Fixes #49 - Nodes without the reminder host role can now use the reminders library without crashing at startup.

### Changes
- **Role detection at startup**: The hosting extension now checks if the current node has the required role
- **Conditional singleton manager**: Only creates `ClusterSingletonManager` on nodes with the host role
- **Proxy-only mode**: Nodes without the role only create `ClusterSingletonProxy`, allowing them to schedule reminders via the proxy
- **Informational logging**: Logs the node's mode at startup to help operators understand the configuration

### Before
Nodes without the host role would fail with:
```
System.ArgumentException: This cluster member [akka.tcp://MySystem@localhost:32829] doesn't have the role [user-service]
```

### After
Nodes without the host role start successfully and log:
```
Node does not have role 'reminder-host' - reminder scheduler proxy will forward messages to singleton host. 
This node cannot host the reminder scheduler but can still schedule and cancel reminders.
```

## Test Plan
- [x] Added `NonHostRoleClusterSpecs` test class with 5 tests covering proxy-only scenarios
- [x] Verified existing cluster integration tests still pass
- [x] Verified host nodes log the correct message and create singleton manager
- [x] Verified non-host nodes log the correct message and only create proxy