### PR TITLE
Fix full table scans in reminder storage overview queries

### DIFF
--- a/src/Akka.Reminders.PostgreSql/Internal/ISqlDialect.cs
+++ b/src/Akka.Reminders.PostgreSql/Internal/ISqlDialect.cs
@@ -10,7 +10,8 @@ internal interface ISqlDialect
     string GetMarkCompletedSql(string schemaName, string tableName);
     string GetBatchMarkCompletedSql(string schemaName, string tableName, int count);
     string GetCleanupSql(string schemaName, string tableName);
-    string GetOverviewSql(string schemaName, string tableName);
+    string GetOverviewAggregateSql(string schemaName, string tableName);
+    string GetNextReminderTimeSql(string schemaName, string tableName);
     string GetCancelReminderSql(string schemaName, string tableName);
     string GetCancelAllRemindersSql(string schemaName, string tableName);
     string GetFetchRemindersSql(string schemaName, string tableName);

--- a/src/Akka.Reminders.PostgreSql/Internal/PostgreSqlDialect.cs
+++ b/src/Akka.Reminders.PostgreSql/Internal/PostgreSqlDialect.cs
@@ -140,15 +140,27 @@ internal sealed class PostgreSqlDialect : ISqlDialect
             """;
     }
 
-    public string GetOverviewSql(string schemaName, string tableName)
+    public string GetOverviewAggregateSql(string schemaName, string tableName)
     {
         var fullTableName = $"\"{schemaName}\".\"{tableName}\"";
 
         return $"""
-            SELECT shard_region_name, entity_id, reminder_key, when_utc, repeat_interval_ticks,
-                   serializer_id, manifest, payload, attempt_count, last_failure_reason, is_completed
+            SELECT COUNT(*) AS total_count, MIN(when_utc) AS next_when_utc
             FROM {fullTableName}
