### PR TITLE
Fix reminders not scheduling until restart with SQL storage on empty database

### DIFF
--- a/src/Akka.Reminders.Sql/SqlReminderStorage.cs
+++ b/src/Akka.Reminders.Sql/SqlReminderStorage.cs
@@ -155,7 +155,7 @@ public sealed class SqlReminderStorage : IReminderStorage
 
         // Calculate overview from remaining reminders
         var nextReminder = remainingReminders.OrderBy(r => r.When).FirstOrDefault();
-        var timeUntilNext = nextReminder != null ? nextReminder.When - now : TimeSpan.Zero;
+        var timeUntilNext = nextReminder != null ? nextReminder.When - now : TimeSpan.MaxValue;
 
         var adjustedOverview = new ReminderOverview
         {
@@ -247,7 +247,7 @@ public sealed class SqlReminderStorage : IReminderStorage
 
         // Calculate time until next reminder
         var nextReminder = allReminders.OrderBy(r => r.When).FirstOrDefault();
-        var timeUntilNext = nextReminder != null ? nextReminder.When - now : TimeSpan.Zero;
+        var timeUntilNext = nextReminder != null ? nextReminder.When - now : TimeSpan.MaxValue;
 
         return new ReminderOverview
         {

--- a/src/Akka.Reminders.Tests/Storage/ReminderStorageSpecBase.cs
+++ b/src/Akka.Reminders.Tests/Storage/ReminderStorageSpecBase.cs
@@ -375,7 +375,30 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
 
         // Assert
         Assert.Equal(0, overview.TotalPendingReminders);
-        Assert.True(overview.TimeUntilNext >= TimeSpan.MaxValue || overview.TimeUntilNext == TimeSpan.Zero);
+        Assert.Equal(TimeSpan.MaxValue, overview.TimeUntilNext);
+    }
+
+    [Fact]
+    public async Task GetRemindersOverview_ApplyMethod_ShouldReturnHasNewerDate_WhenDatabaseIsEmpty()
+    {
+        // This test validates the fix for a bug where reminders scheduled against an empty
+        // database were never executed until the system restarted.
+        // The root cause was that SQL storage returned TimeSpan.Zero for empty databases,
+        // causing Apply() to return hasNewerDate=false for future reminders.
+
+        // Arrange - get overview from empty database
+        var now = DateTimeOffset.UtcNow;
+        var emptyOverview = await Storage!.GetRemindersOverviewAsync(now);
+
+        // Act - apply a new reminder scheduled for 5 minutes in the future
+        var futureReminder = CreateTestReminder(when: now.AddMinutes(5));
+        var (newOverview, hasNewerDate) = emptyOverview.Apply(futureReminder, now);
+
+        // Assert - hasNewerDate must be true so TryScheduleFetchReminders() is called
+        Assert.True(hasNewerDate,
+            "When database is empty, any new reminder should be considered 'newer' to trigger scheduling. " +
+            $"TimeUntilNext was: {emptyOverview.TimeUntilNext}");
+        Assert.Equal(1, newOverview.TotalPendingReminders);
     }
 
     [Fact]

--- a/src/Akka.Reminders/Storage/IReminderStorage.cs
+++ b/src/Akka.Reminders/Storage/IReminderStorage.cs
@@ -5,7 +5,7 @@ public sealed record ReminderOverview
     /// <summary>
     /// Determined from our actual data set - how soon is the next reminder?
     /// </summary>
-    public TimeSpan TimeUntilNext { get; init; } = TimeSpan.Zero;
+    public TimeSpan TimeUntilNext { get; init; } = TimeSpan.MaxValue;
     
     /// <summary>
     /// How many reminders are pending?
@@ -15,7 +15,8 @@ public sealed record ReminderOverview
     public (ReminderOverview newOverview, bool hasNewerDate) Apply(ScheduledReminder newReminder, DateTimeOffset now)
     {
         var newTimespan = newReminder.When - now;
-        var hasNewerDate = newTimespan <= TimeUntilNext;
+        // If TimeUntilNext is Zero (no reminders), any new reminder is "newer"
+        var hasNewerDate = TimeUntilNext == TimeSpan.Zero || newTimespan <= TimeUntilNext;
 
         return (new ReminderOverview
         {


### PR DESCRIPTION
## Summary

- Fix bug where reminders scheduled against an empty SQL database were never executed until system restart
- SQL storage now returns `TimeSpan.MaxValue` (instead of `TimeSpan.Zero`) when no reminders exist, matching `InMemoryReminderStorage` behavior
- Added defensive check in `ReminderOverview.Apply()` to handle `TimeSpan.Zero` edge case
- Updated test to require consistent `TimeSpan.MaxValue` behavior across all storage implementations

## Test plan

- [x] Run existing tests - all 122 tests pass
- [x] Verify `GetRemindersOverview_ShouldReturnZero_WhenNoRemindersExist` test now requires `TimeSpan.MaxValue`
- [x] New test `GetRemindersOverview_ApplyMethod_ShouldReturnHasNewerDate_WhenDatabaseIsEmpty` validates the fix scenario

Fixes #61