### PR TITLE
Prepare 0.5.1 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,28 +7,13 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.5.0</VersionPrefix>
-    <PackageReleaseNotes>**New Features**
+    <VersionPrefix>0.5.1</VersionPrefix>
+    <PackageReleaseNotes>**Bug Fixes**
 
-- **SQLite Storage Backend** - Added SQLite as a first-class storage provider for akka-reminders ([#83](https://github.com/Aaronontheweb/akka-reminders/pull/83), closes [#63](https://github.com/Aaronontheweb/akka-reminders/issues/63))
-  - Configure via `WithSqliteStorage(...)` in the Akka.Hosting API
-  - Full feature parity with SQL Server and PostgreSQL storage backends
-  - Well suited for local development, testing, and single-node deployments
-
-- **Provider-Specific NuGet Packages** - SQL storage implementations are now available as dedicated packages ([#83](https://github.com/Aaronontheweb/akka-reminders/pull/83))
-  - `Aaron.Akka.Reminders.SqlServer` - SQL Server storage provider
-  - `Aaron.Akka.Reminders.PostgreSql` - PostgreSQL storage provider
-  - `Aaron.Akka.Reminders.Sqlite` - SQLite storage provider
-  - `Aaron.Akka.Reminders.Sql` remains fully functional as a compatibility package that re-exports all three providers
-
-- **Configurable PostgreSQL Schema Settings** - PostgreSQL storage can now be configured via HOCON for schema name, table name, auto-initialization, and command timeout ([#84](https://github.com/Aaronontheweb/akka-reminders/pull/84), closes [#67](https://github.com/Aaronontheweb/akka-reminders/issues/67))
-  - New `WithPostgreSqlStorageFromConfig(...)` Akka.Hosting API reads settings directly from the actor system config
-  - Supported HOCON keys: `schema-name`, `table-name`, `auto-initialize`, `command-timeout`
-  - Default schema remains `reminders` for full backward compatibility
-
-**Dependency Updates**
-
-- Updated Npgsql from 8.0.8 to 10.0.1 ([#47](https://github.com/Aaronontheweb/akka-reminders/pull/47))</PackageReleaseNotes>
+- **Fixed Full Table Scans in Reminder Storage Queries** - Resolved significant performance regression introduced in 0.5.0 where `GetNextRemindersAsync` and `GetRemindersOverviewAsync` loaded all rows from the database on every scheduling tick ([#92](https://github.com/Aaronontheweb/akka-reminders/pull/92))
+  - Replaced full-row scans with efficient aggregate queries (`COUNT(*) / MIN(when_utc)`) across all three SQL providers (SqlServer, PostgreSQL, SQLite)
+  - Removed an unused internal call to `GetRemindersOverviewAsync` inside `GetNextRemindersAsync` that was performing a full table load and discarding the result
+  - Removed `GetOverviewSql` from the `ISqlDialect` interface entirely, making it structurally impossible to reintroduce the full-scan path in the future</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Visual Studio C# settings -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+#### 0.5.1 March 9th 2026 ####
+
+**Bug Fixes**
+
+- **Fixed Full Table Scans in Reminder Storage Queries** - Resolved significant performance regression introduced in 0.5.0 where `GetNextRemindersAsync` and `GetRemindersOverviewAsync` loaded all rows from the database on every scheduling tick ([#92](https://github.com/Aaronontheweb/akka-reminders/pull/92))
+  - Replaced full-row scans with efficient aggregate queries (`COUNT(*) / MIN(when_utc)`) across all three SQL providers (SqlServer, PostgreSQL, SQLite)
+  - Removed an unused internal call to `GetRemindersOverviewAsync` inside `GetNextRemindersAsync` that was performing a full table load and discarding the result
+  - Removed `GetOverviewSql` from the `ISqlDialect` interface entirely, making it structurally impossible to reintroduce the full-scan path in the future
+
 #### 0.5.0 March 2nd 2026 ####
 
 **New Features**


### PR DESCRIPTION
## Summary

- Bumps `VersionPrefix` in `Directory.Build.props` from `0.5.0` to `0.5.1`
- Adds 0.5.1 release notes to `RELEASE_NOTES.md` documenting the fix for full table scans in reminder storage queries ([#92](https://github.com/Aaronontheweb/akka-reminders/pull/92))

## Changes included in this release

**Bug Fixes**

- Fixed full table scans in `GetNextRemindersAsync` and `GetRemindersOverviewAsync` across all three SQL providers (SqlServer, PostgreSQL, SQLite). Replaced full-row scans with efficient aggregate queries and removed `GetOverviewSql` from `ISqlDialect` entirely.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, tag `0.5.1` is created from `dev` and pushed — CI/CD publishes NuGet packages automatically