-            ORDER BY when_utc ASC;
+            WHERE is_completed = FALSE;
+            """;
+    }
+
+    public string GetNextReminderTimeSql(string schemaName, string tableName)
+    {
+        var fullTableName = $"\"{schemaName}\".\"{tableName}\"";
+
+        return $"""
+            SELECT when_utc
+            FROM {fullTableName}
+            WHERE is_completed = FALSE
+            ORDER BY when_utc ASC
+            LIMIT 1 OFFSET @Skip;
             """;
     }
 

--- a/src/Akka.Reminders.PostgreSql/PostgreSqlReminderStorage.cs
+++ b/src/Akka.Reminders.PostgreSql/PostgreSqlReminderStorage.cs
@@ -108,40 +108,43 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
             reminders.Add(reminder);
         }
 
-        var overview = await GetRemindersOverviewAsync(now, cancellationToken);
-
-        var fetchedKeys = new HashSet<(string, string, string)>(
-            reminders.Select(r => (r.Entity.ShardRegionName, r.Entity.EntityId, r.Key.Name)));
-
+        // Get overview of remaining reminders using aggregate queries
         await using var conn2 = _dialect.CreateConnection(_settings.ConnectionString);
         await conn2.OpenAsync(cancellationToken);
-        await using var cmd2 = conn2.CreateCommand();
-        cmd2.CommandText = _dialect.GetOverviewSql(_settings.SchemaName, _settings.TableName);
-        cmd2.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-        await using var reader2 = await cmd2.ExecuteReaderAsync(cancellationToken);
 
-        var remainingReminders = new List<ScheduledReminder>();
-        while (await reader2.ReadAsync(cancellationToken))
+        long totalPending = 0;
+        await using (var cmd2 = conn2.CreateCommand())
         {
-            var isCompleted = reader2.GetBoolean(reader2.GetOrdinal("is_completed"));
-            if (!isCompleted)
+            cmd2.CommandText = _dialect.GetOverviewAggregateSql(_settings.SchemaName, _settings.TableName);
+            cmd2.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+            await using var reader2 = await cmd2.ExecuteReaderAsync(cancellationToken);
+            if (await reader2.ReadAsync(cancellationToken))
             {
-                var reminder = ReadReminderFromReader(reader2);
-                var key = (reminder.Entity.ShardRegionName, reminder.Entity.EntityId, reminder.Key.Name);
-                if (!fetchedKeys.Contains(key))
-                {
-                    remainingReminders.Add(reminder);
-                }
+                totalPending = reader2.GetInt64(reader2.GetOrdinal("total_count"));
             }
         }
 
-        var nextReminder = remainingReminders.OrderBy(r => r.When).FirstOrDefault();
-        var timeUntilNext = nextReminder != null ? nextReminder.When - now : TimeSpan.MaxValue;
+        var remainingCount = totalPending - reminders.Count;
+        var timeUntilNext = TimeSpan.MaxValue;
+
+        if (remainingCount > 0)
+        {
+            await using var cmd3 = conn2.CreateCommand();
+            cmd3.CommandText = _dialect.GetNextReminderTimeSql(_settings.SchemaName, _settings.TableName);
+            cmd3.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+            _dialect.AddParameter(cmd3, "@Skip", reminders.Count);
+
+            var result = await cmd3.ExecuteScalarAsync(cancellationToken);
+            if (result is DateTime nextWhenUtc)
+            {
+                timeUntilNext = new DateTimeOffset(DateTime.SpecifyKind(nextWhenUtc, DateTimeKind.Utc)) - now;
+            }
+        }
 
         var adjustedOverview = new ReminderOverview
         {
             TimeUntilNext = timeUntilNext,
-            TotalPendingReminders = remainingReminders.Count
+            TotalPendingReminders = remainingCount
         };
 
         return new PendingRemindersWithSummary(reminders, adjustedOverview);
@@ -201,42 +204,41 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
         }
     }
 
+    /// <inheritdoc />
     public async Task<ReminderOverview> GetRemindersOverviewAsync(
         DateTimeOffset now,
         CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
 
-        var allReminders = new List<ScheduledReminder>();
-
         await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
         await connection.OpenAsync(cancellationToken);
 
         await using var command = connection.CreateCommand();
-        command.CommandText = _dialect.GetOverviewSql(_settings.SchemaName, _settings.TableName);
+        command.CommandText = _dialect.GetOverviewAggregateSql(_settings.SchemaName, _settings.TableName);
         command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
 
-        while (await reader.ReadAsync(cancellationToken))
+        if (await reader.ReadAsync(cancellationToken))
         {
-            var isCompleted = reader.GetBoolean(reader.GetOrdinal("is_completed"));
+            var totalCount = reader.GetInt64(reader.GetOrdinal("total_count"));
+            var nextWhenUtcOrdinal = reader.GetOrdinal("next_when_utc");
 
-            if (!isCompleted)
+            if (totalCount == 0 || reader.IsDBNull(nextWhenUtcOrdinal))
+                return ReminderOverview.Empty;
+
+            var nextWhenUtc = reader.GetDateTime(nextWhenUtcOrdinal);
+            var timeUntilNext = new DateTimeOffset(DateTime.SpecifyKind(nextWhenUtc, DateTimeKind.Utc)) - now;
+
+            return new ReminderOverview
             {
-                var reminder = ReadReminderFromReader(reader);
-                allReminders.Add(reminder);
-            }
+                TotalPendingReminders = totalCount,
+                TimeUntilNext = timeUntilNext
+            };
         }
 
-        var nextReminder = allReminders.OrderBy(r => r.When).FirstOrDefault();
-        var timeUntilNext = nextReminder != null ? nextReminder.When - now : TimeSpan.MaxValue;
-
-        return new ReminderOverview
-        {
-            TimeUntilNext = timeUntilNext,
-            TotalPendingReminders = allReminders.Count
-        };
+        return ReminderOverview.Empty;
     }
 
     public async Task<bool> CleanUpCompletedRemindersAsync(

--- a/src/Akka.Reminders.SqlServer/Internal/ISqlDialect.cs
+++ b/src/Akka.Reminders.SqlServer/Internal/ISqlDialect.cs
@@ -10,7 +10,8 @@ internal interface ISqlDialect
     string GetMarkCompletedSql(string schemaName, string tableName);
     string GetBatchMarkCompletedSql(string schemaName, string tableName, int count);
     string GetCleanupSql(string schemaName, string tableName);
-    string GetOverviewSql(string schemaName, string tableName);
+    string GetOverviewAggregateSql(string schemaName, string tableName);
+    string GetNextReminderTimeSql(string schemaName, string tableName);
     string GetCancelReminderSql(string schemaName, string tableName);
     string GetCancelAllRemindersSql(string schemaName, string tableName);
     string GetFetchRemindersSql(string schemaName, string tableName);

--- a/src/Akka.Reminders.SqlServer/Internal/SqlServerDialect.cs
+++ b/src/Akka.Reminders.SqlServer/Internal/SqlServerDialect.cs
@@ -162,15 +162,27 @@ internal sealed class SqlServerDialect : ISqlDialect
             """;
     }
 
-    public string GetOverviewSql(string schemaName, string tableName)
+    public string GetOverviewAggregateSql(string schemaName, string tableName)
     {
         var fullTableName = $"[{schemaName}].[{tableName}]";
 
         return $"""
-            SELECT ShardRegionName, EntityId, ReminderKey, WhenUtc, RepeatIntervalTicks,
-                   SerializerId, Manifest, Payload, AttemptCount, LastFailureReason, IsCompleted
+            SELECT COUNT(*) AS TotalCount, MIN(WhenUtc) AS NextWhenUtc
             FROM {fullTableName}
-            ORDER BY WhenUtc ASC;
+            WHERE IsCompleted = 0;
+            """;
+    }
+
+    public string GetNextReminderTimeSql(string schemaName, string tableName)
+    {
+        var fullTableName = $"[{schemaName}].[{tableName}]";
+
+        return $"""
+            SELECT WhenUtc
+            FROM {fullTableName}
+            WHERE IsCompleted = 0
+            ORDER BY WhenUtc ASC
+            OFFSET @Skip ROWS FETCH NEXT 1 ROW ONLY;
             """;
     }
 

--- a/src/Akka.Reminders.SqlServer/SqlServerReminderStorage.cs
+++ b/src/Akka.Reminders.SqlServer/SqlServerReminderStorage.cs
@@ -99,40 +99,43 @@ public sealed class SqlServerReminderStorage : IReminderStorage
             reminders.Add(reminder);
         }
 
-        var overview = await GetRemindersOverviewAsync(now, cancellationToken);
-
-        var fetchedKeys = new HashSet<(string, string, string)>(
-            reminders.Select(r => (r.Entity.ShardRegionName, r.Entity.EntityId, r.Key.Name)));
-
+        // Get overview of remaining reminders using aggregate queries
         await using var conn2 = _dialect.CreateConnection(_settings.ConnectionString);
         await conn2.OpenAsync(cancellationToken);
-        await using var cmd2 = conn2.CreateCommand();
-        cmd2.CommandText = _dialect.GetOverviewSql(_settings.SchemaName, _settings.TableName);
-        cmd2.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-        await using var reader2 = await cmd2.ExecuteReaderAsync(cancellationToken);
 
-        var remainingReminders = new List<ScheduledReminder>();
-        while (await reader2.ReadAsync(cancellationToken))
+        long totalPending = 0;
+        await using (var cmd2 = conn2.CreateCommand())
         {
-            var isCompleted = reader2.GetBoolean(reader2.GetOrdinal("IsCompleted"));
-            if (!isCompleted)
+            cmd2.CommandText = _dialect.GetOverviewAggregateSql(_settings.SchemaName, _settings.TableName);
+            cmd2.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+            await using var reader2 = await cmd2.ExecuteReaderAsync(cancellationToken);
+            if (await reader2.ReadAsync(cancellationToken))
             {
-                var reminder = ReadReminderFromReader(reader2);
-                var key = (reminder.Entity.ShardRegionName, reminder.Entity.EntityId, reminder.Key.Name);
-                if (!fetchedKeys.Contains(key))
-                {
-                    remainingReminders.Add(reminder);
-                }
+                totalPending = reader2.GetInt32(reader2.GetOrdinal("TotalCount"));
             }
         }
 
-        var nextReminder = remainingReminders.OrderBy(r => r.When).FirstOrDefault();
-        var timeUntilNext = nextReminder != null ? nextReminder.When - now : TimeSpan.MaxValue;
+        var remainingCount = totalPending - reminders.Count;
+        var timeUntilNext = TimeSpan.MaxValue;
+
+        if (remainingCount > 0)
+        {
+            await using var cmd3 = conn2.CreateCommand();
+            cmd3.CommandText = _dialect.GetNextReminderTimeSql(_settings.SchemaName, _settings.TableName);
+            cmd3.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+            _dialect.AddParameter(cmd3, "@Skip", reminders.Count);
+
+            var result = await cmd3.ExecuteScalarAsync(cancellationToken);
+            if (result is DateTime nextWhenUtc)
+            {
+                timeUntilNext = new DateTimeOffset(DateTime.SpecifyKind(nextWhenUtc, DateTimeKind.Utc)) - now;
+            }
+        }
 
         var adjustedOverview = new ReminderOverview
         {
             TimeUntilNext = timeUntilNext,
-            TotalPendingReminders = remainingReminders.Count
+            TotalPendingReminders = remainingCount
         };
 
         return new PendingRemindersWithSummary(reminders, adjustedOverview);
@@ -192,42 +195,41 @@ public sealed class SqlServerReminderStorage : IReminderStorage
         }
     }
 
+    /// <inheritdoc />
     public async Task<ReminderOverview> GetRemindersOverviewAsync(
         DateTimeOffset now,
         CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
 
-        var allReminders = new List<ScheduledReminder>();
-
         await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
         await connection.OpenAsync(cancellationToken);
 
         await using var command = connection.CreateCommand();
-        command.CommandText = _dialect.GetOverviewSql(_settings.SchemaName, _settings.TableName);
+        command.CommandText = _dialect.GetOverviewAggregateSql(_settings.SchemaName, _settings.TableName);
         command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
 
-        while (await reader.ReadAsync(cancellationToken))
+        if (await reader.ReadAsync(cancellationToken))
         {
-            var isCompleted = reader.GetBoolean(reader.GetOrdinal("IsCompleted"));
+            var totalCount = reader.GetInt32(reader.GetOrdinal("TotalCount"));
+            var nextWhenUtcOrdinal = reader.GetOrdinal("NextWhenUtc");
 
-            if (!isCompleted)
+            if (totalCount == 0 || reader.IsDBNull(nextWhenUtcOrdinal))
+                return ReminderOverview.Empty;
+
+            var nextWhenUtc = reader.GetDateTime(nextWhenUtcOrdinal);
+            var timeUntilNext = new DateTimeOffset(DateTime.SpecifyKind(nextWhenUtc, DateTimeKind.Utc)) - now;
+
+            return new ReminderOverview
             {
-                var reminder = ReadReminderFromReader(reader);
-                allReminders.Add(reminder);
-            }
+                TotalPendingReminders = totalCount,
+                TimeUntilNext = timeUntilNext
+            };
         }
 
-        var nextReminder = allReminders.OrderBy(r => r.When).FirstOrDefault();
-        var timeUntilNext = nextReminder != null ? nextReminder.When - now : TimeSpan.MaxValue;
-
-        return new ReminderOverview
-        {
-            TimeUntilNext = timeUntilNext,
-            TotalPendingReminders = allReminders.Count
-        };
+        return ReminderOverview.Empty;
     }
 
     public async Task<bool> CleanUpCompletedRemindersAsync(

--- a/src/Akka.Reminders.Sqlite/Internal/ISqlDialect.cs
+++ b/src/Akka.Reminders.Sqlite/Internal/ISqlDialect.cs
@@ -10,7 +10,8 @@ internal interface ISqlDialect
     string GetMarkCompletedSql(string tableName);
     string GetBatchMarkCompletedSql(string tableName, int count);
     string GetCleanupSql(string tableName);
-    string GetOverviewSql(string tableName);
+    string GetOverviewAggregateSql(string tableName);
+    string GetNextReminderTimeSql(string tableName);
     string GetCancelReminderSql(string tableName);
     string GetCancelAllRemindersSql(string tableName);
     string GetFetchRemindersSql(string tableName);

--- a/src/Akka.Reminders.Sqlite/Internal/SqliteDialect.cs
+++ b/src/Akka.Reminders.Sqlite/Internal/SqliteDialect.cs
@@ -132,15 +132,27 @@ internal sealed class SqliteDialect : ISqlDialect
             """;
     }
 
-    public string GetOverviewSql(string tableName)
+    public string GetOverviewAggregateSql(string tableName)
     {
         var fullTableName = $"\"{tableName}\"";
 
         return $"""
-            SELECT shard_region_name, entity_id, reminder_key, when_utc, repeat_interval_ticks,
-                   serializer_id, manifest, payload, attempt_count, last_failure_reason, is_completed
+            SELECT COUNT(*) AS total_count, MIN(when_utc) AS next_when_utc
             FROM {fullTableName}
-            ORDER BY when_utc ASC;
+            WHERE is_completed = 0;
+            """;
+    }
+
+    public string GetNextReminderTimeSql(string tableName)
+    {
+        var fullTableName = $"\"{tableName}\"";
+
+        return $"""
+            SELECT when_utc
+            FROM {fullTableName}
+            WHERE is_completed = 0
+            ORDER BY when_utc ASC
+            LIMIT 1 OFFSET @Skip;
             """;
     }
 

--- a/src/Akka.Reminders.Sqlite/SqliteReminderStorage.cs
+++ b/src/Akka.Reminders.Sqlite/SqliteReminderStorage.cs
@@ -97,40 +97,45 @@ public sealed class SqliteReminderStorage : IReminderStorage
             reminders.Add(reminder);
         }
 
-        var overview = await GetRemindersOverviewAsync(now, cancellationToken);
-
-        var fetchedKeys = new HashSet<(string, string, string)>(
-            reminders.Select(r => (r.Entity.ShardRegionName, r.Entity.EntityId, r.Key.Name)));
-
+        // Get overview of remaining reminders using aggregate queries
         await using var conn2 = _dialect.CreateConnection(_settings.ConnectionString);
         await conn2.OpenAsync(cancellationToken);
-        await using var cmd2 = conn2.CreateCommand();
-        cmd2.CommandText = _dialect.GetOverviewSql(_settings.TableName);
-        cmd2.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-        await using var reader2 = await cmd2.ExecuteReaderAsync(cancellationToken);
 
-        var remainingReminders = new List<ScheduledReminder>();
-        while (await reader2.ReadAsync(cancellationToken))
+        long totalPending = 0;
+        await using (var cmd2 = conn2.CreateCommand())
         {
-            var isCompleted = ReadBoolean(reader2, "is_completed");
-            if (!isCompleted)
+            cmd2.CommandText = _dialect.GetOverviewAggregateSql(_settings.TableName);
+            cmd2.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+            await using var reader2 = await cmd2.ExecuteReaderAsync(cancellationToken);
+            if (await reader2.ReadAsync(cancellationToken))
             {
-                var reminder = ReadReminderFromReader(reader2);
-                var key = (reminder.Entity.ShardRegionName, reminder.Entity.EntityId, reminder.Key.Name);
-                if (!fetchedKeys.Contains(key))
-                {
-                    remainingReminders.Add(reminder);
-                }
+                totalPending = Convert.ToInt64(reader2.GetValue(reader2.GetOrdinal("total_count")),
+                    CultureInfo.InvariantCulture);
             }
         }
 
-        var nextReminder = remainingReminders.OrderBy(r => r.When).FirstOrDefault();
-        var timeUntilNext = nextReminder != null ? nextReminder.When - now : TimeSpan.MaxValue;
+        var remainingCount = totalPending - reminders.Count;
+        var timeUntilNext = TimeSpan.MaxValue;
+
+        if (remainingCount > 0)
+        {
+            await using var cmd3 = conn2.CreateCommand();
+            cmd3.CommandText = _dialect.GetNextReminderTimeSql(_settings.TableName);
+            cmd3.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+            _dialect.AddParameter(cmd3, "@Skip", reminders.Count);
+
+            var result = await cmd3.ExecuteScalarAsync(cancellationToken);
+            if (result != null && result != DBNull.Value)
+            {
+                var nextWhenUtc = ParseDateTimeOffset(result);
+                timeUntilNext = nextWhenUtc - now;
+            }
+        }
 
         var adjustedOverview = new ReminderOverview
         {
             TimeUntilNext = timeUntilNext,
-            TotalPendingReminders = remainingReminders.Count
+            TotalPendingReminders = remainingCount
         };
 
         return new PendingRemindersWithSummary(reminders, adjustedOverview);
@@ -197,36 +202,35 @@ public sealed class SqliteReminderStorage : IReminderStorage
     {
         await EnsureInitializedAsync(cancellationToken);
 
-        var allReminders = new List<ScheduledReminder>();
-
         await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
         await connection.OpenAsync(cancellationToken);
 
         await using var command = connection.CreateCommand();
-        command.CommandText = _dialect.GetOverviewSql(_settings.TableName);
+        command.CommandText = _dialect.GetOverviewAggregateSql(_settings.TableName);
         command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
 
-        while (await reader.ReadAsync(cancellationToken))
+        if (await reader.ReadAsync(cancellationToken))
         {
-            var isCompleted = ReadBoolean(reader, "is_completed");
+            var totalCount = Convert.ToInt64(reader.GetValue(reader.GetOrdinal("total_count")),
+                CultureInfo.InvariantCulture);
+            var nextWhenUtcOrdinal = reader.GetOrdinal("next_when_utc");
 
-            if (!isCompleted)
+            if (totalCount == 0 || reader.IsDBNull(nextWhenUtcOrdinal))
+                return ReminderOverview.Empty;
+
+            var nextWhenUtc = ParseDateTimeOffset(reader.GetValue(nextWhenUtcOrdinal));
+            var timeUntilNext = nextWhenUtc - now;
+
+            return new ReminderOverview
             {
-                var reminder = ReadReminderFromReader(reader);
-                allReminders.Add(reminder);
-            }
+                TotalPendingReminders = totalCount,
+                TimeUntilNext = timeUntilNext
+            };
         }
 
-        var nextReminder = allReminders.OrderBy(r => r.When).FirstOrDefault();
-        var timeUntilNext = nextReminder != null ? nextReminder.When - now : TimeSpan.MaxValue;
-
-        return new ReminderOverview
-        {
-            TimeUntilNext = timeUntilNext,
-            TotalPendingReminders = allReminders.Count
-        };
+        return ReminderOverview.Empty;
     }
 
     public async Task<bool> CleanUpCompletedRemindersAsync(
@@ -455,13 +459,17 @@ public sealed class SqliteReminderStorage : IReminderStorage
     {
         var ordinal = reader.GetOrdinal(columnName);
         var value = reader.GetValue(ordinal);
+        return ParseDateTimeOffset(value);
+    }
 
+    private static DateTimeOffset ParseDateTimeOffset(object value)
+    {
         return value switch
         {
             DateTimeOffset dto => dto,
             DateTime dt => new DateTimeOffset(DateTime.SpecifyKind(dt, DateTimeKind.Utc)),
             string s => DateTimeOffset.Parse(s, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
-            _ => throw new InvalidOperationException($"Unexpected datetime value type '{value.GetType()}' for column '{columnName}'.")
+            _ => throw new InvalidOperationException($"Unexpected datetime value type '{value.GetType()}'.")
         };
     }
 

--- a/src/Akka.Reminders/Storage/IReminderStorage.cs
+++ b/src/Akka.Reminders/Storage/IReminderStorage.cs
@@ -98,8 +98,17 @@ public interface IReminderStorage
     Task<ReminderProtocol.RemindersCancelled> CancelAllRemindersForEntityAsync(ReminderEntity entity, CancellationToken ct = default);
     
     /// <summary>
-    /// Fetches a summary of pending reminders.
+    /// Fetches a summary of pending reminders for diagnostics, testing, and ad-hoc queries.
     /// </summary>
+    /// <remarks>
+    /// This method is intended for external use cases: diagnostic tooling, integration tests,
+    /// health check endpoints, and monitoring dashboards.
+    ///
+    /// It MUST NOT be called from the scheduling hot path (e.g., inside <see cref="GetNextRemindersAsync"/>).
+    /// The scheduling actor computes its own overview from efficient aggregate queries as part of
+    /// <see cref="GetNextRemindersAsync"/> — calling this method from there would introduce
+    /// redundant database round-trips.
+    /// </remarks>
     /// <param name="now">Current time from scheduler</param>
     /// <param name="ct">Cancellation token</param>
     Task<ReminderOverview> GetRemindersOverviewAsync(DateTimeOffset now, CancellationToken ct = default);


### PR DESCRIPTION
## Summary

- **Removed full table scans** from `GetNextRemindersAsync` and `GetRemindersOverviewAsync` across all three SQL providers (SqlServer, PostgreSQL, SQLite)
- Replaced `GetOverviewSql` (which returned all columns for all rows) with two efficient aggregate queries:
  - `GetOverviewAggregateSql`: `SELECT COUNT(*), MIN(when_utc) WHERE is_completed = 0`
  - `GetNextReminderTimeSql`: `SELECT when_utc ... ORDER BY when_utc OFFSET @Skip LIMIT 1`
- Removed unused `GetRemindersOverviewAsync` call inside `GetNextRemindersAsync` (result was discarded)
- Added XML doc comments to `IReminderStorage.GetRemindersOverviewAsync` clarifying it is for diagnostics/testing/monitoring only and must not be called from the scheduling hot path

## Context

`GetNextRemindersAsync` had two performance bugs introduced during the provider package split (`0ce1026`):

1. Called `GetRemindersOverviewAsync` and stored result in an unused variable — loading all rows and deserializing all payloads for nothing.
2. Opened a second connection loading ALL rows (including completed ones, filtering in C#) into memory, just to compute `COUNT` and `MIN(WhenUtc)` of remaining reminders.

`GetRemindersOverviewAsync` itself had the same issue — loading every row to compute two scalar values.

## Structural safeguard

`GetOverviewSql` has been removed from the `ISqlDialect` interface entirely. The only overview-related queries now return aggregate scalars, making it structurally impossible to accidentally reintroduce a full table scan through the overview path.

## Test plan

- [x] All 28 InMemory storage tests pass (validates correctness of overview counts, TimeUntilNext, batch size limits)
- [ ] CI validates SqlServer/PostgreSQL/SQLite against real databases