### PR TITLE
Redesign reminder delivery around occurrence deadlines

### DIFF
--- a/Akka.Reminders.slnx
+++ b/Akka.Reminders.slnx
@@ -7,6 +7,7 @@
     <File Path="README.md" />
   </Folder>
   <Folder Name="/src/">
+    <Project Path="src/Akka.Reminders.Migration.Tests/Akka.Reminders.Migration.Tests.csproj" />
     <Project Path="src/Akka.Reminders.PostgreSql/Akka.Reminders.PostgreSql.csproj" />
     <Project Path="src/Akka.Reminders.Sql/Akka.Reminders.Sql.csproj" />
     <Project Path="src/Akka.Reminders.SqlServer/Akka.Reminders.SqlServer.csproj" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,13 +7,18 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.5.1</VersionPrefix>
-    <PackageReleaseNotes>**Bug Fixes**
+    <VersionPrefix>0.6.0</VersionPrefix>
+    <PackageReleaseNotes>**Breaking Changes**
 
-- **Fixed Full Table Scans in Reminder Storage Queries** - Resolved significant performance regression introduced in 0.5.0 where `GetNextRemindersAsync` and `GetRemindersOverviewAsync` loaded all rows from the database on every scheduling tick ([#92](https://github.com/Aaronontheweb/akka-reminders/pull/92))
-  - Replaced full-row scans with efficient aggregate queries (`COUNT(*) / MIN(when_utc)`) across all three SQL providers (SqlServer, PostgreSQL, SQLite)
-  - Removed an unused internal call to `GetRemindersOverviewAsync` inside `GetNextRemindersAsync` that was performing a full table load and discarding the result
-  - Removed `GetOverviewSql` from the `ISqlDialect` interface entirely, making it structurally impossible to reintroduce the full-scan path in the future</PackageReleaseNotes>
+- **Reminder delivery now uses `ReminderEnvelope&lt;T&gt;` instead of raw messages** - All reminders are delivered wrapped in a strongly-typed envelope that must be acknowledged. Actors receiving reminders must change from `Receive&lt;MyMessage&gt;` to `ReceiveAsync&lt;ReminderEnvelope&lt;MyMessage&gt;&gt;` and call `await client.AckAsync(envelope)` after processing.
+- **`IReminderClient` scheduling methods are now generic** - `ScheduleSingleReminderAsync&lt;T&gt;` and `ScheduleRecurringReminderAsync&lt;T&gt;` replace the `object message` parameter with `T message` for type safety.
+- **`IShardRegionResolver.DeliverReminder` signature changed** - Now accepts `ReminderEnvelope` and `IActorRef sender` instead of raw `object message`.
+
+**New Features**
+
+- **Reliable Delivery with Acknowledgement Protocol** - Reminders now require explicit acknowledgement from recipients via `IReminderClient.AckAsync(envelope)`. Unacknowledged reminders are automatically retried with exponential backoff.
+- **Strongly-Typed `ReminderEnvelope&lt;T&gt;`** - Delivered reminders are wrapped in a generic envelope implementing `IWrappedMessage`.
+- **Custom Akka.Remote Serializer** - `ReminderEnvelope`, `ReminderAck`, and `ReminderAckResponse` are automatically serialized across cluster boundaries using a dedicated `SerializerWithStringManifest`.</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Visual Studio C# settings -->

--- a/README.md
+++ b/README.md
@@ -359,7 +359,8 @@ Configure reminder behavior and performance characteristics:
         PruneOlderThan = TimeSpan.FromDays(30),
 
         // Maximum delivery attempts before marking as permanently failed
-        MaxDeliveryAttempts = 3,
+        // Applies to both infrastructure failures and ack timeouts
+        MaxDeliveryAttempts = 10,
 
         // Maximum reminders fetched per batch (limits query size under load)
         MaxBatchSize = 1000,
@@ -369,8 +370,11 @@ Configure reminder behavior and performance characteristics:
         DeliveryCommitChunkSize = 100,
 
         // Base delay for exponential backoff on retries
-        // Actual delay = RetryBackoffBase * (2 ^ attemptCount)
-        RetryBackoffBase = TimeSpan.FromSeconds(30),
+        // Actual delay = min(RetryBackoffBase * 2^attempt, MaxRetryBackoff)
+        RetryBackoffBase = TimeSpan.FromSeconds(60),
+
+        // Cap on exponential backoff to prevent absurdly long intervals
+        MaxRetryBackoff = TimeSpan.FromMinutes(10),
 
         // How long to wait for a recipient ack before retrying delivery
         AckTimeout = TimeSpan.FromSeconds(30),

--- a/README.md
+++ b/README.md
@@ -384,10 +384,7 @@ Configure reminder behavior and performance characteristics:
         MaxRetryBackoff = TimeSpan.FromMinutes(10),
 
         // How long to wait for a recipient ack before retrying delivery
-        AckTimeout = TimeSpan.FromSeconds(30),
-
-        // How frequently to scan for reminders whose ack deadline has passed
-        AckTimeoutCheckInterval = TimeSpan.FromSeconds(10)
+        AckTimeout = TimeSpan.FromSeconds(30)
     }))
 ```
 

--- a/README.md
+++ b/README.md
@@ -146,11 +146,12 @@ public class MyEntityActor : ReceiveActor
 
         ReceiveAsync<ScheduleReminder>(async msg =>
         {
-            // Schedule a one-time reminder
+            // Schedule a one-time reminder that expires if it is more than 30 seconds late.
             var result = await _reminders.ScheduleSingleReminderAsync(
                 new ReminderKey("my-reminder"),
                 DateTimeOffset.UtcNow.AddMinutes(5),
-                new DoSomething());
+                new DoSomething(),
+                maxDeliveryWindow: TimeSpan.FromSeconds(30));
 
             if (result.ResponseCode == ReminderScheduleResponseCode.Success)
             {
@@ -170,6 +171,12 @@ public class MyEntityActor : ReceiveActor
 
         ReceiveAsync<ReminderEnvelope<DoSomething>>(async envelope =>
         {
+            if (envelope.Deadline.IsExpired())
+            {
+                await _reminders.AckAsync(envelope);
+                return;
+            }
+
             // Handle the reminder when it fires
             Console.WriteLine("Reminder received!");
 
@@ -370,7 +377,7 @@ Configure reminder behavior and performance characteristics:
         DeliveryCommitChunkSize = 100,
 
         // Base delay for exponential backoff on retries
-        // Actual delay = min(RetryBackoffBase * 2^attempt, MaxRetryBackoff)
+        // Retries are also bounded by each occurrence's delivery deadline.
         RetryBackoffBase = TimeSpan.FromSeconds(60),
 
         // Cap on exponential backoff to prevent absurdly long intervals
@@ -410,13 +417,19 @@ public class HealthCheckActor : ReceiveActor
 
         ReceiveAsync<ReminderEnvelope<PerformHealthCheck>>(async envelope =>
         {
-            await _reminders.AckAsync(envelope);
+            if (envelope.Deadline.IsExpired())
+            {
+                await _reminders.AckAsync(envelope);
+                return;
+            }
 
             var isHealthy = await CheckHealth();
             if (!isHealthy)
             {
                 Self.Tell(new Restart());
             }
+
+            await _reminders.AckAsync(envelope);
         });
     }
 }
@@ -447,12 +460,18 @@ public class OrderActor : ReceiveActor
 
         ReceiveAsync<ReminderEnvelope<CheckPayment>>(async envelope =>
         {
-            await _reminders.AckAsync(envelope);
+            if (envelope.Deadline.IsExpired())
+            {
+                await _reminders.AckAsync(envelope);
+                return;
+            }
 
             if (!await PaymentReceived())
             {
                 Self.Tell(new CancelOrder());
             }
+
+            await _reminders.AckAsync(envelope);
         });
     }
 }
@@ -476,10 +495,12 @@ Task<ReminderScheduled> ScheduleSingleReminderAsync(
     ReminderKey key,
     DateTimeOffset when,
     object message,
+    TimeSpan? maxDeliveryWindow = null,
     CancellationToken cancellationToken = default)
 ```
 
-Schedules a one-time reminder that fires at the specified time.
+Schedules a one-time reminder that fires at the specified time. When `maxDeliveryWindow` is provided,
+the occurrence expires after `when + maxDeliveryWindow` and will not be retried beyond that deadline.
 
 #### Schedule Recurring Reminder
 ```csharp
@@ -488,10 +509,13 @@ Task<ReminderScheduled> ScheduleRecurringReminderAsync(
     DateTimeOffset firstOccurrence,
     TimeSpan interval,
     object message,
+    TimeSpan? maxDeliveryWindow = null,
     CancellationToken cancellationToken = default)
 ```
 
-Schedules a recurring reminder that fires repeatedly at the specified interval.
+Schedules a recurring reminder that fires repeatedly at the specified interval. Recurring reminders are
+latest-only: each occurrence expires when the next occurrence becomes due, or sooner if `maxDeliveryWindow`
+produces an earlier deadline.
 
 #### Cancel Reminder
 ```csharp
@@ -525,18 +549,26 @@ Task<ReminderAckResponse> AckAsync(
     CancellationToken cancellationToken = default)
 ```
 
-Acknowledges receipt of a delivered reminder. Must be called after processing a `ReminderEnvelope<T>`. If this call faults or times out, the scheduler will redeliver the reminder after `AckTimeout` elapses.
+Acknowledges receipt of a delivered reminder. Must be called after processing a `ReminderEnvelope<T>`. If this call faults or times out, the scheduler will redeliver the reminder after `AckTimeout` elapses, subject to the occurrence deadline.
 
 ### Acknowledgement Protocol
 
-Reminders are wrapped in `ReminderEnvelope<T>` before delivery. The envelope carries the original payload alongside the `ReminderEntity` and `ReminderKey` needed to acknowledge receipt.
+Reminders are wrapped in `ReminderEnvelope<T>` before delivery. The envelope carries the original payload alongside the `ReminderEntity`, `ReminderKey`, occurrence `DueTimeUtc`, and a non-null `Deadline` value object. Unbounded reminders use `ReminderDeadline.Infinite`.
 
 **Receiving and acknowledging a reminder:**
 
 ```csharp
 ReceiveAsync<ReminderEnvelope<DoSomething>>(async envelope =>
 {
-    // Process the reminder payload first (idempotently)
+    // Drop stale work before doing side effects.
+    if (envelope.Deadline.IsExpired())
+    {
+        await _reminders.AckAsync(envelope);
+        return;
+    }
+
+    // Process the reminder payload first (idempotently).
+    // Use DueTimeUtc as your occurrence identity for dedupe.
     await DoWork(envelope.Message);
 
     // Then acknowledge. If this fails, the reminder is retried.
@@ -553,13 +585,14 @@ ReceiveAsync<ReminderEnvelope<DoSomething>>(async envelope =>
 
 | Outcome | Scheduler behavior |
 |---------|-------------------|
-| `AckAsync` succeeds (one-time reminder) | Reminder marked Delivered |
-| `AckAsync` succeeds (recurring reminder) | Next occurrence scheduled; original entry updated |
-| `AckAsync` times out or returns Error | Reminder retried after `AckTimeout` with exponential backoff |
+| `AckAsync` succeeds | Current occurrence marked Delivered |
+| `AckAsync` times out or returns Error | Reminder retried after `AckTimeout` with exponential backoff while it is still before deadline |
 | Retry attempts exhausted (`MaxDeliveryAttempts`) | Reminder marked Failed |
-| Ack received after timeout deadline but before retry | Scheduler returns `NotFound`; harmless, retry will deliver again |
+| Reminder exceeds its deadline | Reminder marked Expired and will not be retried |
+| Ack received for a stale or superseded occurrence | Scheduler returns `NotFound`; the ack is a harmless no-op |
 
 Because duplicates are possible whenever an ack is lost or times out, **consumers must be idempotent**.
+For recurring reminders, dedupe by `(ReminderEntity, ReminderKey, DueTimeUtc)`.
 
 ### Response Codes
 
@@ -578,8 +611,9 @@ Because duplicates are possible whenever an ack is lost or times out, **consumer
 Reminders progress through the following states:
 - **Pending**: Scheduled but not yet delivered
 - **AwaitingAck**: Delivered via `Tell`; waiting for recipient to call `AckAsync`
-- **Delivered**: Acknowledged by recipient; one-time reminder is complete
+- **Delivered**: Recipient acknowledged the occurrence
 - **Failed**: Permanently failed after `MaxDeliveryAttempts` exhausted
+- **Expired**: Deadline passed before the occurrence could be successfully acknowledged
 - **Cancelled**: Manually cancelled by user
 
 ## Testing
@@ -692,20 +726,20 @@ public async Task Reminder_should_fire_at_scheduled_time()
 2. Request routed to ReminderScheduler singleton (via cluster singleton proxy)
 3. Reminder persisted to storage backend
 4. Scheduler tracks next due reminder time
-5. When due, message wrapped in `ReminderEnvelope<T>` and delivered to target shard region via `Tell`
-6. Reminder moved to AwaitingAck state; ack deadline set based on `AckTimeout`
-7. Recipient calls `IReminderClient.AckAsync(envelope)` to confirm receipt
-8. On successful ack: one-time reminders marked Delivered; recurring reminders have next occurrence scheduled
-9. If ack times out: delivery retried with exponential backoff (up to `MaxDeliveryAttempts`)
-10. Completed/cancelled reminders pruned periodically based on PruneInterval setting
+5. When due, the scheduler persists the occurrence's delivery state (and any next recurring occurrence) before sending
+6. Message wrapped in `ReminderEnvelope<T>` and delivered to the target shard region via `Tell`
+7. Recipient calls `IReminderClient.AckAsync(envelope)` to confirm receipt for that specific `DueTimeUtc`
+8. If ack times out: delivery retried with exponential backoff while the occurrence remains before deadline
+9. Recurring reminders are latest-only; older occurrences expire when the next occurrence becomes due
+10. Completed/cancelled/expired reminders are pruned periodically based on PruneInterval setting
 
 ### Reliability Features
 
-- **At-least-once delivery with acknowledgement**: Reminders are wrapped in `ReminderEnvelope<T>` and delivered via `Tell`. Recipients call `IReminderClient.AckAsync(envelope)` to confirm receipt. Unacknowledged reminders are retried with exponential backoff. Consumers must be idempotent.
+- **At-least-once delivery with acknowledgement**: Reminders are wrapped in `ReminderEnvelope<T>` and delivered via `Tell`. Recipients call `IReminderClient.AckAsync(envelope)` to confirm receipt. Unacknowledged reminders are retried with exponential backoff until they expire or exhaust attempts. Consumers must be idempotent.
 - **Durable persistence**: Reminders survive actor restarts and cluster failures
-- **Automatic retries**: Failed deliveries retry with exponential backoff
+- **Deadline-bounded retries**: Failed deliveries retry with exponential backoff inside each occurrence's absolute delivery deadline
 - **Cluster singleton**: Single scheduler instance with automatic failover
-- **Delivery tracking**: Reminders track delivery attempts and failure reasons
+- **Occurrence identity**: Reminders track delivery attempts, deadlines, and due-time identity per occurrence
 - **Periodic pruning**: Automatic cleanup of old completed/cancelled reminders
 - **Write circuit breaker**: Automatically pauses batch delivery when database writes fail, probing with a single reminder until writes recover. Prevents duplicate delivery storms during database outages.
 - **Bounded first-failure blast radius**: Interleaved deliver/persist chunking caps duplicate deliveries on the first failed tick to `DeliveryCommitChunkSize`.

--- a/README.md
+++ b/README.md
@@ -168,10 +168,14 @@ public class MyEntityActor : ReceiveActor
                 new PerformHealthCheck());
         });
 
-        Receive<DoSomething>(msg =>
+        ReceiveAsync<ReminderEnvelope<DoSomething>>(async envelope =>
         {
             // Handle the reminder when it fires
             Console.WriteLine("Reminder received!");
+
+            // Acknowledge receipt so the scheduler marks it delivered.
+            // If AckAsync fails or times out, the reminder will be retried.
+            await _reminders.AckAsync(envelope);
         });
     }
 }
@@ -366,7 +370,13 @@ Configure reminder behavior and performance characteristics:
 
         // Base delay for exponential backoff on retries
         // Actual delay = RetryBackoffBase * (2 ^ attemptCount)
-        RetryBackoffBase = TimeSpan.FromSeconds(30)
+        RetryBackoffBase = TimeSpan.FromSeconds(30),
+
+        // How long to wait for a recipient ack before retrying delivery
+        AckTimeout = TimeSpan.FromSeconds(30),
+
+        // How frequently to scan for reminders whose ack deadline has passed
+        AckTimeoutCheckInterval = TimeSpan.FromSeconds(10)
     }))
 ```
 
@@ -394,8 +404,10 @@ public class HealthCheckActor : ReceiveActor
                 new PerformHealthCheck());
         });
 
-        ReceiveAsync<PerformHealthCheck>(async _ =>
+        ReceiveAsync<ReminderEnvelope<PerformHealthCheck>>(async envelope =>
         {
+            await _reminders.AckAsync(envelope);
+
             var isHealthy = await CheckHealth();
             if (!isHealthy)
             {
@@ -429,8 +441,10 @@ public class OrderActor : ReceiveActor
                 new CheckPayment());
         });
 
-        ReceiveAsync<CheckPayment>(async _ =>
+        ReceiveAsync<ReminderEnvelope<CheckPayment>>(async envelope =>
         {
+            await _reminders.AckAsync(envelope);
+
             if (!await PaymentReceived())
             {
                 Self.Tell(new CancelOrder());
@@ -500,6 +514,49 @@ Task<FetchedReminders> ListRemindersAsync(
 
 Lists all active reminders for the current entity.
 
+#### Acknowledge Reminder
+```csharp
+Task<ReminderAckResponse> AckAsync(
+    ReminderEnvelope envelope,
+    CancellationToken cancellationToken = default)
+```
+
+Acknowledges receipt of a delivered reminder. Must be called after processing a `ReminderEnvelope<T>`. If this call faults or times out, the scheduler will redeliver the reminder after `AckTimeout` elapses.
+
+### Acknowledgement Protocol
+
+Reminders are wrapped in `ReminderEnvelope<T>` before delivery. The envelope carries the original payload alongside the `ReminderEntity` and `ReminderKey` needed to acknowledge receipt.
+
+**Receiving and acknowledging a reminder:**
+
+```csharp
+ReceiveAsync<ReminderEnvelope<DoSomething>>(async envelope =>
+{
+    // Process the reminder payload first (idempotently)
+    await DoWork(envelope.Message);
+
+    // Then acknowledge. If this fails, the reminder is retried.
+    var ack = await _reminders.AckAsync(envelope);
+    if (ack.ResponseCode != ReminderAckResponseCode.Success)
+    {
+        // Log the failure; the scheduler will retry after AckTimeout
+        Log.Warning("Ack failed: {0}", ack.Message);
+    }
+});
+```
+
+**What happens on each outcome:**
+
+| Outcome | Scheduler behavior |
+|---------|-------------------|
+| `AckAsync` succeeds (one-time reminder) | Reminder marked Delivered |
+| `AckAsync` succeeds (recurring reminder) | Next occurrence scheduled; original entry updated |
+| `AckAsync` times out or returns Error | Reminder retried after `AckTimeout` with exponential backoff |
+| Retry attempts exhausted (`MaxDeliveryAttempts`) | Reminder marked Failed |
+| Ack received after timeout deadline but before retry | Scheduler returns `NotFound`; harmless, retry will deliver again |
+
+Because duplicates are possible whenever an ack is lost or times out, **consumers must be idempotent**.
+
 ### Response Codes
 
 **ReminderScheduleResponseCode:**
@@ -516,8 +573,9 @@ Lists all active reminders for the current entity.
 
 Reminders progress through the following states:
 - **Pending**: Scheduled but not yet delivered
-- **Delivered**: Successfully delivered to target entity
-- **Failed**: Permanently failed after max retry attempts
+- **AwaitingAck**: Delivered via `Tell`; waiting for recipient to call `AckAsync`
+- **Delivered**: Acknowledged by recipient; one-time reminder is complete
+- **Failed**: Permanently failed after `MaxDeliveryAttempts` exhausted
 - **Cancelled**: Manually cancelled by user
 
 ## Testing
@@ -562,10 +620,10 @@ public class ReminderTests : Akka.Hosting.TestKit.TestKit
             DateTimeOffset.UtcNow.AddMilliseconds(200),
             new PaymentRetry());
 
-        // Assert - Reminder delivered
-        var envelope = targetActor.ExpectMsg<ShardingEnvelope>(TimeSpan.FromSeconds(2));
-        Assert.Equal("customer-123", envelope.EntityId);
-        Assert.IsType<PaymentRetry>(envelope.Message);
+        // Assert - Reminder delivered wrapped in ReminderEnvelope
+        var shardEnvelope = targetActor.ExpectMsg<ShardingEnvelope>(TimeSpan.FromSeconds(2));
+        Assert.Equal("customer-123", shardEnvelope.EntityId);
+        var reminderEnvelope = Assert.IsType<ReminderEnvelope<PaymentRetry>>(shardEnvelope.Message);
     }
 }
 ```
@@ -609,8 +667,8 @@ public async Task Reminder_should_fire_at_scheduled_time()
     // Act - Advance time
     testScheduler.Advance(TimeSpan.FromMinutes(5));
 
-    // Assert - Reminder fires
-    testProbe.ExpectMsg<TestMessage>();
+    // Assert - Reminder fires (wrapped in ReminderEnvelope)
+    testProbe.ExpectMsg<ReminderEnvelope<TestMessage>>();
 }
 ```
 
@@ -630,14 +688,16 @@ public async Task Reminder_should_fire_at_scheduled_time()
 2. Request routed to ReminderScheduler singleton (via cluster singleton proxy)
 3. Reminder persisted to storage backend
 4. Scheduler tracks next due reminder time
-5. When due, message delivered to target shard region
-6. For recurring reminders, next occurrence automatically scheduled
-7. Failed deliveries retry with exponential backoff (up to MaxDeliveryAttempts)
-8. Completed/cancelled reminders pruned periodically based on PruneInterval setting
+5. When due, message wrapped in `ReminderEnvelope<T>` and delivered to target shard region via `Tell`
+6. Reminder moved to AwaitingAck state; ack deadline set based on `AckTimeout`
+7. Recipient calls `IReminderClient.AckAsync(envelope)` to confirm receipt
+8. On successful ack: one-time reminders marked Delivered; recurring reminders have next occurrence scheduled
+9. If ack times out: delivery retried with exponential backoff (up to `MaxDeliveryAttempts`)
+10. Completed/cancelled reminders pruned periodically based on PruneInterval setting
 
 ### Reliability Features
 
-- **At-least-once delivery**: Reminders are delivered via fire-and-forget `Tell`. Consumers must be idempotent.
+- **At-least-once delivery with acknowledgement**: Reminders are wrapped in `ReminderEnvelope<T>` and delivered via `Tell`. Recipients call `IReminderClient.AckAsync(envelope)` to confirm receipt. Unacknowledged reminders are retried with exponential backoff. Consumers must be idempotent.
 - **Durable persistence**: Reminders survive actor restarts and cluster failures
 - **Automatic retries**: Failed deliveries retry with exponential backoff
 - **Cluster singleton**: Single scheduler instance with automatic failover

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@
 
 - **Reliable Delivery with Acknowledgement Protocol** - Reminders now require explicit acknowledgement from recipients via `IReminderClient.AckAsync(envelope)`. Unacknowledged reminders are automatically retried with exponential backoff. This ensures recipients actually process reminders, not just that `Tell()` didn't throw.
   - `AckAsync` returns a `Task` backed by `Ask<T>` — recipients know whether the scheduler confirmed their ack (no duplicate coming) or if a duplicate may arrive
-  - Configurable via `ReminderSettings.AckTimeout` (default: 30s) and `ReminderSettings.AckTimeoutCheckInterval` (default: 10s)
+  - Configurable via `ReminderSettings.AckTimeout` (default: 30s)
   - Existing `MaxDeliveryAttempts` and `RetryBackoffBase` now apply to ack-timeout retries
   - New `AwaitingAck` delivery state in the state machine: `Pending → AwaitingAck → Delivered/Failed`
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,42 @@
+#### 0.6.0 March 18th 2026 ####
+
+**Breaking Changes**
+
+- **Reminder delivery now uses `ReminderEnvelope<T>` instead of raw messages** - All reminders are delivered wrapped in a strongly-typed envelope that must be acknowledged. Actors receiving reminders must change from `Receive<MyMessage>` to `ReceiveAsync<ReminderEnvelope<MyMessage>>` and call `await client.AckAsync(envelope)` after processing.
+- **`IReminderClient` scheduling methods are now generic** - `ScheduleSingleReminderAsync<T>` and `ScheduleRecurringReminderAsync<T>` replace the `object message` parameter with `T message` for type safety.
+- **`IShardRegionResolver.DeliverReminder` signature changed** - Now accepts `ReminderEnvelope` and `IActorRef sender` instead of raw `object message`.
+
+**New Features**
+
+- **Reliable Delivery with Acknowledgement Protocol** - Reminders now require explicit acknowledgement from recipients via `IReminderClient.AckAsync(envelope)`. Unacknowledged reminders are automatically retried with exponential backoff. This ensures recipients actually process reminders, not just that `Tell()` didn't throw.
+  - `AckAsync` returns a `Task` backed by `Ask<T>` — recipients know whether the scheduler confirmed their ack (no duplicate coming) or if a duplicate may arrive
+  - Configurable via `ReminderSettings.AckTimeout` (default: 30s) and `ReminderSettings.AckTimeoutCheckInterval` (default: 10s)
+  - Existing `MaxDeliveryAttempts` and `RetryBackoffBase` now apply to ack-timeout retries
+  - New `AwaitingAck` delivery state in the state machine: `Pending → AwaitingAck → Delivered/Failed`
+
+- **Strongly-Typed `ReminderEnvelope<T>`** - Delivered reminders are wrapped in a generic envelope implementing `IWrappedMessage`. Use `ReminderEnvelope<T>` for compile-time type safety or `ReminderEnvelope` (non-generic base) for flexibility. Both have public constructors for easy testing.
+
+- **Custom Akka.Remote Serializer** - `ReminderEnvelope`, `ReminderAck`, and `ReminderAckResponse` are automatically serialized across cluster boundaries using a dedicated `SerializerWithStringManifest`. Inner message serialization is delegated to Akka's existing serialization system.
+
+**Migration from 0.5.x**
+
+- **Database schema**: Run the migration script for your storage provider:
+  - [SQLite](https://github.com/Aaronontheweb/akka-reminders/blob/dev/src/Akka.Reminders.Sqlite/Scripts/Migrations/V0_6_0__add_ack_columns.sql)
+  - [PostgreSQL](https://github.com/Aaronontheweb/akka-reminders/blob/dev/src/Akka.Reminders.PostgreSql/Scripts/Migrations/V0_6_0__add_ack_columns.sql)
+  - [SQL Server](https://github.com/Aaronontheweb/akka-reminders/blob/dev/src/Akka.Reminders.SqlServer/Scripts/Migrations/V0_6_0__add_ack_columns.sql)
+- **Code changes**: Update reminder handlers:
+  ```csharp
+  // Before (0.5.x):
+  Receive<MyMessage>(msg => { /* handle */ });
+
+  // After (0.6.0):
+  ReceiveAsync<ReminderEnvelope<MyMessage>>(async envelope => {
+      var msg = envelope.Message; // MyMessage, strongly typed
+      /* handle */
+      await _reminderClient.AckAsync(envelope);
+  });
+  ```
+
 #### 0.5.1 March 9th 2026 ####
 
 **Bug Fixes**

--- a/docs/design/failure-modes.md
+++ b/docs/design/failure-modes.md
@@ -4,7 +4,7 @@
 
 Akka.Reminders uses **at-least-once delivery with explicit acknowledgement**.
 
-- Reminders are delivered via fire-and-forget `Tell` wrapped in `ReminderEnvelope<T>`.
+- Reminders are delivered through `IShardRegionResolver.DeliverReminder`, which wraps the message in a `ShardingEnvelope(entityId, ReminderEnvelope<T>)` and sends it to the shard region via fire-and-forget `Tell`. The consumer actor receives a strongly-typed `ReminderEnvelope<T>`.
 - Consumers MUST be idempotent.
 - Each occurrence is identified by `(ReminderEntity, ReminderKey, DueTimeUtc)`.
 - The envelope exposes a non-null `Deadline` value object. Unbounded reminders use `ReminderDeadline.Infinite`.
@@ -20,30 +20,79 @@ Recurring reminders are modeled as a stream of occurrences.
 - If `MaxDeliveryWindow` is configured, the effective deadline is `min(due + window, next due)`.
 - A late ack for an old occurrence is a harmless `NotFound` because the ack is matched by `DueTimeUtc`.
 
+## Scheduler Initialization
+
+On startup, the scheduler actor is in an initial behavior that stashes all client messages until initialization completes.
+
+1. `PreStart` calls `LoadReminderOverview`, which fetches both the `ReminderOverview` and the next awaiting-ack deadline from storage in a single async pipeline, bundled into an `InitResult` record.
+2. The result is delivered to `Self` via `PipeTo`.
+3. On receipt, the scheduler schedules the ack-timeout check synchronously, transitions to the `Scheduling` behavior, then calls `UnstashAll` to replay buffered client messages.
+
+This ensures the scheduler is fully initialized — with ack-timeout tracking active — before any client messages are processed. There is no intermediate `RunTask` between the behavior transition and client message replay.
+
 ## Processing Pipeline
 
-Each scheduler tick runs `ProcessReminders`:
+### Scheduler tick
+
+Each tick is triggered by a `FetchReminders` timer. The timer delay is derived from the pending overview's `TimeUntilNext` value, plus the `MaxSlippage` setting (which causes the scheduler to fetch reminders slightly ahead of their due time to avoid re-scheduling overhead).
 
 ```text
-Expire stale occurrences (best effort)
-  -> Fetch due Pending reminders (bounded batch)
-  -> Process in delivery/persist chunks
-      -> Classify each occurrence: retry, terminal, or deliver
-      -> Persist retries / next recurring occurrences
-      -> Persist terminal states
-      -> Persist AwaitingAck state for deliverable occurrences
-      -> Deliver ReminderEnvelope<T> only after writes succeed
-  -> Reload overview and schedule next fetch
+Flush buffered ack writes (if any)
+  -> Expire stale occurrences (best effort)
+  -> Fetch due Pending reminders (bounded batch, up to MaxBatchSize)
+  -> Process in DeliveryCommitChunkSize chunks:
+      -> Classify each occurrence:
+          - Deadline expired -> terminal (Expired)
+          - Shard region not found -> retry or terminal (Failed/Expired)
+          - Deliverable -> create AwaitingAck state
+      -> For recurring reminders: pre-create next occurrence
+      -> Commit all mutations in a single CommitReminderMutationsAsync call:
+          - Pending upserts (retries + next recurring occurrences)
+          - Terminal completions
+          - AwaitingAck transitions
+      -> Deliver ReminderEnvelope<T> only after the commit succeeds
+  -> Update overview (incrementally from batch results; reload from storage only on failure)
+  -> Schedule next fetch timer
+```
 
-Ack handler:
-  -> Match by (Entity, Key, DueTimeUtc)
-  -> Mark occurrence Delivered if still AwaitingAck and before deadline
-  -> Return NotFound for stale, superseded, expired, or duplicate acks
+### Ack handler
 
-Ack-timeout checker:
-  -> Scan storage for AwaitingAck rows whose ack deadline elapsed
-  -> Retry with exponential backoff while retry stays before deadline
-  -> Otherwise mark Failed or Expired
+Acks are **not** written to storage immediately. They are buffered in memory and flushed in batches.
+
+```text
+ReminderAck received:
+  -> Buffer in _bufferedAcknowledgements, keyed by (Entity, Key, DueTimeUtc)
+  -> Duplicate acks for the same occurrence are coalesced (additional senders appended)
+  -> Schedule a FlushBufferedAcks self-message (debounced by flag)
+
+FlushBufferedAcks:
+  -> Drain buffer in batches of AckFlushBatchSize (default 256)
+  -> Call Storage.AcknowledgeRemindersAsync per batch
+  -> Storage checks: still AwaitingAck? Before deadline? -> mark Delivered
+  -> Stale, superseded, expired, or already-acked -> return NotFound
+  -> Reply to all buffered senders with the result
+  -> On success, refresh the ack-timeout schedule from storage
+  -> On failure, reply Error to senders; the occurrence stays AwaitingAck
+    and will be retried after ack timeout
+```
+
+Buffered acks are also flushed at the start of each `FetchReminders` tick and each `CheckAckTimeouts` tick, ensuring pending acks are committed before new work begins.
+
+### Ack-timeout checker
+
+Ack-timeout checking is **event-driven**, not periodic. After delivering reminders, the scheduler computes the earliest ack deadline in the batch and schedules a one-shot `CheckAckTimeouts` timer at exactly that deadline. The timer is replaced if an earlier deadline is found.
+
+```text
+CheckAckTimeouts fires:
+  -> Flush buffered ack writes (if any)
+  -> Expire stale occurrences
+  -> Scan storage for AwaitingAck rows whose ack deadline has elapsed
+  -> For each timed-out occurrence:
+      -> If retry is possible (within MaxDeliveryAttempts and deadline):
+          schedule retry with exponential backoff
+      -> Otherwise: mark Failed or Expired
+  -> Commit mutations via CommitReminderMutationsAsync
+  -> Refresh ack-timeout schedule from storage
 ```
 
 ## Threat Model
@@ -80,13 +129,21 @@ Delivery-state writes now happen **before** user messages are sent.
 ### Ack lost or recipient crashes before acking
 
 - The occurrence remains `AwaitingAck`.
-- Once `AckTimeout` elapses, the scheduler retries with exponential backoff.
-- Retries stop when the occurrence would exceed its deadline or max attempts.
+- Once `AckTimeout` elapses, the deadline-driven `CheckAckTimeouts` timer fires.
+- The scheduler retries with exponential backoff (`RetryBackoffBase`, capped by `MaxRetryBackoff`).
+- Retries stop when the occurrence would exceed its deadline or `MaxDeliveryAttempts`.
+
+### Ack buffer flush fails
+
+- The ack write is dropped. All buffered senders receive an `Error` response.
+- The occurrence stays `AwaitingAck` in storage.
+- When the ack deadline elapses, `CheckAckTimeouts` re-encounters the row and retries delivery.
+- The consumer may receive a duplicate delivery; idempotency handles this.
 
 ### Scheduler restart / singleton handoff
 
 - Awaiting-ack state is stored in the database, not only in memory.
-- After restart, the new scheduler can continue scanning timed-out ack rows from storage.
+- On startup, the scheduler loads the next ack deadline from storage as part of `InitResult` and schedules the timeout check before processing any messages.
 - Late acks remain safe because they are matched by `DueTimeUtc`.
 
 ### Late ack for superseded recurring occurrence
@@ -113,30 +170,33 @@ Each fetched batch is processed in smaller chunks. This bounds the amount of sta
 
 ### 3. Batched SQL writes
 
-Hot-path writes are batched:
+Hot-path writes are batched into single round-trips:
 
-- completion updates use batched `UPDATE ... FROM (VALUES ...)`
-- awaiting-ack updates are batched
-- retry / recurring occurrence upserts are batched
+- **Delivery path**: `CommitReminderMutationsAsync` handles pending upserts (retries + next recurring occurrences), terminal completions, and awaiting-ack transitions in a single call per chunk.
+- **Ack path**: `AcknowledgeRemindersAsync` flushes buffered acks in batches of `AckFlushBatchSize`.
 
-This avoids one round-trip per reminder in the delivery path.
+This avoids one round-trip per reminder in both the delivery and acknowledgement paths.
 
 ### 4. Pending overview excludes AwaitingAck
 
 Pending-overview queries only count actionable `Pending` rows.
 
-- `AwaitingAck` rows are not treated as pending work
-- expired rows are excluded by deadline filters
-- this prevents hot empty-fetch polling while the system is simply waiting for acks
+- `AwaitingAck` rows are not treated as pending work.
+- Expired rows are excluded by deadline filters.
+- This prevents hot empty-fetch polling while the system is simply waiting for acks.
 
-### 5. Write circuit breaker
+### 5. Incremental overview maintenance
 
-When any hot-path write fails:
+The scheduler maintains the `ReminderOverview` incrementally during batch processing by applying each upserted reminder to the in-memory overview. A full storage reload only happens when a fetch or write fails. This avoids an extra query per tick.
 
-- the circuit opens
-- the current run stops
-- later runs probe with a single reminder
-- once the probe succeeds, the scheduler resumes full-batch processing in the same run
+### 6. Write circuit breaker
+
+When any hot-path write fails (in either `ProcessReminders` or `ProcessAckTimeouts`):
+
+- The circuit opens.
+- The current run stops.
+- Later runs probe with a single reminder.
+- Once the probe succeeds, the scheduler resumes full-batch processing in the same run.
 
 ## Accepted Trade-offs
 
@@ -151,5 +211,9 @@ If an old recurring occurrence is still unacked when the next occurrence becomes
 
 ### Deadline expiration is best-effort cleanup
 
-The scheduler periodically marks expired rows terminally, but correctness does not depend on cleanup running first.
+The scheduler marks expired rows terminally during each tick (as a prelude to fetching), but correctness does not depend on cleanup running first.
 Fetch and ack paths also enforce the deadline directly.
+
+### Ack writes are eventually consistent
+
+Acks are buffered in memory and flushed in batches rather than written per-ack. This trades immediate durability for throughput. If the scheduler crashes between receiving an ack and flushing it, the occurrence stays `AwaitingAck` and will be retried after timeout — which is the same outcome as if the ack message had been lost in transit.

--- a/docs/design/failure-modes.md
+++ b/docs/design/failure-modes.md
@@ -2,24 +2,36 @@
 
 ## Delivery Semantics
 
-Akka.Reminders uses **at-least-once delivery**. Reminders are delivered via fire-and-forget `Tell` (no acknowledgement from the target entity). This means:
+Akka.Reminders uses **at-least-once delivery with explicit acknowledgement**. Reminders are delivered via fire-and-forget `Tell`, but the payload is wrapped in a `ReminderEnvelope<T>` that recipients must acknowledge. This means:
 
-- A reminder may be delivered more than once if the system can't confirm completion.
+- A reminder may be delivered more than once if the acknowledgement is lost or times out.
 - Consumers MUST be idempotent — receiving the same reminder twice should not cause incorrect behavior.
 - There is no exactly-once guarantee and no plan to add one.
+- Recipients call `IReminderClient.AckAsync(envelope)` to confirm successful processing.
+- When an ack succeeds: one-time reminders are marked Delivered; recurring reminders have their next occurrence scheduled.
+- When an ack times out: the scheduler retries delivery with exponential backoff, controlled by `MaxDeliveryAttempts` and `RetryBackoffBase`.
 
 ## Processing Pipeline
 
 Each tick of the `ReminderScheduler` runs `ProcessReminders`, which loops through batches:
 
 ```
-Fetch batch (SELECT with LIMIT/TOP)
+Fetch batch (SELECT with LIMIT/TOP, WHERE completion_status = 'Pending')
   → Process in delivery/persist chunks
-      → Deliver via Tell (fire-and-forget, irrevocable)
-      → Mark completed one-time reminders (batched UPDATE)
+      → Wrap in ReminderEnvelope, deliver via Tell
+      → Add to in-memory AwaitingAck tracker
       → Schedule retries for unresolvable shard regions
-      → Schedule next occurrence for recurring reminders
   → Loop until no more due reminders
+
+Ack handler (async, triggered by ReminderAck messages):
+  → Mark one-time reminders as Delivered
+  → Schedule next occurrence for recurring reminders
+  → Reply with ReminderAckResponse
+
+Ack timeout checker (periodic timer, interval = AckTimeoutCheckInterval):
+  → Scan AwaitingAck reminders past deadline
+  → Retry with backoff if under MaxDeliveryAttempts
+  → Mark as Failed if attempts exhausted
 ```
 
 ## Threat Model
@@ -36,8 +48,8 @@ When reads work but writes fail:
 
 1. **Fetch succeeds** — we get a batch of reminders
 2. **Deliver succeeds** — `Tell` is in-process, doesn't touch the database
-3. **Mark-complete fails** — write timeout
-4. Reminders remain `IsCompleted = 0` in the database
+3. **AwaitingAck write fails** — the scheduler cannot record that delivery is pending
+4. Reminders remain `Pending` in the database
 5. On the next tick, the same reminders are re-fetched and re-delivered
 
 Without mitigation, this creates a **self-inflicted denial of service**:
@@ -45,6 +57,15 @@ Without mitigation, this creates a **self-inflicted denial of service**:
 - Those entities' mailboxes fill with duplicate messages
 - Other due reminders beyond the `LIMIT`/`TOP` batch are never reached
 - The shard regions can't process real work
+
+### Ack-specific failure modes
+
+| Failure | What happens |
+|---------|-------------|
+| Ack lost (network partition) | Scheduler retries after `AckTimeout` expires; recipient may get a duplicate delivery |
+| Recipient crashes before acking | Same as ack lost — scheduler retries after timeout |
+| Scheduler singleton handoff while acks in-flight | `ReminderAck` messages route through the `ClusterSingletonProxy` and survive the handoff. The in-memory `AwaitingAck` dictionary is lost on the old node, but DB state is authoritative — the ack timeout checker on the new scheduler instance will pick up any lingering in-flight reminders and retry them |
+| Ack arrives after timeout but before retry delivery | Scheduler replies `NotFound` (the ack is harmless; the reminder was already moved back to Pending for re-delivery) |
 
 ## Mitigations
 
@@ -78,8 +99,10 @@ Each chunk auto-commits independently (no wrapping transaction). If chunk 4 of 5
 
 - **Normal state:** `ProcessReminders` fetches `MaxBatchSize` per batch.
 - **Circuit opens:** When any write operation fails (mark-complete, schedule-retry, schedule-recurring), `_writeCircuitOpen` is set to `true` and the loop breaks.
-- **Probing:** On the next tick, if the circuit is open, `effectiveBatchSize` drops to 1. The scheduler fetches and delivers a single reminder, then attempts mark-complete. This limits the blast radius to 1 duplicate delivery.
+- **Probing:** On the next tick, if the circuit is open, `effectiveBatchSize` drops to 1. The scheduler fetches and delivers a single reminder, then attempts the ack-tracking write. This limits the blast radius to 1 duplicate delivery.
 - **Circuit closes:** If the probe's write succeeds, `_writeCircuitOpen` is reset to `false` and `effectiveBatchSize` returns to `MaxBatchSize`. The scheduler immediately continues with full-batch processing in the same run.
+
+**Blast radius with the ack protocol:** Reminders currently awaiting acknowledgement are in `AwaitingAck` state, not `Pending`, so they are not re-fetched by the circuit breaker probe. Only genuinely `Pending` reminders are fetched. The probe behavior is therefore unchanged from the pre-ack design. Write failures that occur during ack processing (marking a reminder Delivered or scheduling the next occurrence) are surfaced as an `Error` response code in `ReminderAckResponse`; the reminder remains in `AwaitingAck` and will be retried by the ack timeout checker.
 
 ### 5. Interleaved Deliver/Persist Chunks (`DeliveryCommitChunkSize`)
 
@@ -120,3 +143,9 @@ On the first tick after writes break, the scheduler has no way to know writes ar
 ### Probe re-delivery
 
 During the circuit-open period, each probe tick delivers 1 reminder that may have already been delivered. Under at-least-once semantics, this is expected behavior. The consumer must be idempotent.
+
+### AwaitingAck state lost on scheduler restart
+
+The in-memory `AwaitingAck` dictionary is not persisted. If the scheduler singleton restarts (crash or planned handoff), any reminders that were in-flight at the time are lost from the dictionary. The database is authoritative: those reminders remain in `AwaitingAck` state in the DB. The ack timeout checker on the new scheduler instance will eventually scan them, find them past their deadline, and trigger a retry delivery. This causes one extra duplicate delivery per in-flight reminder at the time of restart.
+
+**Accepted because:** This is consistent with at-least-once semantics. Consumers must already be idempotent to handle normal ack-timeout retries.

--- a/docs/design/failure-modes.md
+++ b/docs/design/failure-modes.md
@@ -24,11 +24,19 @@ Recurring reminders are modeled as a stream of occurrences.
 
 On startup, the scheduler actor is in an initial behavior that stashes all client messages until initialization completes.
 
-1. `PreStart` calls `LoadReminderOverview`, which fetches both the `ReminderOverview` and the next awaiting-ack deadline from storage in a single async pipeline, bundled into an `InitResult` record.
+1. `PreStart` calls `LoadReminderOverview`, which fetches the `ReminderOverview` (an efficient `COUNT`/`MIN` aggregate — not a full table scan) and the next awaiting-ack deadline from storage in a single async pipeline, bundled into an `InitResult` record.
 2. The result is delivered to `Self` via `PipeTo`.
 3. On receipt, the scheduler schedules the ack-timeout check synchronously, transitions to the `Scheduling` behavior, then calls `UnstashAll` to replay buffered client messages.
 
 This ensures the scheduler is fully initialized — with ack-timeout tracking active — before any client messages are processed. There is no intermediate `RunTask` between the behavior transition and client message replay.
+
+### Recovery of AwaitingAck state after restart
+
+There is no explicit recovery step that resets `AwaitingAck` rows back to `Pending` on startup. Instead, `InitResult.NextAckDeadline` schedules the first ack-timeout check, which naturally discovers any `AwaitingAck` rows whose deadline has elapsed and retries or expires them through the normal `CheckAckTimeouts` path.
+
+### Reply ordering
+
+Schedule and cancel handlers reply to the caller **after** `ReloadPendingOverviewAsync` and `TryScheduleFetchReminders` complete. This guarantees the Ask response is a reliable signal that the fetch timer is registered — callers can depend on the scheduler being ready to process the reminder on the next tick.
 
 ## Processing Pipeline
 

--- a/docs/design/failure-modes.md
+++ b/docs/design/failure-modes.md
@@ -2,150 +2,154 @@
 
 ## Delivery Semantics
 
-Akka.Reminders uses **at-least-once delivery with explicit acknowledgement**. Reminders are delivered via fire-and-forget `Tell`, but the payload is wrapped in a `ReminderEnvelope<T>` that recipients must acknowledge. This means:
+Akka.Reminders uses **at-least-once delivery with explicit acknowledgement**.
 
-- A reminder may be delivered more than once if the acknowledgement is lost or times out.
-- Consumers MUST be idempotent — receiving the same reminder twice should not cause incorrect behavior.
-- There is no exactly-once guarantee and no plan to add one.
-- Recipients call `IReminderClient.AckAsync(envelope)` to confirm successful processing.
-- When an ack succeeds: one-time reminders are marked Delivered; recurring reminders have their next occurrence scheduled.
-- When an ack times out: the scheduler retries delivery with exponential backoff, controlled by `MaxDeliveryAttempts` and `RetryBackoffBase`.
+- Reminders are delivered via fire-and-forget `Tell` wrapped in `ReminderEnvelope<T>`.
+- Consumers MUST be idempotent.
+- Each occurrence is identified by `(ReminderEntity, ReminderKey, DueTimeUtc)`.
+- The envelope exposes a non-null `Deadline` value object. Unbounded reminders use `ReminderDeadline.Infinite`.
+- Retries are bounded by both `MaxDeliveryAttempts` and the occurrence deadline.
+
+### Latest-only recurring reminders
+
+Recurring reminders are modeled as a stream of occurrences.
+
+- The next occurrence is persisted when the current occurrence is delivered.
+- Each occurrence has its own absolute UTC deadline.
+- By default, a recurring occurrence expires when the next occurrence becomes due.
+- If `MaxDeliveryWindow` is configured, the effective deadline is `min(due + window, next due)`.
+- A late ack for an old occurrence is a harmless `NotFound` because the ack is matched by `DueTimeUtc`.
 
 ## Processing Pipeline
 
-Each tick of the `ReminderScheduler` runs `ProcessReminders`, which loops through batches:
+Each scheduler tick runs `ProcessReminders`:
 
-```
-Fetch batch (SELECT with LIMIT/TOP, WHERE completion_status = 'Pending')
-  → Process in delivery/persist chunks
-      → Wrap in ReminderEnvelope, deliver via Tell
-      → Add to in-memory AwaitingAck tracker
-      → Schedule retries for unresolvable shard regions
-  → Loop until no more due reminders
+```text
+Expire stale occurrences (best effort)
+  -> Fetch due Pending reminders (bounded batch)
+  -> Process in delivery/persist chunks
+      -> Classify each occurrence: retry, terminal, or deliver
+      -> Persist retries / next recurring occurrences
+      -> Persist terminal states
+      -> Persist AwaitingAck state for deliverable occurrences
+      -> Deliver ReminderEnvelope<T> only after writes succeed
+  -> Reload overview and schedule next fetch
 
-Ack handler (async, triggered by ReminderAck messages):
-  → Mark one-time reminders as Delivered
-  → Schedule next occurrence for recurring reminders
-  → Reply with ReminderAckResponse
+Ack handler:
+  -> Match by (Entity, Key, DueTimeUtc)
+  -> Mark occurrence Delivered if still AwaitingAck and before deadline
+  -> Return NotFound for stale, superseded, expired, or duplicate acks
 
-Ack timeout checker (periodic timer, interval = AckTimeoutCheckInterval):
-  → Scan AwaitingAck reminders past deadline
-  → Retry with backoff if under MaxDeliveryAttempts
-  → Mark as Failed if attempts exhausted
+Ack-timeout checker:
+  -> Scan storage for AwaitingAck rows whose ack deadline elapsed
+  -> Retry with exponential backoff while retry stays before deadline
+  -> Otherwise mark Failed or Expired
 ```
 
 ## Threat Model
 
-The primary threat is **asymmetric database failure**: reads succeed but writes fail. This is the exact scenario from issue #73, where Azure SQL at 100% DTU could serve reads from the buffer pool but write I/O was saturated.
+The primary threat is **asymmetric database failure**: reads succeed but writes fail.
 
 ### Why total database failure is safe
 
-If the database is completely unavailable, `GetNextRemindersAsync` (a read) fails in Phase 1. No reminders are fetched, no deliveries happen. The scheduler breaks out of the loop and retries on the next tick. This is completely safe.
+If the database is completely unavailable, the due-reminder fetch fails before any reminders are delivered.
+No delivery occurs and the scheduler retries on a later tick.
 
-### Why asymmetric failure is dangerous
+### Why asymmetric failure used to be dangerous
 
-When reads work but writes fail:
+The historical failure mode was:
 
-1. **Fetch succeeds** — we get a batch of reminders
-2. **Deliver succeeds** — `Tell` is in-process, doesn't touch the database
-3. **AwaitingAck write fails** — the scheduler cannot record that delivery is pending
-4. Reminders remain `Pending` in the database
-5. On the next tick, the same reminders are re-fetched and re-delivered
+1. Fetch succeeds
+2. Delivery succeeds
+3. Persistence of delivery state fails
+4. The same reminders remain Pending
+5. The next tick re-fetches and re-delivers them
 
-Without mitigation, this creates a **self-inflicted denial of service**:
-- The same N reminders are delivered every tick (~5 seconds)
-- Those entities' mailboxes fill with duplicate messages
-- Other due reminders beyond the `LIMIT`/`TOP` batch are never reached
-- The shard regions can't process real work
+That created duplicate-delivery storms under write pressure.
 
-### Ack-specific failure modes
+### Current mitigation
 
-| Failure | What happens |
-|---------|-------------|
-| Ack lost (network partition) | Scheduler retries after `AckTimeout` expires; recipient may get a duplicate delivery |
-| Recipient crashes before acking | Same as ack lost — scheduler retries after timeout |
-| Scheduler singleton handoff while acks in-flight | `ReminderAck` messages route through the `ClusterSingletonProxy` and survive the handoff. The in-memory `AwaitingAck` dictionary is lost on the old node, but DB state is authoritative — the ack timeout checker on the new scheduler instance will pick up any lingering in-flight reminders and retry them |
-| Ack arrives after timeout but before retry delivery | Scheduler replies `NotFound` (the ack is harmless; the reminder was already moved back to Pending for re-delivery) |
+Delivery-state writes now happen **before** user messages are sent.
 
-## Mitigations
+- If those writes fail, the scheduler opens the write circuit and sends nothing.
+- The first-failure duplicate blast radius for delivery-state write failure is therefore zero.
+- While the circuit is open, the scheduler probes with a single reminder before resuming full batches.
 
-### 1. Per-Phase Cancellation Tokens
+## Important Failure Modes
 
-**Problem:** A single `CancellationTokenSource` shared across all phases meant a slow fetch could starve mark-complete of its timeout budget.
+### Ack lost or recipient crashes before acking
 
-**Fix:** Each phase (fetch, mark-complete, retries, recurring, overview) gets its own `CancellationTokenSource(StorageTimeout)`.
+- The occurrence remains `AwaitingAck`.
+- Once `AckTimeout` elapses, the scheduler retries with exponential backoff.
+- Retries stop when the occurrence would exceed its deadline or max attempts.
 
-### 2. Bounded Batch Size (`MaxBatchSize`)
+### Scheduler restart / singleton handoff
 
-**Problem:** `GetNextRemindersAsync` had no row limit, fetching all due reminders in a single query. With 25K reminders, the SELECT alone could exceed the timeout.
+- Awaiting-ack state is stored in the database, not only in memory.
+- After restart, the new scheduler can continue scanning timed-out ack rows from storage.
+- Late acks remain safe because they are matched by `DueTimeUtc`.
 
-**Fix:** `MaxBatchSize` setting (default 1,000) adds `TOP`/`LIMIT` to the query. Reminders are processed in a loop of bounded batches.
+### Late ack for superseded recurring occurrence
 
-### 3. Batched UPDATE via VALUES JOIN
+- The old occurrence is already expired or no longer AwaitingAck.
+- The scheduler returns `NotFound`.
+- The newer occurrence is unaffected.
 
-**Problem:** `MarkRemindersAsCompletedAsync` executed N individual UPDATE statements in a single transaction. With 2,000 reminders, that's 2,000 sequential round-trips, consistently exceeding the 5-second timeout on a loaded database.
+### Reminder becomes stale in the mailbox
 
-**Fix:** Groups completions by `(Status, When)`, chunks at 500 per statement (to stay within SQL Server's 2,100 parameter limit), and uses dialect-specific batched UPDATE syntax:
-- **SQL Server:** `UPDATE t ... FROM table t INNER JOIN (VALUES ...) AS v(...) ON ...`
-- **PostgreSQL:** `UPDATE table t SET ... FROM (VALUES ...) AS v(...) WHERE ...`
+- The envelope carries `Deadline` to user code.
+- Consumers can call `envelope.Deadline.IsExpired()` before doing side effects.
+- Even if the consumer declines to act, it should still ack to stop useless retries.
 
-Each chunk auto-commits independently (no wrapping transaction). If chunk 4 of 5 times out, chunks 1-3 are already persisted. Mark-complete is idempotent, so partial progress is safe.
+## Backpressure and SQL Design
 
-### 4. Write Circuit Breaker
+### 1. Bounded batch size (`MaxBatchSize`)
 
-**Problem:** Even with all the above, if writes are failing, each tick still fetches a full batch and delivers it before discovering the write failure. With 1,000 reminders and 5-second ticks, that's 1,000 duplicate deliveries every 5 seconds.
+Due-reminder fetches use `TOP` / `LIMIT` so the scheduler never attempts to process the entire backlog in one query.
 
-**Fix:** A simple boolean circuit breaker on the scheduler actor:
+### 2. Chunked delivery commits (`DeliveryCommitChunkSize`)
 
-- **Normal state:** `ProcessReminders` fetches `MaxBatchSize` per batch.
-- **Circuit opens:** When any write operation fails (mark-complete, schedule-retry, schedule-recurring), `_writeCircuitOpen` is set to `true` and the loop breaks.
-- **Probing:** On the next tick, if the circuit is open, `effectiveBatchSize` drops to 1. The scheduler fetches and delivers a single reminder, then attempts the ack-tracking write. This limits the blast radius to 1 duplicate delivery.
-- **Circuit closes:** If the probe's write succeeds, `_writeCircuitOpen` is reset to `false` and `effectiveBatchSize` returns to `MaxBatchSize`. The scheduler immediately continues with full-batch processing in the same run.
+Each fetched batch is processed in smaller chunks. This bounds the amount of state the scheduler tries to persist per write phase.
 
-**Blast radius with the ack protocol:** Reminders currently awaiting acknowledgement are in `AwaitingAck` state, not `Pending`, so they are not re-fetched by the circuit breaker probe. Only genuinely `Pending` reminders are fetched. The probe behavior is therefore unchanged from the pre-ack design. Write failures that occur during ack processing (marking a reminder Delivered or scheduling the next occurrence) are surfaced as an `Error` response code in `ReminderAckResponse`; the reminder remains in `AwaitingAck` and will be retried by the ack timeout checker.
+### 3. Batched SQL writes
 
-### 5. Interleaved Deliver/Persist Chunks (`DeliveryCommitChunkSize`)
+Hot-path writes are batched:
 
-**Problem:** Even with a write circuit breaker, the first tick after writes fail could still deliver a full batch (for example, 1,000 reminders) before the first write failure is detected.
+- completion updates use batched `UPDATE ... FROM (VALUES ...)`
+- awaiting-ack updates are batched
+- retry / recurring occurrence upserts are batched
 
-**Fix:** Each fetched batch is processed in smaller chunks (`DeliveryCommitChunkSize`, default 100). After each chunk is delivered, writes are attempted immediately. If writes fail, processing stops before the next chunk.
+This avoids one round-trip per reminder in the delivery path.
 
-This bounds first-failure duplicate blast radius to chunk size instead of full fetch size.
+### 4. Pending overview excludes AwaitingAck
 
-### 6. Recurring durability boundary changed
+Pending-overview queries only count actionable `Pending` rows.
 
-**Problem:** If mark-complete succeeded for a recurring reminder but scheduling the next occurrence failed, the recurring chain could break permanently.
+- `AwaitingAck` rows are not treated as pending work
+- expired rows are excluded by deadline filters
+- this prevents hot empty-fetch polling while the system is simply waiting for acks
 
-**Fix:** Recurring reminders are no longer marked complete. Instead, their durability boundary is successful persistence of the next occurrence (idempotent upsert). If scheduling the next occurrence fails, the original reminder remains pending and can be retried on the next tick.
+### 5. Write circuit breaker
 
-**Blast radius comparison during a 1-minute write outage (12 ticks at 5s interval):**
+When any hot-path write fails:
 
-| Scenario | Deliveries per tick | Total duplicates |
-|----------|-------------------:|----------------:|
-| No mitigation (original code) | 1,000 | 12,000 |
-| With circuit breaker | 1 (probe) | 12 |
+- the circuit opens
+- the current run stops
+- later runs probe with a single reminder
+- once the probe succeeds, the scheduler resumes full-batch processing in the same run
 
-**First-failure duplicate bound:**
+## Accepted Trade-offs
 
-| Scenario | First failed tick duplicate upper bound |
-|----------|---------------------------------------:|
-| Legacy full-batch flow | `MaxBatchSize` |
-| Interleaved chunk flow | `DeliveryCommitChunkSize` |
+### At-least-once remains the contract
 
-## Remaining Accepted Risks
+This system still allows duplicates during normal distributed failure modes.
+The design goal is to keep those duplicates bounded and occurrence-specific.
 
-### First-tick delivery before circuit opens
+### Recurring reminders are latest-only, not catch-up
 
-On the first tick after writes break, the scheduler has no way to know writes are failing until it tries. It delivers a full batch before discovering the problem. This is unavoidable without a health-check mechanism that runs before fetch.
+If an old recurring occurrence is still unacked when the next occurrence becomes due, the old one expires instead of building an unbounded replay backlog.
 
-**Accepted because:** One batch of duplicates is tolerable. The circuit breaker prevents the sustained flood.
+### Deadline expiration is best-effort cleanup
 
-### Probe re-delivery
-
-During the circuit-open period, each probe tick delivers 1 reminder that may have already been delivered. Under at-least-once semantics, this is expected behavior. The consumer must be idempotent.
-
-### AwaitingAck state lost on scheduler restart
-
-The in-memory `AwaitingAck` dictionary is not persisted. If the scheduler singleton restarts (crash or planned handoff), any reminders that were in-flight at the time are lost from the dictionary. The database is authoritative: those reminders remain in `AwaitingAck` state in the DB. The ack timeout checker on the new scheduler instance will eventually scan them, find them past their deadline, and trigger a retry delivery. This causes one extra duplicate delivery per in-flight reminder at the time of restart.
-
-**Accepted because:** This is consistent with at-least-once semantics. Consumers must already be idempotent to handle normal ack-timeout retries.
+The scheduler periodically marks expired rows terminally, but correctness does not depend on cleanup running first.
+Fetch and ack paths also enforce the deadline directly.

--- a/src/Akka.Reminders.Benchmarks/Program.cs
+++ b/src/Akka.Reminders.Benchmarks/Program.cs
@@ -5,7 +5,7 @@ using Npgsql;
 
 Console.WriteLine("Akka.Reminders Benchmarks");
 Console.WriteLine("-------------------------");
-Console.WriteLine("IMPORTANT: Make sure PostgreSQL is running via 'docker-compose up -d' before running benchmarks.");
+Console.WriteLine("IMPORTANT: Make sure PostgreSQL is running via 'docker compose up -d' before running benchmarks.");
 Console.WriteLine();
 
 // Try to connect to PostgreSQL to give early warning
@@ -17,7 +17,7 @@ try
 catch (Exception)
 {
     Console.WriteLine($"ERROR: Could not connect to PostgreSQL at {SqlReminderBenchmarkBase.ConnectionString}");
-    Console.WriteLine("Please make sure PostgreSQL is running via 'docker-compose up -d'");
+    Console.WriteLine("Please make sure PostgreSQL is running via 'docker compose up -d'");
     return;
 }
 

--- a/src/Akka.Reminders.Benchmarks/ReminderAcknowledgementBenchmarks.cs
+++ b/src/Akka.Reminders.Benchmarks/ReminderAcknowledgementBenchmarks.cs
@@ -1,0 +1,50 @@
+using Akka.Reminders.Storage;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Reminders.Benchmarks;
+
+/// <summary>
+/// Benchmarks the batched acknowledgement write path for reminders that are already awaiting ack.
+/// </summary>
+[Config(typeof(ReminderBenchmarkConfig))]
+public class ReminderAcknowledgementBenchmarks : SqlReminderBenchmarkBase
+{
+    private IReadOnlyList<ReminderAcknowledgement> _acknowledgements = [];
+
+    [Params(1000, 5000)]
+    public int ReminderCount { get; set; }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        var dueAt = TruncateToMicroseconds(DateTimeOffset.UtcNow.AddMinutes(-5));
+        var deliveredAt = dueAt.AddSeconds(1);
+        var ackDeadline = dueAt.AddMinutes(10);
+
+        PopulateReminders(ReminderCount, dueAt).GetAwaiter().GetResult();
+
+        var awaitingAckReminders = Enumerable.Range(0, ReminderCount)
+            .Select(i => CreateAwaitingAckReminder(i, dueAt, deliveredAt, ackDeadline))
+            .ToList();
+
+        if (!Storage.MarkRemindersAsAwaitingAckAsync(awaitingAckReminders).GetAwaiter().GetResult())
+            throw new InvalidOperationException("Failed to prepare awaiting-ack reminders for benchmark.");
+
+        _acknowledgements = Enumerable.Range(0, ReminderCount)
+            .Select(i => CreateAcknowledgement(i, dueAt, deliveredAt.AddSeconds(1)))
+            .ToList();
+    }
+
+    [IterationCleanup]
+    public void IterationCleanup()
+    {
+        ResetReminders().GetAwaiter().GetResult();
+    }
+
+    [Benchmark(OperationsPerInvoke = 1)]
+    public async Task<int> AcknowledgeAllReminders()
+    {
+        var results = await Storage.AcknowledgeRemindersAsync(_acknowledgements);
+        return results.Count(r => r.Success);
+    }
+}

--- a/src/Akka.Reminders.Benchmarks/ReminderMutationBenchmarks.cs
+++ b/src/Akka.Reminders.Benchmarks/ReminderMutationBenchmarks.cs
@@ -1,0 +1,63 @@
+using Akka.Reminders.Storage;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Reminders.Benchmarks;
+
+/// <summary>
+/// Benchmarks the scheduler's atomic storage commit path for mixed reminder mutations.
+/// </summary>
+[Config(typeof(ReminderBenchmarkConfig))]
+public class ReminderMutationBenchmarks : SqlReminderBenchmarkBase
+{
+    private ReminderMutationBatch _mutationBatch = ReminderMutationBatch.Empty;
+
+    [Params(1000, 5000)]
+    public int ReminderCount { get; set; }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        var now = TruncateToMicroseconds(DateTimeOffset.UtcNow);
+        var dueAt = now.AddMinutes(-5);
+        var completedAt = now;
+        var ackDeadline = now.AddMinutes(5);
+        var nextDueAt = now.AddMinutes(10);
+        var deliveryDeadline = nextDueAt.AddMinutes(5);
+
+        var completedCount = ReminderCount / 3;
+        var awaitingAckCount = ReminderCount / 3;
+        var upsertCount = ReminderCount - completedCount - awaitingAckCount;
+        var existingReminderCount = completedCount + awaitingAckCount;
+
+        PopulateReminders(existingReminderCount, dueAt).GetAwaiter().GetResult();
+
+        var completedReminders = Enumerable.Range(0, completedCount)
+            .Select(i => CreateCompletedReminder(i, dueAt, completedAt))
+            .ToList();
+
+        var awaitingAckReminders = Enumerable.Range(completedCount, awaitingAckCount)
+            .Select(i => CreateAwaitingAckReminder(i, dueAt, completedAt, ackDeadline))
+            .ToList();
+
+        var pendingUpserts = Enumerable.Range(existingReminderCount, upsertCount)
+            .Select(i => CreateReminder(
+                i,
+                nextDueAt,
+                dueTimeUtc: nextDueAt,
+                maxDeliveryWindow: TimeSpan.FromMinutes(5),
+                deliveryDeadlineUtc: deliveryDeadline))
+            .ToList();
+
+        _mutationBatch = new ReminderMutationBatch(pendingUpserts, completedReminders, awaitingAckReminders);
+    }
+
+    [IterationCleanup]
+    public void IterationCleanup()
+    {
+        ResetReminders().GetAwaiter().GetResult();
+    }
+
+    [Benchmark(OperationsPerInvoke = 1)]
+    public Task<bool> CommitReminderMutations()
+        => Storage.CommitReminderMutationsAsync(_mutationBatch);
+}

--- a/src/Akka.Reminders.Benchmarks/ReminderStorageBenchmarks.cs
+++ b/src/Akka.Reminders.Benchmarks/ReminderStorageBenchmarks.cs
@@ -44,7 +44,7 @@ public class ReminderStorageBenchmarks : SqlReminderBenchmarkBase
                 break;
 
             var completed = batch.Reminders
-                .Select(r => new CompletedReminder(r.Entity, r.Key, now))
+                .Select(r => new CompletedReminder(r.Entity, r.Key, r.DueTimeUtc, now))
                 .ToList();
 
             await Storage.MarkRemindersAsCompletedAsync(completed);

--- a/src/Akka.Reminders.Benchmarks/ReminderStorageBenchmarks.cs
+++ b/src/Akka.Reminders.Benchmarks/ReminderStorageBenchmarks.cs
@@ -5,7 +5,7 @@ namespace Akka.Reminders.Benchmarks;
 
 /// <summary>
 /// Benchmarks the critical path: fetching due reminders in batches and marking them complete.
-/// Uses real PostgreSQL via Testcontainers to measure actual I/O performance.
+/// Uses a real PostgreSQL instance to measure actual I/O performance.
 /// </summary>
 [Config(typeof(ReminderBenchmarkConfig))]
 public class ReminderStorageBenchmarks : SqlReminderBenchmarkBase

--- a/src/Akka.Reminders.Benchmarks/SqlReminderBenchmarkBase.cs
+++ b/src/Akka.Reminders.Benchmarks/SqlReminderBenchmarkBase.cs
@@ -1,4 +1,5 @@
 using Akka.Actor;
+using Akka.Reminders.Storage;
 using Akka.Reminders.PostgreSql;
 using Akka.Reminders.PostgreSql.Configuration;
 using BenchmarkDotNet.Attributes;
@@ -9,12 +10,15 @@ namespace Akka.Reminders.Benchmarks;
 
 /// <summary>
 /// Abstract base class for reminder storage benchmarks using an external PostgreSQL instance.
-/// Start PostgreSQL before running benchmarks via: docker-compose up -d
+/// Start PostgreSQL before running benchmarks via: docker compose up -d
 /// </summary>
 public abstract class SqlReminderBenchmarkBase
 {
     public const string ConnectionString =
         "Host=localhost;Port=5432;Database=reminders_bench;Username=postgres;Password=postgres";
+
+    protected const string BenchmarkRegionName = "bench-region";
+    protected const string BenchmarkMessage = "benchmark-message";
 
     private ActorSystem? _system;
     protected PostgreSqlReminderStorage Storage { get; private set; } = null!;
@@ -50,10 +54,12 @@ public abstract class SqlReminderBenchmarkBase
     protected async Task PopulateReminders(int count, DateTimeOffset dueAt)
     {
         var serialization = _system!.Serialization;
-        const string message = "benchmark-message";
+        const string message = BenchmarkMessage;
         var serializer = serialization.FindSerializerFor(message);
         var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, message);
         var payload = serializer.ToBinary(message);
+
+        dueAt = TruncateToMicroseconds(dueAt);
 
         await using var conn = new NpgsqlConnection(ConnectionString);
         await conn.OpenAsync();
@@ -61,7 +67,7 @@ public abstract class SqlReminderBenchmarkBase
         await using var writer = await conn.BeginBinaryImportAsync(
             """
             COPY "reminders"."scheduled_reminders" (
-                shard_region_name, entity_id, reminder_key, when_utc,
+                shard_region_name, entity_id, reminder_key, when_utc, due_time_utc,
                 repeat_interval_ticks, serializer_id, manifest, payload,
                 attempt_count, last_failure_reason, is_completed,
                 completed_at_utc, completion_status
@@ -71,9 +77,10 @@ public abstract class SqlReminderBenchmarkBase
         for (var i = 0; i < count; i++)
         {
             await writer.StartRowAsync();
-            await writer.WriteAsync("bench-region", NpgsqlDbType.Varchar);
+            await writer.WriteAsync(BenchmarkRegionName, NpgsqlDbType.Varchar);
             await writer.WriteAsync($"entity-{i}", NpgsqlDbType.Varchar);
             await writer.WriteAsync($"key-{i}", NpgsqlDbType.Varchar);
+            await writer.WriteAsync(dueAt, NpgsqlDbType.TimestampTz);
             await writer.WriteAsync(dueAt, NpgsqlDbType.TimestampTz);
             await writer.WriteNullAsync(); // repeat_interval_ticks
             await writer.WriteAsync(serializer.Identifier, NpgsqlDbType.Integer);
@@ -99,5 +106,73 @@ public abstract class SqlReminderBenchmarkBase
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = """TRUNCATE TABLE "reminders"."scheduled_reminders" """;
         await cmd.ExecuteNonQueryAsync();
+    }
+
+    protected static ReminderEntity CreateEntity(int index)
+        => new(BenchmarkRegionName, $"entity-{index}");
+
+    protected static ReminderKey CreateKey(int index)
+        => new($"key-{index}");
+
+    protected static ScheduledReminder CreateReminder(
+        int index,
+        DateTimeOffset when,
+        DateTimeOffset? dueTimeUtc = null,
+        TimeSpan? repeatInterval = null,
+        int attemptCount = 0,
+        string? lastFailureReason = null,
+        TimeSpan? maxDeliveryWindow = null,
+        DateTimeOffset? deliveryDeadlineUtc = null,
+        object? message = null)
+        => new(
+            CreateEntity(index),
+            CreateKey(index),
+            TruncateToMicroseconds(when),
+            message ?? BenchmarkMessage,
+            repeatInterval,
+            attemptCount,
+            lastFailureReason,
+            maxDeliveryWindow,
+            deliveryDeadlineUtc.HasValue ? TruncateToMicroseconds(deliveryDeadlineUtc.Value) : null,
+            dueTimeUtc.HasValue ? TruncateToMicroseconds(dueTimeUtc.Value) : null);
+
+    protected static CompletedReminder CreateCompletedReminder(
+        int index,
+        DateTimeOffset dueTimeUtc,
+        DateTimeOffset completedAt,
+        ReminderCompletionStatus status = ReminderCompletionStatus.Delivered)
+        => new(
+            CreateEntity(index),
+            CreateKey(index),
+            TruncateToMicroseconds(dueTimeUtc),
+            TruncateToMicroseconds(completedAt),
+            status);
+
+    protected static AwaitingAckReminder CreateAwaitingAckReminder(
+        int index,
+        DateTimeOffset dueTimeUtc,
+        DateTimeOffset deliveredAt,
+        DateTimeOffset ackDeadline)
+        => new(
+            CreateEntity(index),
+            CreateKey(index),
+            TruncateToMicroseconds(dueTimeUtc),
+            TruncateToMicroseconds(deliveredAt),
+            TruncateToMicroseconds(ackDeadline));
+
+    protected static ReminderAcknowledgement CreateAcknowledgement(
+        int index,
+        DateTimeOffset dueTimeUtc,
+        DateTimeOffset ackedAt)
+        => new(
+            CreateEntity(index),
+            CreateKey(index),
+            TruncateToMicroseconds(dueTimeUtc),
+            TruncateToMicroseconds(ackedAt));
+
+    protected static DateTimeOffset TruncateToMicroseconds(DateTimeOffset value)
+    {
+        var ticksToRemove = value.Ticks % 10;
+        return ticksToRemove == 0 ? value : new DateTimeOffset(value.Ticks - ticksToRemove, value.Offset);
     }
 }

--- a/src/Akka.Reminders.Migration.Tests/Akka.Reminders.Migration.Tests.csproj
+++ b/src/Akka.Reminders.Migration.Tests/Akka.Reminders.Migration.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Testcontainers.MsSql" />
+    <PackageReference Include="Testcontainers.PostgreSql" />
+    <PackageReference Include="Npgsql" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Akka.Reminders\Akka.Reminders.csproj" />
+    <ProjectReference Include="..\Akka.Reminders.PostgreSql\Akka.Reminders.PostgreSql.csproj" />
+    <ProjectReference Include="..\Akka.Reminders.SqlServer\Akka.Reminders.SqlServer.csproj" />
+    <ProjectReference Include="..\Akka.Reminders.Sqlite\Akka.Reminders.Sqlite.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/src/Akka.Reminders.Migration.Tests/PostgreSqlMigrationSpecs.cs
+++ b/src/Akka.Reminders.Migration.Tests/PostgreSqlMigrationSpecs.cs
@@ -1,0 +1,232 @@
+using Akka.Actor;
+using Akka.Reminders.PostgreSql;
+using Akka.Reminders.PostgreSql.Configuration;
+using Akka.Reminders.Storage;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace Akka.Reminders.Migration.Tests;
+
+[Collection("PostgreSQL-Migration")]
+public class PostgreSqlMigrationSpecs : IAsyncLifetime
+{
+    private PostgreSqlContainer? _container;
+    private ActorSystem? _actorSystem;
+    private IReminderStorage? _storage;
+
+    /// <summary>
+    /// The 0.5.x schema: PK is (shard_region_name, entity_id, reminder_key).
+    /// No due_time_utc, max_delivery_window_ticks, delivery_deadline_utc, delivered_at_utc, ack_deadline_utc.
+    /// Index filter is just WHERE is_completed = FALSE.
+    /// </summary>
+    private const string V05xCreateSchema = @"
+CREATE SCHEMA IF NOT EXISTS reminders;
+
+CREATE TABLE IF NOT EXISTS reminders.scheduled_reminders (
+    shard_region_name VARCHAR(255) NOT NULL,
+    entity_id VARCHAR(255) NOT NULL,
+    reminder_key VARCHAR(255) NOT NULL,
+    when_utc TIMESTAMP WITH TIME ZONE NOT NULL,
+    repeat_interval_ticks BIGINT NULL,
+    serializer_id INTEGER NOT NULL,
+    manifest VARCHAR(500) NULL,
+    payload BYTEA NOT NULL,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_failure_reason TEXT NULL,
+    is_completed BOOLEAN NOT NULL DEFAULT FALSE,
+    completed_at_utc TIMESTAMP WITH TIME ZONE NULL,
+    completion_status VARCHAR(20) NOT NULL DEFAULT 'Pending',
+
+    CONSTRAINT pk_scheduled_reminders PRIMARY KEY (shard_region_name, entity_id, reminder_key)
+);
+
+CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_due_reminders
+ON reminders.scheduled_reminders (when_utc, shard_region_name, entity_id)
+WHERE is_completed = FALSE;
+
+CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_cleanup
+ON reminders.scheduled_reminders (completed_at_utc)
+WHERE is_completed = TRUE;
+";
+
+    private const string MigrationSql = @"
+ALTER TABLE reminders.scheduled_reminders ADD COLUMN IF NOT EXISTS due_time_utc TIMESTAMP WITH TIME ZONE NULL;
+ALTER TABLE reminders.scheduled_reminders ADD COLUMN IF NOT EXISTS max_delivery_window_ticks BIGINT NULL;
+ALTER TABLE reminders.scheduled_reminders ADD COLUMN IF NOT EXISTS delivery_deadline_utc TIMESTAMP WITH TIME ZONE NULL;
+ALTER TABLE reminders.scheduled_reminders ADD COLUMN IF NOT EXISTS delivered_at_utc TIMESTAMP WITH TIME ZONE NULL;
+ALTER TABLE reminders.scheduled_reminders ADD COLUMN IF NOT EXISTS ack_deadline_utc TIMESTAMP WITH TIME ZONE NULL;
+
+UPDATE reminders.scheduled_reminders SET due_time_utc = when_utc WHERE due_time_utc IS NULL;
+ALTER TABLE reminders.scheduled_reminders ALTER COLUMN due_time_utc SET NOT NULL;
+
+ALTER TABLE reminders.scheduled_reminders DROP CONSTRAINT IF EXISTS pk_scheduled_reminders;
+ALTER TABLE reminders.scheduled_reminders
+    ADD CONSTRAINT pk_scheduled_reminders PRIMARY KEY (shard_region_name, entity_id, reminder_key, due_time_utc);
+
+DROP INDEX IF EXISTS reminders.ix_scheduled_reminders_due_reminders;
+CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_due_reminders
+ON reminders.scheduled_reminders (when_utc, shard_region_name, entity_id)
+WHERE is_completed = FALSE AND completion_status = 'Pending';
+
+CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_awaiting_ack
+ON reminders.scheduled_reminders (ack_deadline_utc)
+WHERE completion_status = 'AwaitingAck' AND is_completed = FALSE;
+";
+
+    private const string SeedDataSql = @"
+INSERT INTO reminders.scheduled_reminders
+    (shard_region_name, entity_id, reminder_key, when_utc, repeat_interval_ticks,
+     serializer_id, manifest, payload, attempt_count, is_completed, completion_status)
+VALUES
+    ('test-region', 'entity-1', 'seed-reminder',
+     NOW() + INTERVAL '1 hour', NULL,
+     1, 'System.String', E'\\x01', 0, FALSE, 'Pending');
+";
+
+    public async Task InitializeAsync()
+    {
+        _container = new PostgreSqlBuilder()
+            .WithImage("postgres:16-alpine")
+            .Build();
+
+        await _container.StartAsync();
+        var connStr = _container.GetConnectionString();
+
+        // Execute 0.5.x schema creation
+        await ExecuteSqlAsync(connStr, V05xCreateSchema);
+
+        // Insert seed data
+        await ExecuteSqlAsync(connStr, SeedDataSql);
+
+        // Run migration
+        await ExecuteSqlAsync(connStr, MigrationSql);
+
+        // Mark the seed row as completed so it doesn't interfere with API tests
+        // (its payload isn't valid Akka serialization — it exists only to test the migration backfill)
+        await ExecuteSqlAsync(connStr,
+            "UPDATE reminders.scheduled_reminders SET is_completed = TRUE, completion_status = 'Delivered', completed_at_utc = NOW() WHERE reminder_key = 'seed-reminder'");
+
+        // Create ActorSystem and storage provider
+        _actorSystem = ActorSystem.Create("pg-migration-test");
+        var settings = PostgreSqlReminderStorageSettings.Create(connStr) with { AutoInitialize = false };
+        _storage = new PostgreSqlReminderStorage(settings, _actorSystem);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_container != null)
+        {
+            await _container.DisposeAsync();
+        }
+
+        if (_actorSystem != null)
+        {
+            await _actorSystem.Terminate();
+        }
+    }
+
+    [Fact]
+    public async Task MigratedData_ShouldHaveDueTimeEqualToWhenUtc()
+    {
+        // Verify via raw SQL — the seed row's payload isn't a valid Akka serialized message,
+        // so we can't read it through the storage API. We only need to check the column values.
+        await using var conn = new Npgsql.NpgsqlConnection(_container!.GetConnectionString());
+        await conn.OpenAsync();
+        await using var cmd = new Npgsql.NpgsqlCommand(
+            "SELECT when_utc, due_time_utc FROM reminders.scheduled_reminders WHERE reminder_key = 'seed-reminder'",
+            conn);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        Assert.True(await reader.ReadAsync());
+        var whenUtc = reader.GetDateTime(0);
+        var dueTimeUtc = reader.GetDateTime(1);
+        Assert.Equal(whenUtc, dueTimeUtc);
+    }
+
+    [Fact]
+    public async Task MigratedSchema_ShouldSupportSchedulingNewReminders()
+    {
+        var entity = new ReminderEntity("test-region", "entity-new");
+        var key = new ReminderKey("new-reminder");
+        var dueTime = DateTimeOffset.UtcNow.AddMinutes(30);
+
+        var reminder = new ScheduledReminder(
+            entity,
+            key,
+            dueTime,
+            "test message",
+            RepeatInterval: null,
+            MaxDeliveryWindow: null,
+            DeliveryDeadlineUtc: null,
+            OccurrenceDueTimeUtc: dueTime);
+
+        var result = await _storage!.ScheduleReminderAsync(reminder, default);
+        Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
+
+        var fetched = await _storage.GetRemindersForEntityAsync(entity, ct: default);
+        Assert.Contains(fetched, r => r.Key == key);
+    }
+
+    [Fact]
+    public async Task MigratedSchema_ShouldSupportAckWorkflow()
+    {
+        var entity = new ReminderEntity("test-region", "entity-ack");
+        var key = new ReminderKey("ack-test-reminder");
+        var now = DateTimeOffset.UtcNow;
+        var dueTime = now.AddMinutes(1);
+
+        var reminder = new ScheduledReminder(
+            entity,
+            key,
+            dueTime,
+            "test message",
+            RepeatInterval: null,
+            MaxDeliveryWindow: null,
+            DeliveryDeadlineUtc: null,
+            OccurrenceDueTimeUtc: dueTime);
+
+        await _storage!.ScheduleReminderAsync(reminder, default);
+
+        // Fetch via GetNextRemindersAsync
+        var pending = await _storage.GetNextRemindersAsync(
+            dueTime.AddMinutes(1), now, new ReminderBatchSize(100), default);
+
+        var targetReminder = pending.Reminders.FirstOrDefault(r => r.Key == key);
+        Assert.NotNull(targetReminder);
+
+        // Move to AwaitingAck via CommitReminderMutationsAsync
+        var deliveredAt = now;
+        var ackDeadline = now.AddMinutes(5);
+        var awaitingAck = new AwaitingAckReminder(entity, key, targetReminder.DueTimeUtc, deliveredAt, ackDeadline);
+        var batch = new ReminderMutationBatch([], [], [awaitingAck]);
+        var commitResult = await _storage.CommitReminderMutationsAsync(batch, default);
+        Assert.True(commitResult);
+
+        // Acknowledge via AcknowledgeRemindersAsync
+        var ack = new ReminderAcknowledgement(entity, key, targetReminder.DueTimeUtc, now.AddSeconds(30));
+        var ackResults = await _storage.AcknowledgeRemindersAsync([ack], default);
+        Assert.Single(ackResults);
+        Assert.Equal(ReminderAckStorageStatus.Success, ackResults[0].Status);
+    }
+
+    [Fact]
+    public async Task MigratedSchema_ShouldSupportOverviewQuery()
+    {
+        var entity = new ReminderEntity("test-region", "entity-overview");
+        var dueTime = DateTimeOffset.UtcNow.AddMinutes(10);
+        await _storage!.ScheduleReminderAsync(new ScheduledReminder(
+            entity, new ReminderKey("overview-reminder"), dueTime, "test",
+            RepeatInterval: null, MaxDeliveryWindow: null,
+            DeliveryDeadlineUtc: null, OccurrenceDueTimeUtc: dueTime), default);
+
+        var overview = await _storage.GetRemindersOverviewAsync(DateTimeOffset.UtcNow, default);
+        Assert.True(overview.TotalPendingReminders >= 1);
+    }
+
+    private static async Task ExecuteSqlAsync(string connectionString, string sql)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = new NpgsqlCommand(sql, connection);
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/src/Akka.Reminders.Migration.Tests/SqlServerMigrationSpecs.cs
+++ b/src/Akka.Reminders.Migration.Tests/SqlServerMigrationSpecs.cs
@@ -1,0 +1,326 @@
+using Akka.Actor;
+using Akka.Reminders.SqlServer;
+using Akka.Reminders.SqlServer.Configuration;
+using Akka.Reminders.Storage;
+using Microsoft.Data.SqlClient;
+using Testcontainers.MsSql;
+
+namespace Akka.Reminders.Migration.Tests;
+
+[Collection("SqlServer-Migration")]
+public class SqlServerMigrationSpecs : IAsyncLifetime
+{
+    private MsSqlContainer? _container;
+    private ActorSystem? _actorSystem;
+    private IReminderStorage? _storage;
+
+    /// <summary>
+    /// The 0.5.x schema: PK is (ShardRegionName, EntityId, ReminderKey).
+    /// No DueTimeUtc, MaxDeliveryWindowTicks, DeliveryDeadlineUtc, DeliveredAtUtc, AckDeadlineUtc.
+    /// Index filter is just WHERE IsCompleted = 0.
+    /// </summary>
+    private const string V05xCreateSchema = @"
+IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = 'reminders')
+BEGIN
+    EXEC('CREATE SCHEMA [reminders]');
+END
+
+IF NOT EXISTS (
+    SELECT * FROM sys.tables t
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = 'reminders' AND t.name = 'scheduled_reminders'
+)
+BEGIN
+    CREATE TABLE [reminders].[scheduled_reminders] (
+        ShardRegionName NVARCHAR(255) NOT NULL,
+        EntityId NVARCHAR(255) NOT NULL,
+        ReminderKey NVARCHAR(255) NOT NULL,
+        WhenUtc DATETIME2 NOT NULL,
+        RepeatIntervalTicks BIGINT NULL,
+        SerializerId INT NOT NULL,
+        Manifest NVARCHAR(500) NULL,
+        Payload VARBINARY(MAX) NOT NULL,
+        AttemptCount INT NOT NULL DEFAULT 0,
+        LastFailureReason NVARCHAR(MAX) NULL,
+        IsCompleted BIT NOT NULL DEFAULT 0,
+        CompletedAtUtc DATETIME2 NULL,
+        CompletionStatus VARCHAR(20) NOT NULL DEFAULT 'Pending',
+
+        CONSTRAINT PK_scheduled_reminders PRIMARY KEY (ShardRegionName, EntityId, ReminderKey)
+    );
+
+    CREATE INDEX IX_scheduled_reminders_DueReminders
+    ON [reminders].[scheduled_reminders] (WhenUtc, ShardRegionName, EntityId)
+    WHERE IsCompleted = 0;
+
+    CREATE INDEX IX_scheduled_reminders_Cleanup
+    ON [reminders].[scheduled_reminders] (CompletedAtUtc)
+    WHERE IsCompleted = 1;
+END
+";
+
+    private const string MigrationSql = @"
+DECLARE @SchemaName NVARCHAR(255) = 'reminders';
+DECLARE @TableName  NVARCHAR(255) = 'scheduled_reminders';
+DECLARE @FullTableName NVARCHAR(500) = '[' + @SchemaName + '].[' + @TableName + ']';
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.columns c
+    JOIN sys.tables  t ON c.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = @SchemaName AND t.name = @TableName AND c.name = 'DueTimeUtc'
+)
+BEGIN
+    EXEC('ALTER TABLE ' + @FullTableName + ' ADD DueTimeUtc DATETIME2 NULL');
+END
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.columns c
+    JOIN sys.tables  t ON c.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = @SchemaName AND t.name = @TableName AND c.name = 'MaxDeliveryWindowTicks'
+)
+BEGIN
+    EXEC('ALTER TABLE ' + @FullTableName + ' ADD MaxDeliveryWindowTicks BIGINT NULL');
+END
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.columns c
+    JOIN sys.tables  t ON c.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = @SchemaName AND t.name = @TableName AND c.name = 'DeliveryDeadlineUtc'
+)
+BEGIN
+    EXEC('ALTER TABLE ' + @FullTableName + ' ADD DeliveryDeadlineUtc DATETIME2 NULL');
+END
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.columns c
+    JOIN sys.tables  t ON c.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = @SchemaName AND t.name = @TableName AND c.name = 'DeliveredAtUtc'
+)
+BEGIN
+    EXEC('ALTER TABLE ' + @FullTableName + ' ADD DeliveredAtUtc DATETIME2 NULL');
+END
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.columns c
+    JOIN sys.tables  t ON c.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = @SchemaName AND t.name = @TableName AND c.name = 'AckDeadlineUtc'
+)
+BEGIN
+    EXEC('ALTER TABLE ' + @FullTableName + ' ADD AckDeadlineUtc DATETIME2 NULL');
+END
+
+EXEC('UPDATE ' + @FullTableName + ' SET DueTimeUtc = WhenUtc WHERE DueTimeUtc IS NULL');
+EXEC('ALTER TABLE ' + @FullTableName + ' ALTER COLUMN DueTimeUtc DATETIME2 NOT NULL');
+
+DECLARE @PKName NVARCHAR(500) = 'PK_' + @TableName;
+
+IF EXISTS (
+    SELECT 1 FROM sys.key_constraints kc
+    JOIN sys.tables  t ON kc.parent_object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = @SchemaName AND t.name = @TableName AND kc.name = @PKName AND kc.type = 'PK'
+)
+BEGIN
+    EXEC('ALTER TABLE ' + @FullTableName + ' DROP CONSTRAINT ' + @PKName);
+END
+
+EXEC('ALTER TABLE ' + @FullTableName + ' ADD CONSTRAINT ' + @PKName + ' PRIMARY KEY (ShardRegionName, EntityId, ReminderKey, DueTimeUtc)');
+
+DECLARE @DueIndexName NVARCHAR(500) = 'IX_' + @TableName + '_DueReminders';
+
+IF EXISTS (
+    SELECT 1 FROM sys.indexes i
+    JOIN sys.tables  t ON i.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = @SchemaName AND t.name = @TableName AND i.name = @DueIndexName
+)
+BEGIN
+    EXEC('DROP INDEX ' + @DueIndexName + ' ON ' + @FullTableName);
+END
+
+DECLARE @CreateDueIndexSql NVARCHAR(MAX) =
+    'CREATE INDEX ' + @DueIndexName +
+    ' ON ' + @FullTableName + ' (WhenUtc, ShardRegionName, EntityId)' +
+    ' WHERE IsCompleted = 0 AND CompletionStatus = ''Pending'';';
+EXEC(@CreateDueIndexSql);
+
+DECLARE @AckIndexName NVARCHAR(500) = 'IX_' + @TableName + '_AwaitingAck';
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes i
+    JOIN sys.tables  t ON i.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = @SchemaName AND t.name = @TableName AND i.name = @AckIndexName
+)
+BEGIN
+    DECLARE @CreateAckIndexSql NVARCHAR(MAX) =
+        'CREATE INDEX ' + @AckIndexName +
+        ' ON ' + @FullTableName + ' (AckDeadlineUtc)' +
+        ' WHERE CompletionStatus = ''AwaitingAck'' AND IsCompleted = 0;';
+    EXEC(@CreateAckIndexSql);
+END
+";
+
+    private const string SeedDataSql = @"
+INSERT INTO [reminders].[scheduled_reminders]
+    (ShardRegionName, EntityId, ReminderKey, WhenUtc, RepeatIntervalTicks,
+     SerializerId, Manifest, Payload, AttemptCount, IsCompleted, CompletionStatus)
+VALUES
+    ('test-region', 'entity-1', 'seed-reminder',
+     DATEADD(HOUR, 1, SYSUTCDATETIME()), NULL,
+     1, 'System.String', 0x01, 0, 0, 'Pending');
+";
+
+    public async Task InitializeAsync()
+    {
+        _container = new MsSqlBuilder()
+            .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+            .WithPassword("yourStrong(!)Password")
+            .Build();
+
+        await _container.StartAsync();
+        var connStr = _container.GetConnectionString();
+
+        // Execute 0.5.x schema creation
+        await ExecuteSqlAsync(connStr, V05xCreateSchema);
+
+        // Insert seed data
+        await ExecuteSqlAsync(connStr, SeedDataSql);
+
+        // Run migration
+        await ExecuteSqlAsync(connStr, MigrationSql);
+
+        // Mark the seed row as completed so it doesn't interfere with API tests
+        // (its payload isn't valid Akka serialization — it exists only to test the migration backfill)
+        await ExecuteSqlAsync(connStr,
+            "UPDATE [reminders].[scheduled_reminders] SET IsCompleted = 1, CompletionStatus = 'Delivered', CompletedAtUtc = SYSUTCDATETIME() WHERE ReminderKey = 'seed-reminder'");
+
+        // Create ActorSystem and storage provider
+        _actorSystem = ActorSystem.Create("sqlserver-migration-test");
+        var settings = SqlServerReminderStorageSettings.Create(connStr) with { AutoInitialize = false };
+        _storage = new SqlServerReminderStorage(settings, _actorSystem);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_container != null)
+        {
+            await _container.DisposeAsync();
+        }
+
+        if (_actorSystem != null)
+        {
+            await _actorSystem.Terminate();
+        }
+    }
+
+    [Fact]
+    public async Task MigratedData_ShouldHaveDueTimeEqualToWhenUtc()
+    {
+        // Verify via raw SQL — the seed row's payload isn't a valid Akka serialized message,
+        // so we can't read it through the storage API. We only need to check the column values.
+        await using var conn = new Microsoft.Data.SqlClient.SqlConnection(_container!.GetConnectionString());
+        await conn.OpenAsync();
+        await using var cmd = new Microsoft.Data.SqlClient.SqlCommand(
+            "SELECT WhenUtc, DueTimeUtc FROM [reminders].[scheduled_reminders] WHERE ReminderKey = 'seed-reminder'",
+            conn);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        Assert.True(await reader.ReadAsync());
+        var whenUtc = reader.GetDateTime(0);
+        var dueTimeUtc = reader.GetDateTime(1);
+        Assert.Equal(whenUtc, dueTimeUtc);
+    }
+
+    [Fact]
+    public async Task MigratedSchema_ShouldSupportSchedulingNewReminders()
+    {
+        var entity = new ReminderEntity("test-region", "entity-new");
+        var key = new ReminderKey("new-reminder");
+        var dueTime = DateTimeOffset.UtcNow.AddMinutes(30);
+
+        var reminder = new ScheduledReminder(
+            entity,
+            key,
+            dueTime,
+            "test message",
+            RepeatInterval: null,
+            MaxDeliveryWindow: null,
+            DeliveryDeadlineUtc: null,
+            OccurrenceDueTimeUtc: dueTime);
+
+        var result = await _storage!.ScheduleReminderAsync(reminder, default);
+        Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
+
+        var fetched = await _storage.GetRemindersForEntityAsync(entity, ct: default);
+        Assert.Contains(fetched, r => r.Key == key);
+    }
+
+    [Fact]
+    public async Task MigratedSchema_ShouldSupportAckWorkflow()
+    {
+        var entity = new ReminderEntity("test-region", "entity-ack");
+        var key = new ReminderKey("ack-test-reminder");
+        var now = DateTimeOffset.UtcNow;
+        var dueTime = now.AddMinutes(1);
+
+        var reminder = new ScheduledReminder(
+            entity,
+            key,
+            dueTime,
+            "test message",
+            RepeatInterval: null,
+            MaxDeliveryWindow: null,
+            DeliveryDeadlineUtc: null,
+            OccurrenceDueTimeUtc: dueTime);
+
+        await _storage!.ScheduleReminderAsync(reminder, default);
+
+        // Fetch via GetNextRemindersAsync
+        var pending = await _storage.GetNextRemindersAsync(
+            dueTime.AddMinutes(1), now, new ReminderBatchSize(100), default);
+
+        var targetReminder = pending.Reminders.FirstOrDefault(r => r.Key == key);
+        Assert.NotNull(targetReminder);
+
+        // Move to AwaitingAck via CommitReminderMutationsAsync
+        var deliveredAt = now;
+        var ackDeadline = now.AddMinutes(5);
+        var awaitingAck = new AwaitingAckReminder(entity, key, targetReminder.DueTimeUtc, deliveredAt, ackDeadline);
+        var batch = new ReminderMutationBatch([], [], [awaitingAck]);
+        var commitResult = await _storage.CommitReminderMutationsAsync(batch, default);
+        Assert.True(commitResult);
+
+        // Acknowledge via AcknowledgeRemindersAsync
+        var ack = new ReminderAcknowledgement(entity, key, targetReminder.DueTimeUtc, now.AddSeconds(30));
+        var ackResults = await _storage.AcknowledgeRemindersAsync([ack], default);
+        Assert.Single(ackResults);
+        Assert.Equal(ReminderAckStorageStatus.Success, ackResults[0].Status);
+    }
+
+    [Fact]
+    public async Task MigratedSchema_ShouldSupportOverviewQuery()
+    {
+        var entity = new ReminderEntity("test-region", "entity-overview");
+        var dueTime = DateTimeOffset.UtcNow.AddMinutes(10);
+        await _storage!.ScheduleReminderAsync(new ScheduledReminder(
+            entity, new ReminderKey("overview-reminder"), dueTime, "test",
+            RepeatInterval: null, MaxDeliveryWindow: null,
+            DeliveryDeadlineUtc: null, OccurrenceDueTimeUtc: dueTime), default);
+
+        var overview = await _storage.GetRemindersOverviewAsync(DateTimeOffset.UtcNow, default);
+        Assert.True(overview.TotalPendingReminders >= 1);
+    }
+
+    private static async Task ExecuteSqlAsync(string connectionString, string sql)
+    {
+        await using var connection = new SqlConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = new SqlCommand(sql, connection);
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/src/Akka.Reminders.Migration.Tests/SqliteMigrationSpecs.cs
+++ b/src/Akka.Reminders.Migration.Tests/SqliteMigrationSpecs.cs
@@ -1,0 +1,262 @@
+using Akka.Actor;
+using Akka.Reminders.Sqlite;
+using Akka.Reminders.Sqlite.Configuration;
+using Akka.Reminders.Storage;
+using Microsoft.Data.Sqlite;
+
+namespace Akka.Reminders.Migration.Tests;
+
+[Collection("Sqlite-Migration")]
+public class SqliteMigrationSpecs : IAsyncLifetime
+{
+    private ActorSystem? _actorSystem;
+    private IReminderStorage? _storage;
+    private string? _databasePath;
+
+    /// <summary>
+    /// The 0.5.x schema: PK is (shard_region_name, entity_id, reminder_key).
+    /// No due_time_utc, max_delivery_window_ticks, delivery_deadline_utc, delivered_at_utc, ack_deadline_utc.
+    /// Index filter is just WHERE is_completed = 0.
+    /// </summary>
+    private const string V05xCreateSchema = @"
+CREATE TABLE IF NOT EXISTS scheduled_reminders (
+    shard_region_name TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    reminder_key TEXT NOT NULL,
+    when_utc TEXT NOT NULL,
+    repeat_interval_ticks INTEGER NULL,
+    serializer_id INTEGER NOT NULL,
+    manifest TEXT NULL,
+    payload BLOB NOT NULL,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_failure_reason TEXT NULL,
+    is_completed INTEGER NOT NULL DEFAULT 0,
+    completed_at_utc TEXT NULL,
+    completion_status TEXT NOT NULL DEFAULT 'Pending',
+
+    PRIMARY KEY (shard_region_name, entity_id, reminder_key)
+);
+
+CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_due_reminders
+ON scheduled_reminders (when_utc, shard_region_name, entity_id)
+WHERE is_completed = 0;
+
+CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_cleanup
+ON scheduled_reminders (completed_at_utc)
+WHERE is_completed = 1;
+";
+
+    private const string MigrationSql = @"
+ALTER TABLE scheduled_reminders RENAME TO scheduled_reminders_v05x;
+
+CREATE TABLE IF NOT EXISTS scheduled_reminders (
+    shard_region_name TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    reminder_key TEXT NOT NULL,
+    when_utc TEXT NOT NULL,
+    due_time_utc TEXT NOT NULL,
+    repeat_interval_ticks INTEGER NULL,
+    serializer_id INTEGER NOT NULL,
+    manifest TEXT NULL,
+    payload BLOB NOT NULL,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_failure_reason TEXT NULL,
+    max_delivery_window_ticks INTEGER NULL,
+    delivery_deadline_utc TEXT NULL,
+    is_completed INTEGER NOT NULL DEFAULT 0,
+    completed_at_utc TEXT NULL,
+    completion_status TEXT NOT NULL DEFAULT 'Pending',
+    delivered_at_utc TEXT NULL,
+    ack_deadline_utc TEXT NULL,
+    PRIMARY KEY (shard_region_name, entity_id, reminder_key, due_time_utc)
+);
+
+INSERT INTO scheduled_reminders (
+    shard_region_name, entity_id, reminder_key,
+    when_utc, due_time_utc, repeat_interval_ticks,
+    serializer_id, manifest, payload,
+    attempt_count, last_failure_reason,
+    max_delivery_window_ticks, delivery_deadline_utc,
+    is_completed, completed_at_utc, completion_status,
+    delivered_at_utc, ack_deadline_utc
+)
+SELECT
+    shard_region_name, entity_id, reminder_key,
+    when_utc, when_utc AS due_time_utc, repeat_interval_ticks,
+    serializer_id, manifest, payload,
+    attempt_count, last_failure_reason,
+    NULL, NULL,
+    is_completed, completed_at_utc, completion_status,
+    NULL, NULL
+FROM scheduled_reminders_v05x;
+
+DROP TABLE scheduled_reminders_v05x;
+
+CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_due_reminders
+ON scheduled_reminders (when_utc, shard_region_name, entity_id)
+WHERE is_completed = 0 AND completion_status = 'Pending';
+
+CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_cleanup
+ON scheduled_reminders (completed_at_utc)
+WHERE is_completed = 1;
+
+CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_awaiting_ack
+ON scheduled_reminders (ack_deadline_utc)
+WHERE completion_status = 'AwaitingAck' AND is_completed = 0;
+";
+
+    private const string SeedDataSql = @"
+INSERT INTO scheduled_reminders
+    (shard_region_name, entity_id, reminder_key, when_utc, repeat_interval_ticks,
+     serializer_id, manifest, payload, attempt_count, is_completed, completion_status)
+VALUES
+    ('test-region', 'entity-1', 'seed-reminder',
+     datetime('now', '+1 hour'), NULL,
+     1, 'System.String', X'01', 0, 0, 'Pending');
+";
+
+    public async Task InitializeAsync()
+    {
+        _databasePath = Path.Combine(Path.GetTempPath(), $"akka-reminders-migration-{Guid.NewGuid():N}.db");
+        var connStr = $"Data Source={_databasePath};Mode=ReadWriteCreate;Cache=Shared";
+
+        // Execute 0.5.x schema creation
+        await ExecuteSqlAsync(connStr, V05xCreateSchema);
+
+        // Insert seed data
+        await ExecuteSqlAsync(connStr, SeedDataSql);
+
+        // Run migration
+        await ExecuteSqlAsync(connStr, MigrationSql);
+
+        // Mark the seed row as completed so it doesn't interfere with API tests
+        // (its payload isn't valid Akka serialization — it exists only to test the migration backfill)
+        await ExecuteSqlAsync(connStr,
+            "UPDATE scheduled_reminders SET is_completed = 1, completion_status = 'Delivered', completed_at_utc = datetime('now') WHERE reminder_key = 'seed-reminder'");
+
+        // Create ActorSystem and storage provider
+        _actorSystem = ActorSystem.Create("sqlite-migration-test");
+        var settings = SqliteReminderStorageSettings.Create(connStr) with { AutoInitialize = false };
+        _storage = new SqliteReminderStorage(settings, _actorSystem);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_actorSystem != null)
+        {
+            await _actorSystem.Terminate();
+        }
+
+        if (!string.IsNullOrWhiteSpace(_databasePath) && File.Exists(_databasePath))
+        {
+            File.Delete(_databasePath);
+        }
+    }
+
+    [Fact]
+    public async Task MigratedData_ShouldHaveDueTimeEqualToWhenUtc()
+    {
+        // Verify via raw SQL — the seed row's payload isn't a valid Akka serialized message,
+        // so we can't read it through the storage API. We only need to check the column values.
+        var connStr = $"Data Source={_databasePath};Mode=ReadWriteCreate;Cache=Shared";
+        await using var connection = new SqliteConnection(connStr);
+        await connection.OpenAsync();
+        await using var cmd = new SqliteCommand(
+            "SELECT when_utc, due_time_utc FROM scheduled_reminders WHERE reminder_key = 'seed-reminder'",
+            connection);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        Assert.True(await reader.ReadAsync());
+        var whenUtc = reader.GetString(0);
+        var dueTimeUtc = reader.GetString(1);
+        Assert.Equal(whenUtc, dueTimeUtc);
+    }
+
+    [Fact]
+    public async Task MigratedSchema_ShouldSupportSchedulingNewReminders()
+    {
+        var entity = new ReminderEntity("test-region", "entity-new");
+        var key = new ReminderKey("new-reminder");
+        var dueTime = DateTimeOffset.UtcNow.AddMinutes(30);
+
+        var reminder = new ScheduledReminder(
+            entity,
+            key,
+            dueTime,
+            "test message",
+            RepeatInterval: null,
+            MaxDeliveryWindow: null,
+            DeliveryDeadlineUtc: null,
+            OccurrenceDueTimeUtc: dueTime);
+
+        var result = await _storage!.ScheduleReminderAsync(reminder, default);
+        Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
+
+        var fetched = await _storage.GetRemindersForEntityAsync(entity, ct: default);
+        Assert.Contains(fetched, r => r.Key == key);
+    }
+
+    [Fact]
+    public async Task MigratedSchema_ShouldSupportAckWorkflow()
+    {
+        var entity = new ReminderEntity("test-region", "entity-ack");
+        var key = new ReminderKey("ack-test-reminder");
+        var now = DateTimeOffset.UtcNow;
+        var dueTime = now.AddMinutes(1);
+
+        var reminder = new ScheduledReminder(
+            entity,
+            key,
+            dueTime,
+            "test message",
+            RepeatInterval: null,
+            MaxDeliveryWindow: null,
+            DeliveryDeadlineUtc: null,
+            OccurrenceDueTimeUtc: dueTime);
+
+        await _storage!.ScheduleReminderAsync(reminder, default);
+
+        // Fetch via GetNextRemindersAsync
+        var pending = await _storage.GetNextRemindersAsync(
+            dueTime.AddMinutes(1), now, new ReminderBatchSize(100), default);
+
+        var targetReminder = pending.Reminders.FirstOrDefault(r => r.Key == key);
+        Assert.NotNull(targetReminder);
+
+        // Move to AwaitingAck via CommitReminderMutationsAsync
+        var deliveredAt = now;
+        var ackDeadline = now.AddMinutes(5);
+        var awaitingAck = new AwaitingAckReminder(entity, key, targetReminder.DueTimeUtc, deliveredAt, ackDeadline);
+        var batch = new ReminderMutationBatch([], [], [awaitingAck]);
+        var commitResult = await _storage.CommitReminderMutationsAsync(batch, default);
+        Assert.True(commitResult);
+
+        // Acknowledge via AcknowledgeRemindersAsync
+        var ack = new ReminderAcknowledgement(entity, key, targetReminder.DueTimeUtc, now.AddSeconds(30));
+        var ackResults = await _storage.AcknowledgeRemindersAsync([ack], default);
+        Assert.Single(ackResults);
+        Assert.Equal(ReminderAckStorageStatus.Success, ackResults[0].Status);
+    }
+
+    [Fact]
+    public async Task MigratedSchema_ShouldSupportOverviewQuery()
+    {
+        // Schedule a reminder so the overview has something to report
+        var entity = new ReminderEntity("test-region", "entity-overview");
+        var dueTime = DateTimeOffset.UtcNow.AddMinutes(10);
+        await _storage!.ScheduleReminderAsync(new ScheduledReminder(
+            entity, new ReminderKey("overview-reminder"), dueTime, "test",
+            RepeatInterval: null, MaxDeliveryWindow: null,
+            DeliveryDeadlineUtc: null, OccurrenceDueTimeUtc: dueTime), default);
+
+        var overview = await _storage.GetRemindersOverviewAsync(DateTimeOffset.UtcNow, default);
+        Assert.True(overview.TotalPendingReminders >= 1);
+    }
+
+    private static async Task ExecuteSqlAsync(string connectionString, string sql)
+    {
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = new SqliteCommand(sql, connection);
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/src/Akka.Reminders.Migration.Tests/xunit.runner.json
+++ b/src/Akka.Reminders.Migration.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "maxParallelThreads": 1
+}

--- a/src/Akka.Reminders.PostgreSql/Internal/ISqlDialect.cs
+++ b/src/Akka.Reminders.PostgreSql/Internal/ISqlDialect.cs
@@ -18,6 +18,7 @@ internal interface ISqlDialect
     string GetBatchMarkAsAwaitingAckSql(string schemaName, string tableName, int count);
     string GetTimedOutAckRemindersSql(string schemaName, string tableName, int maxCount);
     string GetAcknowledgeReminderSql(string schemaName, string tableName);
+    string GetBatchAcknowledgeRemindersSql(string schemaName, string tableName, int count);
     DbConnection CreateConnection(string connectionString);
     void AddParameter(DbCommand command, string name, object value);
 }

--- a/src/Akka.Reminders.PostgreSql/Internal/ISqlDialect.cs
+++ b/src/Akka.Reminders.PostgreSql/Internal/ISqlDialect.cs
@@ -5,20 +5,19 @@ namespace Akka.Reminders.PostgreSql.Internal;
 internal interface ISqlDialect
 {
     string GetCreateTableSql(string schemaName, string tableName);
-    string GetUpsertReminderSql(string schemaName, string tableName);
+    string GetBatchUpsertRemindersSql(string schemaName, string tableName, int count);
     string GetSelectDueRemindersSql(string schemaName, string tableName, int maxCount);
-    string GetMarkCompletedSql(string schemaName, string tableName);
     string GetBatchMarkCompletedSql(string schemaName, string tableName, int count);
+    string GetExpireRemindersSql(string schemaName, string tableName);
     string GetCleanupSql(string schemaName, string tableName);
     string GetOverviewAggregateSql(string schemaName, string tableName);
     string GetNextReminderTimeSql(string schemaName, string tableName);
     string GetCancelReminderSql(string schemaName, string tableName);
     string GetCancelAllRemindersSql(string schemaName, string tableName);
     string GetFetchRemindersSql(string schemaName, string tableName);
-    string GetMarkAsAwaitingAckSql(string schemaName, string tableName);
+    string GetBatchMarkAsAwaitingAckSql(string schemaName, string tableName, int count);
     string GetTimedOutAckRemindersSql(string schemaName, string tableName, int maxCount);
     string GetAcknowledgeReminderSql(string schemaName, string tableName);
-    string GetResetAwaitingAckSql(string schemaName, string tableName);
     DbConnection CreateConnection(string connectionString);
     void AddParameter(DbCommand command, string name, object value);
 }

--- a/src/Akka.Reminders.PostgreSql/Internal/ISqlDialect.cs
+++ b/src/Akka.Reminders.PostgreSql/Internal/ISqlDialect.cs
@@ -15,6 +15,9 @@ internal interface ISqlDialect
     string GetCancelReminderSql(string schemaName, string tableName);
     string GetCancelAllRemindersSql(string schemaName, string tableName);
     string GetFetchRemindersSql(string schemaName, string tableName);
+    string GetMarkAsAwaitingAckSql(string schemaName, string tableName);
+    string GetTimedOutAckRemindersSql(string schemaName, string tableName, int maxCount);
+    string GetAcknowledgeReminderSql(string schemaName, string tableName);
     DbConnection CreateConnection(string connectionString);
     void AddParameter(DbCommand command, string name, object value);
 }

--- a/src/Akka.Reminders.PostgreSql/Internal/ISqlDialect.cs
+++ b/src/Akka.Reminders.PostgreSql/Internal/ISqlDialect.cs
@@ -18,6 +18,7 @@ internal interface ISqlDialect
     string GetMarkAsAwaitingAckSql(string schemaName, string tableName);
     string GetTimedOutAckRemindersSql(string schemaName, string tableName, int maxCount);
     string GetAcknowledgeReminderSql(string schemaName, string tableName);
+    string GetResetAwaitingAckSql(string schemaName, string tableName);
     DbConnection CreateConnection(string connectionString);
     void AddParameter(DbCommand command, string name, object value);
 }

--- a/src/Akka.Reminders.PostgreSql/Internal/PostgreSqlDialect.cs
+++ b/src/Akka.Reminders.PostgreSql/Internal/PostgreSqlDialect.cs
@@ -262,7 +262,7 @@ internal sealed class PostgreSqlDialect : ISqlDialect
               AND t.reminder_key = v.reminder_key
               AND t.due_time_utc = v.due_time_utc
               AND t.is_completed = FALSE
-              AND t.completion_status = 'Pending';
+             AND t.completion_status = 'Pending';
             """;
     }
 
@@ -304,6 +304,33 @@ internal sealed class PostgreSqlDialect : ISqlDialect
               AND completion_status = 'AwaitingAck'
               AND is_completed = FALSE
               AND (delivery_deadline_utc IS NULL OR delivery_deadline_utc > @AckedAtUtc);
+            """;
+    }
+
+    public string GetBatchAcknowledgeRemindersSql(string schemaName, string tableName, int count)
+    {
+        var fullTableName = $"\"{schemaName}\".\"{tableName}\"";
+        var values = string.Join(",\n                ",
+            Enumerable.Range(0, count).Select(i =>
+                $"(@sr{i}::varchar, @eid{i}::varchar, @rk{i}::varchar, @due{i}::timestamptz, @acked{i}::timestamptz)"));
+
+        return $"""
+            UPDATE {fullTableName} t
+            SET is_completed = TRUE,
+                completed_at_utc = v.acked_at_utc,
+                completion_status = 'Delivered',
+                delivered_at_utc = NULL,
+                ack_deadline_utc = NULL
+            FROM (VALUES
+                {values}
+            ) AS v(shard_region_name, entity_id, reminder_key, due_time_utc, acked_at_utc)
+            WHERE t.shard_region_name = v.shard_region_name
+              AND t.entity_id = v.entity_id
+              AND t.reminder_key = v.reminder_key
+              AND t.due_time_utc = v.due_time_utc
+              AND t.completion_status = 'AwaitingAck'
+              AND t.is_completed = FALSE
+              AND (t.delivery_deadline_utc IS NULL OR t.delivery_deadline_utc > v.acked_at_utc);
             """;
     }
 

--- a/src/Akka.Reminders.PostgreSql/Internal/PostgreSqlDialect.cs
+++ b/src/Akka.Reminders.PostgreSql/Internal/PostgreSqlDialect.cs
@@ -273,6 +273,20 @@ internal sealed class PostgreSqlDialect : ISqlDialect
             """;
     }
 
+    public string GetResetAwaitingAckSql(string schemaName, string tableName)
+    {
+        var fullTableName = $"\"{schemaName}\".\"{tableName}\"";
+
+        return $"""
+            UPDATE {fullTableName}
+            SET completion_status = 'Pending',
+                delivered_at_utc = NULL,
+                ack_deadline_utc = NULL
+            WHERE completion_status = 'AwaitingAck'
+              AND is_completed = FALSE;
+            """;
+    }
+
     public DbConnection CreateConnection(string connectionString)
     {
         return new NpgsqlConnection(connectionString);

--- a/src/Akka.Reminders.PostgreSql/Internal/PostgreSqlDialect.cs
+++ b/src/Akka.Reminders.PostgreSql/Internal/PostgreSqlDialect.cs
@@ -23,24 +23,27 @@ internal sealed class PostgreSqlDialect : ISqlDialect
                 entity_id VARCHAR(255) NOT NULL,
                 reminder_key VARCHAR(255) NOT NULL,
                 when_utc TIMESTAMP WITH TIME ZONE NOT NULL,
+                due_time_utc TIMESTAMP WITH TIME ZONE NOT NULL,
                 repeat_interval_ticks BIGINT NULL,
                 serializer_id INTEGER NOT NULL,
                 manifest VARCHAR(500) NULL,
                 payload BYTEA NOT NULL,
                 attempt_count INTEGER NOT NULL DEFAULT 0,
                 last_failure_reason TEXT NULL,
+                max_delivery_window_ticks BIGINT NULL,
+                delivery_deadline_utc TIMESTAMP WITH TIME ZONE NULL,
                 is_completed BOOLEAN NOT NULL DEFAULT FALSE,
                 completed_at_utc TIMESTAMP WITH TIME ZONE NULL,
                 completion_status VARCHAR(20) NOT NULL DEFAULT 'Pending',
                 delivered_at_utc TIMESTAMP WITH TIME ZONE NULL,
                 ack_deadline_utc TIMESTAMP WITH TIME ZONE NULL,
 
-                CONSTRAINT pk_{tableName} PRIMARY KEY (shard_region_name, entity_id, reminder_key)
+                CONSTRAINT pk_{tableName} PRIMARY KEY (shard_region_name, entity_id, reminder_key, due_time_utc)
             );
 
             CREATE INDEX IF NOT EXISTS ix_{tableName}_due_reminders
             ON {fullTableName} (when_utc, shard_region_name, entity_id)
-            WHERE is_completed = FALSE;
+            WHERE is_completed = FALSE AND completion_status = 'Pending';
 
             CREATE INDEX IF NOT EXISTS ix_{tableName}_cleanup
             ON {fullTableName} (completed_at_utc)
@@ -48,24 +51,26 @@ internal sealed class PostgreSqlDialect : ISqlDialect
 
             CREATE INDEX IF NOT EXISTS ix_{tableName}_awaiting_ack
             ON {fullTableName} (ack_deadline_utc)
-            WHERE completion_status = 'AwaitingAck';
+            WHERE completion_status = 'AwaitingAck' AND is_completed = FALSE;
             """;
     }
 
-    public string GetUpsertReminderSql(string schemaName, string tableName)
+    public string GetBatchUpsertRemindersSql(string schemaName, string tableName, int count)
     {
         var fullTableName = $"\"{schemaName}\".\"{tableName}\"";
+        var values = string.Join(",\n                ",
+            Enumerable.Range(0, count).Select(i =>
+                $"(@ShardRegionName{i}, @EntityId{i}, @ReminderKey{i}, @WhenUtc{i}, @DueTimeUtc{i}, @RepeatIntervalTicks{i}, @SerializerId{i}, @Manifest{i}, @Payload{i}, @AttemptCount{i}, @LastFailureReason{i}, @MaxDeliveryWindowTicks{i}, @DeliveryDeadlineUtc{i}, FALSE, NULL, 'Pending', NULL, NULL)"));
 
         return $"""
             INSERT INTO {fullTableName}
-                (shard_region_name, entity_id, reminder_key, when_utc, repeat_interval_ticks,
+                (shard_region_name, entity_id, reminder_key, when_utc, due_time_utc, repeat_interval_ticks,
                  serializer_id, manifest, payload, attempt_count, last_failure_reason,
-                 is_completed, completed_at_utc, completion_status)
+                 max_delivery_window_ticks, delivery_deadline_utc,
+                 is_completed, completed_at_utc, completion_status, delivered_at_utc, ack_deadline_utc)
             VALUES
-                (@ShardRegionName, @EntityId, @ReminderKey, @WhenUtc, @RepeatIntervalTicks,
-                 @SerializerId, @Manifest, @Payload, @AttemptCount, @LastFailureReason,
-                 FALSE, NULL, 'Pending')
-            ON CONFLICT (shard_region_name, entity_id, reminder_key)
+                {values}
+            ON CONFLICT (shard_region_name, entity_id, reminder_key, due_time_utc)
             DO UPDATE SET
                 when_utc = EXCLUDED.when_utc,
                 repeat_interval_ticks = EXCLUDED.repeat_interval_ticks,
@@ -74,9 +79,13 @@ internal sealed class PostgreSqlDialect : ISqlDialect
                 payload = EXCLUDED.payload,
                 attempt_count = EXCLUDED.attempt_count,
                 last_failure_reason = EXCLUDED.last_failure_reason,
+                max_delivery_window_ticks = EXCLUDED.max_delivery_window_ticks,
+                delivery_deadline_utc = EXCLUDED.delivery_deadline_utc,
                 is_completed = FALSE,
                 completed_at_utc = NULL,
-                completion_status = 'Pending';
+                completion_status = 'Pending',
+                delivered_at_utc = NULL,
+                ack_deadline_utc = NULL;
             """;
     }
 
@@ -88,51 +97,57 @@ internal sealed class PostgreSqlDialect : ISqlDialect
         var fullTableName = $"\"{schemaName}\".\"{tableName}\"";
 
         return $"""
-            SELECT shard_region_name, entity_id, reminder_key, when_utc, repeat_interval_ticks,
-                   serializer_id, manifest, payload, attempt_count, last_failure_reason
+            SELECT shard_region_name, entity_id, reminder_key, when_utc, due_time_utc, repeat_interval_ticks,
+                   serializer_id, manifest, payload, attempt_count, last_failure_reason,
+                   max_delivery_window_ticks, delivery_deadline_utc
             FROM {fullTableName}
             WHERE is_completed = FALSE
               AND completion_status = 'Pending'
               AND when_utc <= @UntilDeadline
+              AND (delivery_deadline_utc IS NULL OR delivery_deadline_utc > @Now)
             ORDER BY when_utc ASC
             LIMIT {maxCount};
-            """;
-    }
-
-    public string GetMarkCompletedSql(string schemaName, string tableName)
-    {
-        var fullTableName = $"\"{schemaName}\".\"{tableName}\"";
-
-        return $"""
-            UPDATE {fullTableName}
-            SET is_completed = TRUE,
-                completed_at_utc = @CompletedAtUtc,
-                completion_status = @CompletionStatus
-            WHERE shard_region_name = @ShardRegionName
-              AND entity_id = @EntityId
-              AND reminder_key = @ReminderKey;
             """;
     }
 
     public string GetBatchMarkCompletedSql(string schemaName, string tableName, int count)
     {
         var fullTableName = $"\"{schemaName}\".\"{tableName}\"";
-
         var values = string.Join(",\n                ",
             Enumerable.Range(0, count).Select(i =>
-                $"(@sr{i}::varchar, @eid{i}::varchar, @rk{i}::varchar)"));
+                $"(@sr{i}::varchar, @eid{i}::varchar, @rk{i}::varchar, @due{i}::timestamptz)"));
 
         return $"""
             UPDATE {fullTableName} t
             SET is_completed = TRUE,
                 completed_at_utc = @CompletedAtUtc,
-                completion_status = @CompletionStatus
+                completion_status = @CompletionStatus,
+                delivered_at_utc = NULL,
+                ack_deadline_utc = NULL
             FROM (VALUES
                 {values}
-            ) AS v(shard_region_name, entity_id, reminder_key)
+            ) AS v(shard_region_name, entity_id, reminder_key, due_time_utc)
             WHERE t.shard_region_name = v.shard_region_name
               AND t.entity_id = v.entity_id
-              AND t.reminder_key = v.reminder_key;
+              AND t.reminder_key = v.reminder_key
+              AND t.due_time_utc = v.due_time_utc;
+            """;
+    }
+
+    public string GetExpireRemindersSql(string schemaName, string tableName)
+    {
+        var fullTableName = $"\"{schemaName}\".\"{tableName}\"";
+
+        return $"""
+            UPDATE {fullTableName}
+            SET is_completed = TRUE,
+                completed_at_utc = @Now,
+                completion_status = 'Expired',
+                delivered_at_utc = NULL,
+                ack_deadline_utc = NULL
+            WHERE is_completed = FALSE
+              AND delivery_deadline_utc IS NOT NULL
+              AND delivery_deadline_utc <= @Now;
             """;
     }
 
@@ -154,7 +169,9 @@ internal sealed class PostgreSqlDialect : ISqlDialect
         return $"""
             SELECT COUNT(*) AS total_count, MIN(when_utc) AS next_when_utc
             FROM {fullTableName}
-            WHERE is_completed = FALSE;
+            WHERE is_completed = FALSE
+              AND completion_status = 'Pending'
+              AND (delivery_deadline_utc IS NULL OR delivery_deadline_utc > @Now);
             """;
     }
 
@@ -166,6 +183,8 @@ internal sealed class PostgreSqlDialect : ISqlDialect
             SELECT when_utc
             FROM {fullTableName}
             WHERE is_completed = FALSE
+              AND completion_status = 'Pending'
+              AND (delivery_deadline_utc IS NULL OR delivery_deadline_utc > @Now)
             ORDER BY when_utc ASC
             LIMIT 1 OFFSET @Skip;
             """;
@@ -179,7 +198,9 @@ internal sealed class PostgreSqlDialect : ISqlDialect
             UPDATE {fullTableName}
             SET is_completed = TRUE,
                 completed_at_utc = @CompletedAtUtc,
-                completion_status = 'Cancelled'
+                completion_status = 'Cancelled',
+                delivered_at_utc = NULL,
+                ack_deadline_utc = NULL
             WHERE shard_region_name = @ShardRegionName
               AND entity_id = @EntityId
               AND reminder_key = @ReminderKey
@@ -195,7 +216,9 @@ internal sealed class PostgreSqlDialect : ISqlDialect
             UPDATE {fullTableName}
             SET is_completed = TRUE,
                 completed_at_utc = @CompletedAtUtc,
-                completion_status = 'Cancelled'
+                completion_status = 'Cancelled',
+                delivered_at_utc = NULL,
+                ack_deadline_utc = NULL
             WHERE shard_region_name = @ShardRegionName
               AND entity_id = @EntityId
               AND is_completed = FALSE;
@@ -207,29 +230,39 @@ internal sealed class PostgreSqlDialect : ISqlDialect
         var fullTableName = $"\"{schemaName}\".\"{tableName}\"";
 
         return $"""
-            SELECT shard_region_name, entity_id, reminder_key, when_utc, repeat_interval_ticks,
-                   serializer_id, manifest, payload, attempt_count, last_failure_reason, is_completed
+            SELECT shard_region_name, entity_id, reminder_key, when_utc, due_time_utc, repeat_interval_ticks,
+                   serializer_id, manifest, payload, attempt_count, last_failure_reason,
+                   max_delivery_window_ticks, delivery_deadline_utc
             FROM {fullTableName}
             WHERE shard_region_name = @ShardRegionName
               AND entity_id = @EntityId
               AND is_completed = FALSE
+              AND (delivery_deadline_utc IS NULL OR delivery_deadline_utc > @Now)
             ORDER BY when_utc ASC;
             """;
     }
 
-    public string GetMarkAsAwaitingAckSql(string schemaName, string tableName)
+    public string GetBatchMarkAsAwaitingAckSql(string schemaName, string tableName, int count)
     {
         var fullTableName = $"\"{schemaName}\".\"{tableName}\"";
+        var values = string.Join(",\n                ",
+            Enumerable.Range(0, count).Select(i =>
+                $"(@sr{i}::varchar, @eid{i}::varchar, @rk{i}::varchar, @due{i}::timestamptz, @del{i}::timestamptz, @ack{i}::timestamptz)"));
 
         return $"""
-            UPDATE {fullTableName}
+            UPDATE {fullTableName} t
             SET completion_status = 'AwaitingAck',
-                delivered_at_utc = @DeliveredAtUtc,
-                ack_deadline_utc = @AckDeadlineUtc
-            WHERE shard_region_name = @ShardRegionName
-              AND entity_id = @EntityId
-              AND reminder_key = @ReminderKey
-              AND is_completed = FALSE;
+                delivered_at_utc = v.delivered_at_utc,
+                ack_deadline_utc = v.ack_deadline_utc
+            FROM (VALUES
+                {values}
+            ) AS v(shard_region_name, entity_id, reminder_key, due_time_utc, delivered_at_utc, ack_deadline_utc)
+            WHERE t.shard_region_name = v.shard_region_name
+              AND t.entity_id = v.entity_id
+              AND t.reminder_key = v.reminder_key
+              AND t.due_time_utc = v.due_time_utc
+              AND t.is_completed = FALSE
+              AND t.completion_status = 'Pending';
             """;
     }
 
@@ -241,8 +274,9 @@ internal sealed class PostgreSqlDialect : ISqlDialect
         var fullTableName = $"\"{schemaName}\".\"{tableName}\"";
 
         return $"""
-            SELECT shard_region_name, entity_id, reminder_key, when_utc, repeat_interval_ticks,
-                   serializer_id, manifest, payload, attempt_count, last_failure_reason
+            SELECT shard_region_name, entity_id, reminder_key, when_utc, due_time_utc, repeat_interval_ticks,
+                   serializer_id, manifest, payload, attempt_count, last_failure_reason,
+                   max_delivery_window_ticks, delivery_deadline_utc
             FROM {fullTableName}
             WHERE completion_status = 'AwaitingAck'
               AND is_completed = FALSE
@@ -256,34 +290,20 @@ internal sealed class PostgreSqlDialect : ISqlDialect
     {
         var fullTableName = $"\"{schemaName}\".\"{tableName}\"";
 
-        // Returns the full reminder row so the caller can read repeat_interval_ticks and
-        // reconstruct the ScheduledReminder for rescheduling recurring reminders.
         return $"""
             UPDATE {fullTableName}
             SET is_completed = TRUE,
                 completed_at_utc = @AckedAtUtc,
-                completion_status = 'Delivered'
+                completion_status = 'Delivered',
+                delivered_at_utc = NULL,
+                ack_deadline_utc = NULL
             WHERE shard_region_name = @ShardRegionName
               AND entity_id = @EntityId
               AND reminder_key = @ReminderKey
+              AND due_time_utc = @DueTimeUtc
               AND completion_status = 'AwaitingAck'
               AND is_completed = FALSE
-            RETURNING shard_region_name, entity_id, reminder_key, when_utc, repeat_interval_ticks,
-                      serializer_id, manifest, payload, attempt_count, last_failure_reason;
-            """;
-    }
-
-    public string GetResetAwaitingAckSql(string schemaName, string tableName)
-    {
-        var fullTableName = $"\"{schemaName}\".\"{tableName}\"";
-
-        return $"""
-            UPDATE {fullTableName}
-            SET completion_status = 'Pending',
-                delivered_at_utc = NULL,
-                ack_deadline_utc = NULL
-            WHERE completion_status = 'AwaitingAck'
-              AND is_completed = FALSE;
+              AND (delivery_deadline_utc IS NULL OR delivery_deadline_utc > @AckedAtUtc);
             """;
     }
 

--- a/src/Akka.Reminders.PostgreSql/Internal/PostgreSqlDialect.cs
+++ b/src/Akka.Reminders.PostgreSql/Internal/PostgreSqlDialect.cs
@@ -32,6 +32,8 @@ internal sealed class PostgreSqlDialect : ISqlDialect
                 is_completed BOOLEAN NOT NULL DEFAULT FALSE,
                 completed_at_utc TIMESTAMP WITH TIME ZONE NULL,
                 completion_status VARCHAR(20) NOT NULL DEFAULT 'Pending',
+                delivered_at_utc TIMESTAMP WITH TIME ZONE NULL,
+                ack_deadline_utc TIMESTAMP WITH TIME ZONE NULL,
 
                 CONSTRAINT pk_{tableName} PRIMARY KEY (shard_region_name, entity_id, reminder_key)
             );
@@ -43,6 +45,10 @@ internal sealed class PostgreSqlDialect : ISqlDialect
             CREATE INDEX IF NOT EXISTS ix_{tableName}_cleanup
             ON {fullTableName} (completed_at_utc)
             WHERE is_completed = TRUE;
+
+            CREATE INDEX IF NOT EXISTS ix_{tableName}_awaiting_ack
+            ON {fullTableName} (ack_deadline_utc)
+            WHERE completion_status = 'AwaitingAck';
             """;
     }
 
@@ -86,6 +92,7 @@ internal sealed class PostgreSqlDialect : ISqlDialect
                    serializer_id, manifest, payload, attempt_count, last_failure_reason
             FROM {fullTableName}
             WHERE is_completed = FALSE
+              AND completion_status = 'Pending'
               AND when_utc <= @UntilDeadline
             ORDER BY when_utc ASC
             LIMIT {maxCount};
@@ -207,6 +214,62 @@ internal sealed class PostgreSqlDialect : ISqlDialect
               AND entity_id = @EntityId
               AND is_completed = FALSE
             ORDER BY when_utc ASC;
+            """;
+    }
+
+    public string GetMarkAsAwaitingAckSql(string schemaName, string tableName)
+    {
+        var fullTableName = $"\"{schemaName}\".\"{tableName}\"";
+
+        return $"""
+            UPDATE {fullTableName}
+            SET completion_status = 'AwaitingAck',
+                delivered_at_utc = @DeliveredAtUtc,
+                ack_deadline_utc = @AckDeadlineUtc
+            WHERE shard_region_name = @ShardRegionName
+              AND entity_id = @EntityId
+              AND reminder_key = @ReminderKey
+              AND is_completed = FALSE;
+            """;
+    }
+
+    public string GetTimedOutAckRemindersSql(string schemaName, string tableName, int maxCount)
+    {
+        if (maxCount < 1)
+            throw new ArgumentOutOfRangeException(nameof(maxCount), "maxCount must be greater than or equal to 1.");
+
+        var fullTableName = $"\"{schemaName}\".\"{tableName}\"";
+
+        return $"""
+            SELECT shard_region_name, entity_id, reminder_key, when_utc, repeat_interval_ticks,
+                   serializer_id, manifest, payload, attempt_count, last_failure_reason
+            FROM {fullTableName}
+            WHERE completion_status = 'AwaitingAck'
+              AND is_completed = FALSE
+              AND ack_deadline_utc <= @Now
+            ORDER BY ack_deadline_utc ASC
+            LIMIT {maxCount};
+            """;
+    }
+
+    public string GetAcknowledgeReminderSql(string schemaName, string tableName)
+    {
+        var fullTableName = $"\"{schemaName}\".\"{tableName}\"";
+
+        // Returns the full reminder row so the caller can read repeat_interval_ticks and
+        // reconstruct the ScheduledReminder for rescheduling recurring reminders.
+        return $"""
+            UPDATE {fullTableName}
+            SET is_completed = TRUE,
+                completed_at_utc = @AckedAtUtc,
+                completion_status = 'Delivered'
+            WHERE shard_region_name = @ShardRegionName
+              AND entity_id = @EntityId
+              AND reminder_key = @ReminderKey
+              AND completion_status = 'AwaitingAck'
+              AND is_completed = FALSE
+            RETURNING shard_region_name, entity_id, reminder_key, when_utc, repeat_interval_ticks,
+                      serializer_id, manifest, payload, attempt_count, last_failure_reason;
             """;
     }
 

--- a/src/Akka.Reminders.PostgreSql/PostgreSqlReminderStorage.cs
+++ b/src/Akka.Reminders.PostgreSql/PostgreSqlReminderStorage.cs
@@ -527,6 +527,20 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
         }
     }
 
+    public async Task<int> ResetAwaitingAckToPendingAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = _dialect.GetResetAwaitingAckSql(_settings.SchemaName, _settings.TableName);
+        command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+        return await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
     private Task EnsureInitializedAsync(CancellationToken cancellationToken)
     {
         if (_initialized || !_settings.AutoInitialize)

--- a/src/Akka.Reminders.PostgreSql/PostgreSqlReminderStorage.cs
+++ b/src/Akka.Reminders.PostgreSql/PostgreSqlReminderStorage.cs
@@ -47,8 +47,9 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
         {
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
+            await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
 
-            await using (var cancelCommand = connection.CreateCommand())
+            await using (var cancelCommand = CreateCommand(connection, transaction))
             {
                 cancelCommand.CommandText = _dialect.GetCancelReminderSql(_settings.SchemaName, _settings.TableName);
                 cancelCommand.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
@@ -59,13 +60,16 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
                 await cancelCommand.ExecuteNonQueryAsync(cancellationToken);
             }
 
-            if (!await UpsertReminderOccurrencesAsync(connection, [adjustedReminder], cancellationToken))
+            if (!await UpsertReminderOccurrencesAsync(connection, transaction, [adjustedReminder], cancellationToken))
             {
+                await transaction.RollbackAsync(cancellationToken);
                 return new ReminderProtocol.ReminderScheduled(
                     adjustedReminder.ToScheduleReminder(),
                     ReminderScheduleResponseCode.Error,
                     "Failed to persist reminder occurrence");
             }
+
+            await transaction.CommitAsync(cancellationToken);
 
             return new ReminderProtocol.ReminderScheduled(adjustedReminder.ToScheduleReminder(), ReminderScheduleResponseCode.Success);
         }
@@ -83,11 +87,55 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
 
         await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
         await connection.OpenAsync(cancellationToken);
-        return await UpsertReminderOccurrencesAsync(connection, reminders.Select(NormalizeReminder), cancellationToken);
+        return await UpsertReminderOccurrencesAsync(connection, null, reminders.Select(NormalizeReminder), cancellationToken);
+    }
+
+    public async Task<bool> CommitReminderMutationsAsync(ReminderMutationBatch mutationBatch, CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+        if (mutationBatch.IsEmpty)
+            return true;
+
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+        try
+        {
+            if (!await UpsertReminderOccurrencesAsync(connection, transaction,
+                    mutationBatch.PendingUpserts.Select(NormalizeReminder), cancellationToken))
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                return false;
+            }
+
+            if (!await MarkRemindersAsCompletedAsync(connection, transaction,
+                    mutationBatch.CompletedReminders.Select(NormalizeCompletedReminder), cancellationToken))
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                return false;
+            }
+
+            if (!await MarkRemindersAsAwaitingAckAsync(connection, transaction,
+                    mutationBatch.AwaitingAckReminders.Select(NormalizeAwaitingAckReminder), cancellationToken))
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                return false;
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+            return true;
+        }
+        catch
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            return false;
+        }
     }
 
     private async Task<bool> UpsertReminderOccurrencesAsync(
         System.Data.Common.DbConnection connection,
+        System.Data.Common.DbTransaction? transaction,
         IEnumerable<ScheduledReminder> reminders,
         CancellationToken cancellationToken)
     {
@@ -100,7 +148,7 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
             for (var offset = 0; offset < remindersList.Count; offset += MaxUpsertedRemindersPerStatement)
             {
                 var chunk = remindersList.Skip(offset).Take(MaxUpsertedRemindersPerStatement).ToList();
-                await using var command = connection.CreateCommand();
+                await using var command = CreateCommand(connection, transaction);
                 command.CommandText = _dialect.GetBatchUpsertRemindersSql(_settings.SchemaName, _settings.TableName, chunk.Count);
                 command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
 
@@ -191,33 +239,8 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
         {
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
-
-            var groups = remindersList.GroupBy(r => (r.Status, CompletedAt: TruncateToMicroseconds(r.CompletedAt)));
-            foreach (var group in groups)
-            {
-                var items = group.ToList();
-                for (var offset = 0; offset < items.Count; offset += MaxRemindersPerStatusUpdate)
-                {
-                    var chunk = items.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
-                    await using var command = connection.CreateCommand();
-                    command.CommandText = _dialect.GetBatchMarkCompletedSql(_settings.SchemaName, _settings.TableName, chunk.Count);
-                    command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-                    _dialect.AddParameter(command, "@CompletedAtUtc", group.Key.CompletedAt);
-                    _dialect.AddParameter(command, "@CompletionStatus", group.Key.Status.ToString());
-
-                    for (var i = 0; i < chunk.Count; i++)
-                    {
-                        _dialect.AddParameter(command, $"@sr{i}", chunk[i].Entity.ShardRegionName);
-                        _dialect.AddParameter(command, $"@eid{i}", chunk[i].Entity.EntityId);
-                        _dialect.AddParameter(command, $"@rk{i}", chunk[i].Key.Name);
-                        _dialect.AddParameter(command, $"@due{i}", TruncateToMicroseconds(chunk[i].DueTimeUtc));
-                    }
-
-                    await command.ExecuteNonQueryAsync(cancellationToken);
-                }
-            }
-
-            return true;
+            return await MarkRemindersAsCompletedAsync(connection, null,
+                remindersList.Select(NormalizeCompletedReminder), cancellationToken);
         }
         catch
         {
@@ -386,27 +409,8 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
         {
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
-            for (var offset = 0; offset < remindersList.Count; offset += MaxRemindersPerStatusUpdate)
-            {
-                var chunk = remindersList.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
-                await using var command = connection.CreateCommand();
-                command.CommandText = _dialect.GetBatchMarkAsAwaitingAckSql(_settings.SchemaName, _settings.TableName, chunk.Count);
-                command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
-                for (var i = 0; i < chunk.Count; i++)
-                {
-                    _dialect.AddParameter(command, $"@sr{i}", chunk[i].Entity.ShardRegionName);
-                    _dialect.AddParameter(command, $"@eid{i}", chunk[i].Entity.EntityId);
-                    _dialect.AddParameter(command, $"@rk{i}", chunk[i].Key.Name);
-                    _dialect.AddParameter(command, $"@due{i}", TruncateToMicroseconds(chunk[i].DueTimeUtc));
-                    _dialect.AddParameter(command, $"@del{i}", TruncateToMicroseconds(chunk[i].DeliveredAt));
-                    _dialect.AddParameter(command, $"@ack{i}", TruncateToMicroseconds(chunk[i].AckDeadline));
-                }
-
-                await command.ExecuteNonQueryAsync(cancellationToken);
-            }
-
-            return true;
+            return await MarkRemindersAsAwaitingAckAsync(connection, null,
+                remindersList.Select(NormalizeAwaitingAckReminder), cancellationToken);
         }
         catch
         {
@@ -434,27 +438,50 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
     }
 
     public async Task<AckResult> AcknowledgeReminderAsync(ReminderEntity entity, ReminderKey key, DateTimeOffset dueTimeUtc, DateTimeOffset ackedAt, CancellationToken cancellationToken = default)
+        => (await AcknowledgeRemindersAsync([new ReminderAcknowledgement(entity, key, dueTimeUtc, ackedAt)], cancellationToken))[0];
+
+    public async Task<IReadOnlyList<AckResult>> AcknowledgeRemindersAsync(
+        IEnumerable<ReminderAcknowledgement> acknowledgements,
+        CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
-        try
+        var results = new List<AckResult>();
+
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        foreach (var acknowledgement in acknowledgements.Select(NormalizeAcknowledgement))
         {
-            await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
-            await connection.OpenAsync(cancellationToken);
-            await using var command = connection.CreateCommand();
-            command.CommandText = _dialect.GetAcknowledgeReminderSql(_settings.SchemaName, _settings.TableName);
-            command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-            _dialect.AddParameter(command, "@ShardRegionName", entity.ShardRegionName);
-            _dialect.AddParameter(command, "@EntityId", entity.EntityId);
-            _dialect.AddParameter(command, "@ReminderKey", key.Name);
-            _dialect.AddParameter(command, "@DueTimeUtc", TruncateToMicroseconds(dueTimeUtc));
-            _dialect.AddParameter(command, "@AckedAtUtc", TruncateToMicroseconds(ackedAt));
-            var count = await command.ExecuteNonQueryAsync(cancellationToken);
-            return new AckResult(count > 0);
+            try
+            {
+                await using var command = CreateCommand(connection, null);
+                command.CommandText = _dialect.GetAcknowledgeReminderSql(_settings.SchemaName, _settings.TableName);
+                command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+                _dialect.AddParameter(command, "@ShardRegionName", acknowledgement.Entity.ShardRegionName);
+                _dialect.AddParameter(command, "@EntityId", acknowledgement.Entity.EntityId);
+                _dialect.AddParameter(command, "@ReminderKey", acknowledgement.Key.Name);
+                _dialect.AddParameter(command, "@DueTimeUtc", acknowledgement.DueTimeUtc);
+                _dialect.AddParameter(command, "@AckedAtUtc", acknowledgement.AckedAt);
+                var count = await command.ExecuteNonQueryAsync(cancellationToken);
+                results.Add(new AckResult(
+                    acknowledgement.Entity,
+                    acknowledgement.Key,
+                    acknowledgement.DueTimeUtc,
+                    count > 0 ? ReminderAckStorageStatus.Success : ReminderAckStorageStatus.NotFound,
+                    count > 0 ? null : "Reminder occurrence was not awaiting acknowledgement or was already stale."));
+            }
+            catch (Exception ex)
+            {
+                results.Add(new AckResult(
+                    acknowledgement.Entity,
+                    acknowledgement.Key,
+                    acknowledgement.DueTimeUtc,
+                    ReminderAckStorageStatus.Error,
+                    ex.Message));
+            }
         }
-        catch
-        {
-            return new AckResult(false);
-        }
+
+        return results;
     }
 
     private Task EnsureInitializedAsync(CancellationToken cancellationToken)
@@ -491,6 +518,113 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
             ? TruncateToMicroseconds(reminder.DeliveryDeadlineUtc.Value)
             : null;
         return reminder with { When = when, DeliveryDeadlineUtc = deadline, OccurrenceDueTimeUtc = due };
+    }
+
+    private static CompletedReminder NormalizeCompletedReminder(CompletedReminder reminder)
+        => reminder with
+        {
+            DueTimeUtc = TruncateToMicroseconds(reminder.DueTimeUtc),
+            CompletedAt = TruncateToMicroseconds(reminder.CompletedAt)
+        };
+
+    private static AwaitingAckReminder NormalizeAwaitingAckReminder(AwaitingAckReminder reminder)
+        => reminder with
+        {
+            DueTimeUtc = TruncateToMicroseconds(reminder.DueTimeUtc),
+            DeliveredAt = TruncateToMicroseconds(reminder.DeliveredAt),
+            AckDeadline = TruncateToMicroseconds(reminder.AckDeadline)
+        };
+
+    private static ReminderAcknowledgement NormalizeAcknowledgement(ReminderAcknowledgement acknowledgement)
+        => acknowledgement with
+        {
+            DueTimeUtc = TruncateToMicroseconds(acknowledgement.DueTimeUtc),
+            AckedAt = TruncateToMicroseconds(acknowledgement.AckedAt)
+        };
+
+    private async Task<bool> MarkRemindersAsCompletedAsync(
+        System.Data.Common.DbConnection connection,
+        System.Data.Common.DbTransaction? transaction,
+        IEnumerable<CompletedReminder> completedReminders,
+        CancellationToken cancellationToken)
+    {
+        var remindersList = completedReminders.ToList();
+        if (remindersList.Count == 0)
+            return true;
+
+        var groups = remindersList.GroupBy(r => (r.Status, r.CompletedAt));
+        foreach (var group in groups)
+        {
+            var items = group.ToList();
+            for (var offset = 0; offset < items.Count; offset += MaxRemindersPerStatusUpdate)
+            {
+                var chunk = items.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
+                await using var command = CreateCommand(connection, transaction);
+                command.CommandText = _dialect.GetBatchMarkCompletedSql(_settings.SchemaName, _settings.TableName, chunk.Count);
+                command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+                _dialect.AddParameter(command, "@CompletedAtUtc", group.Key.CompletedAt);
+                _dialect.AddParameter(command, "@CompletionStatus", group.Key.Status.ToString());
+
+                for (var i = 0; i < chunk.Count; i++)
+                {
+                    _dialect.AddParameter(command, $"@sr{i}", chunk[i].Entity.ShardRegionName);
+                    _dialect.AddParameter(command, $"@eid{i}", chunk[i].Entity.EntityId);
+                    _dialect.AddParameter(command, $"@rk{i}", chunk[i].Key.Name);
+                    _dialect.AddParameter(command, $"@due{i}", chunk[i].DueTimeUtc);
+                }
+
+                var updated = await command.ExecuteNonQueryAsync(cancellationToken);
+                if (updated != chunk.Count)
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private async Task<bool> MarkRemindersAsAwaitingAckAsync(
+        System.Data.Common.DbConnection connection,
+        System.Data.Common.DbTransaction? transaction,
+        IEnumerable<AwaitingAckReminder> reminders,
+        CancellationToken cancellationToken)
+    {
+        var remindersList = reminders.ToList();
+        if (remindersList.Count == 0)
+            return true;
+
+        for (var offset = 0; offset < remindersList.Count; offset += MaxRemindersPerStatusUpdate)
+        {
+            var chunk = remindersList.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
+            await using var command = CreateCommand(connection, transaction);
+            command.CommandText = _dialect.GetBatchMarkAsAwaitingAckSql(_settings.SchemaName, _settings.TableName, chunk.Count);
+            command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+            for (var i = 0; i < chunk.Count; i++)
+            {
+                _dialect.AddParameter(command, $"@sr{i}", chunk[i].Entity.ShardRegionName);
+                _dialect.AddParameter(command, $"@eid{i}", chunk[i].Entity.EntityId);
+                _dialect.AddParameter(command, $"@rk{i}", chunk[i].Key.Name);
+                _dialect.AddParameter(command, $"@due{i}", chunk[i].DueTimeUtc);
+                _dialect.AddParameter(command, $"@del{i}", chunk[i].DeliveredAt);
+                _dialect.AddParameter(command, $"@ack{i}", chunk[i].AckDeadline);
+            }
+
+            var updated = await command.ExecuteNonQueryAsync(cancellationToken);
+            if (updated != chunk.Count)
+                return false;
+        }
+
+        return true;
+    }
+
+    private static System.Data.Common.DbCommand CreateCommand(
+        System.Data.Common.DbConnection connection,
+        System.Data.Common.DbTransaction? transaction)
+    {
+        var command = connection.CreateCommand();
+        if (transaction is not null)
+            command.Transaction = transaction;
+        return command;
     }
 
     private void BindReminderParameters(System.Data.Common.DbCommand command, int index, ScheduledReminder reminder)

--- a/src/Akka.Reminders.PostgreSql/PostgreSqlReminderStorage.cs
+++ b/src/Akka.Reminders.PostgreSql/PostgreSqlReminderStorage.cs
@@ -17,6 +17,9 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
     private readonly object _initLock = new();
     private volatile bool _initialized;
 
+    private const int MaxUpsertedRemindersPerStatement = 120;
+    private const int MaxRemindersPerStatusUpdate = 300;
+
     public PostgreSqlReminderStorage(PostgreSqlReminderStorageSettings settings, ActorSystem system)
     {
         _settings = settings ?? throw new ArgumentNullException(nameof(settings));
@@ -38,77 +41,105 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
     {
         await EnsureInitializedAsync(cancellationToken);
 
-        var truncatedWhen = TruncateToMicroseconds(reminder.When);
-        var adjustedReminder = reminder with { When = truncatedWhen };
+        var adjustedReminder = NormalizeReminder(reminder);
 
         try
         {
-            var (serializerId, manifest, payload) = SerializeMessage(adjustedReminder.Message);
-
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
 
-            await using var command = connection.CreateCommand();
-            command.CommandText = _dialect.GetUpsertReminderSql(_settings.SchemaName, _settings.TableName);
-            command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+            await using (var cancelCommand = connection.CreateCommand())
+            {
+                cancelCommand.CommandText = _dialect.GetCancelReminderSql(_settings.SchemaName, _settings.TableName);
+                cancelCommand.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+                _dialect.AddParameter(cancelCommand, "@ShardRegionName", adjustedReminder.Entity.ShardRegionName);
+                _dialect.AddParameter(cancelCommand, "@EntityId", adjustedReminder.Entity.EntityId);
+                _dialect.AddParameter(cancelCommand, "@ReminderKey", adjustedReminder.Key.Name);
+                _dialect.AddParameter(cancelCommand, "@CompletedAtUtc", TruncateToMicroseconds(DateTimeOffset.UtcNow));
+                await cancelCommand.ExecuteNonQueryAsync(cancellationToken);
+            }
 
-            _dialect.AddParameter(command, "@ShardRegionName", adjustedReminder.Entity.ShardRegionName);
-            _dialect.AddParameter(command, "@EntityId", adjustedReminder.Entity.EntityId);
-            _dialect.AddParameter(command, "@ReminderKey", adjustedReminder.Key.Name);
-            _dialect.AddParameter(command, "@WhenUtc", adjustedReminder.When);
-            _dialect.AddParameter(command, "@RepeatIntervalTicks", adjustedReminder.RepeatInterval?.Ticks ?? (object)DBNull.Value);
-            _dialect.AddParameter(command, "@SerializerId", serializerId);
-            _dialect.AddParameter(command, "@Manifest", manifest ?? (object)DBNull.Value);
-            _dialect.AddParameter(command, "@Payload", payload);
-            _dialect.AddParameter(command, "@AttemptCount", adjustedReminder.AttemptCount);
-            _dialect.AddParameter(command, "@LastFailureReason", adjustedReminder.LastFailureReason ?? (object)DBNull.Value);
+            if (!await UpsertReminderOccurrencesAsync(connection, [adjustedReminder], cancellationToken))
+            {
+                return new ReminderProtocol.ReminderScheduled(
+                    adjustedReminder.ToScheduleReminder(),
+                    ReminderScheduleResponseCode.Error,
+                    "Failed to persist reminder occurrence");
+            }
 
-            await command.ExecuteNonQueryAsync(cancellationToken);
-
-            return new ReminderProtocol.ReminderScheduled(
-                adjustedReminder.ToScheduleReminder(),
-                ReminderScheduleResponseCode.Success);
+            return new ReminderProtocol.ReminderScheduled(adjustedReminder.ToScheduleReminder(), ReminderScheduleResponseCode.Success);
         }
         catch (Exception ex)
         {
-            return new ReminderProtocol.ReminderScheduled(
-                adjustedReminder.ToScheduleReminder(),
-                ReminderScheduleResponseCode.Error,
-                ex.Message);
+            return new ReminderProtocol.ReminderScheduled(adjustedReminder.ToScheduleReminder(), ReminderScheduleResponseCode.Error, ex.Message);
         }
     }
 
-    public async Task<PendingRemindersWithSummary> GetNextRemindersAsync(
-        DateTimeOffset untilDeadline,
-        DateTimeOffset now,
-        ReminderBatchSize maxCount,
+    public async Task<bool> UpsertReminderOccurrencesAsync(
+        IEnumerable<ScheduledReminder> reminders,
         CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
 
-        var reminders = new List<ScheduledReminder>();
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+        return await UpsertReminderOccurrencesAsync(connection, reminders.Select(NormalizeReminder), cancellationToken);
+    }
 
+    private async Task<bool> UpsertReminderOccurrencesAsync(
+        System.Data.Common.DbConnection connection,
+        IEnumerable<ScheduledReminder> reminders,
+        CancellationToken cancellationToken)
+    {
+        var remindersList = reminders.ToList();
+        if (remindersList.Count == 0)
+            return true;
+
+        try
+        {
+            for (var offset = 0; offset < remindersList.Count; offset += MaxUpsertedRemindersPerStatement)
+            {
+                var chunk = remindersList.Skip(offset).Take(MaxUpsertedRemindersPerStatement).ToList();
+                await using var command = connection.CreateCommand();
+                command.CommandText = _dialect.GetBatchUpsertRemindersSql(_settings.SchemaName, _settings.TableName, chunk.Count);
+                command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+                for (var i = 0; i < chunk.Count; i++)
+                {
+                    BindReminderParameters(command, i, chunk[i]);
+                }
+
+                await command.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public async Task<PendingRemindersWithSummary> GetNextRemindersAsync(DateTimeOffset untilDeadline, DateTimeOffset now, ReminderBatchSize maxCount, CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+
+        var reminders = new List<ScheduledReminder>();
         await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
         await connection.OpenAsync(cancellationToken);
 
         await using var command = connection.CreateCommand();
-        command.CommandText = _dialect.GetSelectDueRemindersSql(
-            _settings.SchemaName,
-            _settings.TableName,
-            maxCount.Value);
+        command.CommandText = _dialect.GetSelectDueRemindersSql(_settings.SchemaName, _settings.TableName, maxCount.Value);
         command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
-        _dialect.AddParameter(command, "@UntilDeadline", untilDeadline.UtcDateTime);
+        _dialect.AddParameter(command, "@UntilDeadline", TruncateToMicroseconds(untilDeadline));
+        _dialect.AddParameter(command, "@Now", TruncateToMicroseconds(now));
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
-
         while (await reader.ReadAsync(cancellationToken))
         {
-            var reminder = ReadReminderFromReader(reader);
-            reminders.Add(reminder);
+            reminders.Add(ReadReminderFromReader(reader));
         }
 
-        // Get overview of remaining reminders using aggregate queries
         await using var conn2 = _dialect.CreateConnection(_settings.ConnectionString);
         await conn2.OpenAsync(cancellationToken);
 
@@ -117,11 +148,10 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
         {
             cmd2.CommandText = _dialect.GetOverviewAggregateSql(_settings.SchemaName, _settings.TableName);
             cmd2.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+            _dialect.AddParameter(cmd2, "@Now", TruncateToMicroseconds(now));
             await using var reader2 = await cmd2.ExecuteReaderAsync(cancellationToken);
             if (await reader2.ReadAsync(cancellationToken))
-            {
                 totalPending = reader2.GetInt64(reader2.GetOrdinal("total_count"));
-            }
         }
 
         var remainingCount = totalPending - reminders.Count;
@@ -133,6 +163,7 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
             cmd3.CommandText = _dialect.GetNextReminderTimeSql(_settings.SchemaName, _settings.TableName);
             cmd3.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
             _dialect.AddParameter(cmd3, "@Skip", reminders.Count);
+            _dialect.AddParameter(cmd3, "@Now", TruncateToMicroseconds(now));
 
             var result = await cmd3.ExecuteScalarAsync(cancellationToken);
             if (result is DateTime nextWhenUtc)
@@ -141,20 +172,14 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
             }
         }
 
-        var adjustedOverview = new ReminderOverview
+        return new PendingRemindersWithSummary(reminders, new ReminderOverview
         {
             TimeUntilNext = timeUntilNext,
             TotalPendingReminders = remainingCount
-        };
-
-        return new PendingRemindersWithSummary(reminders, adjustedOverview);
+        });
     }
 
-    private const int MaxRemindersPerStatement = 500;
-
-    public async Task<bool> MarkRemindersAsCompletedAsync(
-        IEnumerable<CompletedReminder> completedReminders,
-        CancellationToken cancellationToken = default)
+    public async Task<bool> MarkRemindersAsCompletedAsync(IEnumerable<CompletedReminder> completedReminders, CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
 
@@ -167,22 +192,17 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
 
-            var groups = remindersList.GroupBy(r => (r.Status, r.When));
-
+            var groups = remindersList.GroupBy(r => (r.Status, CompletedAt: TruncateToMicroseconds(r.CompletedAt)));
             foreach (var group in groups)
             {
                 var items = group.ToList();
-
-                for (var offset = 0; offset < items.Count; offset += MaxRemindersPerStatement)
+                for (var offset = 0; offset < items.Count; offset += MaxRemindersPerStatusUpdate)
                 {
-                    var chunk = items.Skip(offset).Take(MaxRemindersPerStatement).ToList();
-
+                    var chunk = items.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
                     await using var command = connection.CreateCommand();
-                    command.CommandText = _dialect.GetBatchMarkCompletedSql(
-                        _settings.SchemaName, _settings.TableName, chunk.Count);
+                    command.CommandText = _dialect.GetBatchMarkCompletedSql(_settings.SchemaName, _settings.TableName, chunk.Count);
                     command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
-                    _dialect.AddParameter(command, "@CompletedAtUtc", group.Key.When.UtcDateTime);
+                    _dialect.AddParameter(command, "@CompletedAtUtc", group.Key.CompletedAt);
                     _dialect.AddParameter(command, "@CompletionStatus", group.Key.Status.ToString());
 
                     for (var i = 0; i < chunk.Count; i++)
@@ -190,6 +210,7 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
                         _dialect.AddParameter(command, $"@sr{i}", chunk[i].Entity.ShardRegionName);
                         _dialect.AddParameter(command, $"@eid{i}", chunk[i].Entity.EntityId);
                         _dialect.AddParameter(command, $"@rk{i}", chunk[i].Key.Name);
+                        _dialect.AddParameter(command, $"@due{i}", TruncateToMicroseconds(chunk[i].DueTimeUtc));
                     }
 
                     await command.ExecuteNonQueryAsync(cancellationToken);
@@ -198,229 +219,165 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
 
             return true;
         }
-        catch (Exception)
+        catch
         {
             return false;
         }
     }
 
-    /// <inheritdoc />
-    public async Task<ReminderOverview> GetRemindersOverviewAsync(
-        DateTimeOffset now,
-        CancellationToken cancellationToken = default)
+    public async Task<int> ExpireRemindersAsync(DateTimeOffset now, CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
-
         await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
         await connection.OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = _dialect.GetExpireRemindersSql(_settings.SchemaName, _settings.TableName);
+        command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+        _dialect.AddParameter(command, "@Now", TruncateToMicroseconds(now));
+        return await command.ExecuteNonQueryAsync(cancellationToken);
+    }
 
+    public async Task<ReminderOverview> GetRemindersOverviewAsync(DateTimeOffset now, CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
         await using var command = connection.CreateCommand();
         command.CommandText = _dialect.GetOverviewAggregateSql(_settings.SchemaName, _settings.TableName);
         command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
+        _dialect.AddParameter(command, "@Now", TruncateToMicroseconds(now));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
 
         if (await reader.ReadAsync(cancellationToken))
         {
             var totalCount = reader.GetInt64(reader.GetOrdinal("total_count"));
             var nextWhenUtcOrdinal = reader.GetOrdinal("next_when_utc");
-
             if (totalCount == 0 || reader.IsDBNull(nextWhenUtcOrdinal))
                 return ReminderOverview.Empty;
 
             var nextWhenUtc = reader.GetDateTime(nextWhenUtcOrdinal);
-            var timeUntilNext = new DateTimeOffset(DateTime.SpecifyKind(nextWhenUtc, DateTimeKind.Utc)) - now;
-
             return new ReminderOverview
             {
                 TotalPendingReminders = totalCount,
-                TimeUntilNext = timeUntilNext
+                TimeUntilNext = new DateTimeOffset(DateTime.SpecifyKind(nextWhenUtc, DateTimeKind.Utc)) - now
             };
         }
 
         return ReminderOverview.Empty;
     }
 
-    public async Task<bool> CleanUpCompletedRemindersAsync(
-        DateTimeOffset olderThan,
-        CancellationToken cancellationToken = default)
+    public async Task<bool> CleanUpCompletedRemindersAsync(DateTimeOffset olderThan, CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
-
         try
         {
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
-
             await using var command = connection.CreateCommand();
             command.CommandText = _dialect.GetCleanupSql(_settings.SchemaName, _settings.TableName);
             command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
-            _dialect.AddParameter(command, "@OlderThan", olderThan.UtcDateTime);
-
+            _dialect.AddParameter(command, "@OlderThan", TruncateToMicroseconds(olderThan));
             await command.ExecuteNonQueryAsync(cancellationToken);
             return true;
         }
-        catch (Exception)
+        catch
         {
             return false;
         }
     }
 
-    public async Task<ReminderProtocol.RemindersCancelled> CancelReminderAsync(
-        ReminderEntity entity,
-        ReminderKey key,
-        CancellationToken cancellationToken = default)
+    public async Task<ReminderProtocol.RemindersCancelled> CancelReminderAsync(ReminderEntity entity, ReminderKey key, CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
-
         try
         {
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
-
             await using var command = connection.CreateCommand();
             command.CommandText = _dialect.GetCancelReminderSql(_settings.SchemaName, _settings.TableName);
             command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
             _dialect.AddParameter(command, "@ShardRegionName", entity.ShardRegionName);
             _dialect.AddParameter(command, "@EntityId", entity.EntityId);
             _dialect.AddParameter(command, "@ReminderKey", key.Name);
-            _dialect.AddParameter(command, "@CompletedAtUtc", DateTimeOffset.UtcNow.UtcDateTime);
-
+            _dialect.AddParameter(command, "@CompletedAtUtc", TruncateToMicroseconds(DateTimeOffset.UtcNow));
             var count = await command.ExecuteNonQueryAsync(cancellationToken);
-
-            if (count > 0)
-            {
-                return new ReminderProtocol.RemindersCancelled(
-                    entity,
-                    ReminderCancelResponseCode.Success,
-                    new List<ReminderKey> { key },
-                    null);
-            }
-
-            return new ReminderProtocol.RemindersCancelled(
-                entity,
-                ReminderCancelResponseCode.NotFound,
-                new List<ReminderKey>(),
-                null);
+            return count > 0
+                ? new ReminderProtocol.RemindersCancelled(entity, ReminderCancelResponseCode.Success, [key])
+                : new ReminderProtocol.RemindersCancelled(entity, ReminderCancelResponseCode.NotFound, []);
         }
         catch (Exception ex)
         {
-            return new ReminderProtocol.RemindersCancelled(
-                entity,
-                ReminderCancelResponseCode.Error,
-                new List<ReminderKey>(),
-                ex.Message);
+            return new ReminderProtocol.RemindersCancelled(entity, ReminderCancelResponseCode.Error, [], ex.Message);
         }
     }
 
-    public async Task<ReminderProtocol.RemindersCancelled> CancelAllRemindersForEntityAsync(
-        ReminderEntity entity,
-        CancellationToken cancellationToken = default)
+    public async Task<ReminderProtocol.RemindersCancelled> CancelAllRemindersForEntityAsync(ReminderEntity entity, CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
-
         try
         {
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
-
-            var cancelledKeys = new List<ReminderKey>();
+            var cancelledKeys = new HashSet<ReminderKey>();
 
             await using (var selectCommand = connection.CreateCommand())
             {
                 selectCommand.CommandText = _dialect.GetFetchRemindersSql(_settings.SchemaName, _settings.TableName);
                 selectCommand.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
                 _dialect.AddParameter(selectCommand, "@ShardRegionName", entity.ShardRegionName);
                 _dialect.AddParameter(selectCommand, "@EntityId", entity.EntityId);
-
+                _dialect.AddParameter(selectCommand, "@Now", TruncateToMicroseconds(DateTimeOffset.UtcNow));
                 await using var reader = await selectCommand.ExecuteReaderAsync(cancellationToken);
                 while (await reader.ReadAsync(cancellationToken))
                 {
-                    var reminderKey = reader.GetString(reader.GetOrdinal("reminder_key"));
-                    var isCompleted = reader.GetBoolean(reader.GetOrdinal("is_completed"));
-
-                    if (!isCompleted)
-                    {
-                        cancelledKeys.Add(new ReminderKey(reminderKey));
-                    }
+                    cancelledKeys.Add(new ReminderKey(reader.GetString(reader.GetOrdinal("reminder_key"))));
                 }
             }
 
             if (cancelledKeys.Count == 0)
-            {
-                return new ReminderProtocol.RemindersCancelled(
-                    entity,
-                    ReminderCancelResponseCode.NotFound,
-                    new List<ReminderKey>(),
-                    null);
-            }
+                return new ReminderProtocol.RemindersCancelled(entity, ReminderCancelResponseCode.NotFound, []);
 
             await using var command = connection.CreateCommand();
             command.CommandText = _dialect.GetCancelAllRemindersSql(_settings.SchemaName, _settings.TableName);
             command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
             _dialect.AddParameter(command, "@ShardRegionName", entity.ShardRegionName);
             _dialect.AddParameter(command, "@EntityId", entity.EntityId);
-            _dialect.AddParameter(command, "@CompletedAtUtc", DateTimeOffset.UtcNow.UtcDateTime);
-
+            _dialect.AddParameter(command, "@CompletedAtUtc", TruncateToMicroseconds(DateTimeOffset.UtcNow));
             await command.ExecuteNonQueryAsync(cancellationToken);
 
-            return new ReminderProtocol.RemindersCancelled(
-                entity,
-                ReminderCancelResponseCode.Success,
-                cancelledKeys,
-                null);
+            return new ReminderProtocol.RemindersCancelled(entity, ReminderCancelResponseCode.Success, cancelledKeys.ToList());
         }
         catch (Exception ex)
         {
-            return new ReminderProtocol.RemindersCancelled(
-                entity,
-                ReminderCancelResponseCode.Error,
-                new List<ReminderKey>(),
-                ex.Message);
+            return new ReminderProtocol.RemindersCancelled(entity, ReminderCancelResponseCode.Error, [], ex.Message);
         }
     }
 
-    public async Task<IReadOnlyList<ScheduledReminder>> GetRemindersForEntityAsync(
-        ReminderEntity entity,
-        int take = 10,
-        int skip = 0,
-        CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<ScheduledReminder>> GetRemindersForEntityAsync(ReminderEntity entity, int take = 10, int skip = 0, CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
-
         var reminders = new List<ScheduledReminder>();
-
         await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
         await connection.OpenAsync(cancellationToken);
-
         await using var command = connection.CreateCommand();
         command.CommandText = _dialect.GetFetchRemindersSql(_settings.SchemaName, _settings.TableName);
         command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
         _dialect.AddParameter(command, "@ShardRegionName", entity.ShardRegionName);
         _dialect.AddParameter(command, "@EntityId", entity.EntityId);
+        _dialect.AddParameter(command, "@Now", TruncateToMicroseconds(DateTimeOffset.UtcNow));
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
-
         while (await reader.ReadAsync(cancellationToken))
         {
-            var reminder = ReadReminderFromReader(reader);
-            reminders.Add(reminder);
+            reminders.Add(ReadReminderFromReader(reader));
         }
 
         return reminders.Skip(skip).Take(take).ToList();
     }
 
-    public async Task<bool> MarkRemindersAsAwaitingAckAsync(
-        IEnumerable<AwaitingAckReminder> reminders,
-        CancellationToken cancellationToken = default)
+    public async Task<bool> MarkRemindersAsAwaitingAckAsync(IEnumerable<AwaitingAckReminder> reminders, CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
-
         var remindersList = reminders.ToList();
         if (remindersList.Count == 0)
             return true;
@@ -429,116 +386,75 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
         {
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
-
-            foreach (var reminder in remindersList)
+            for (var offset = 0; offset < remindersList.Count; offset += MaxRemindersPerStatusUpdate)
             {
+                var chunk = remindersList.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
                 await using var command = connection.CreateCommand();
-                command.CommandText = _dialect.GetMarkAsAwaitingAckSql(_settings.SchemaName, _settings.TableName);
+                command.CommandText = _dialect.GetBatchMarkAsAwaitingAckSql(_settings.SchemaName, _settings.TableName, chunk.Count);
                 command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
 
-                _dialect.AddParameter(command, "@ShardRegionName", reminder.Entity.ShardRegionName);
-                _dialect.AddParameter(command, "@EntityId", reminder.Entity.EntityId);
-                _dialect.AddParameter(command, "@ReminderKey", reminder.Key.Name);
-                _dialect.AddParameter(command, "@DeliveredAtUtc", TruncateToMicroseconds(reminder.DeliveredAt));
-                _dialect.AddParameter(command, "@AckDeadlineUtc", TruncateToMicroseconds(reminder.AckDeadline));
+                for (var i = 0; i < chunk.Count; i++)
+                {
+                    _dialect.AddParameter(command, $"@sr{i}", chunk[i].Entity.ShardRegionName);
+                    _dialect.AddParameter(command, $"@eid{i}", chunk[i].Entity.EntityId);
+                    _dialect.AddParameter(command, $"@rk{i}", chunk[i].Key.Name);
+                    _dialect.AddParameter(command, $"@due{i}", TruncateToMicroseconds(chunk[i].DueTimeUtc));
+                    _dialect.AddParameter(command, $"@del{i}", TruncateToMicroseconds(chunk[i].DeliveredAt));
+                    _dialect.AddParameter(command, $"@ack{i}", TruncateToMicroseconds(chunk[i].AckDeadline));
+                }
 
                 await command.ExecuteNonQueryAsync(cancellationToken);
             }
 
             return true;
         }
-        catch (Exception)
+        catch
         {
             return false;
         }
     }
 
-    public async Task<IReadOnlyList<ScheduledReminder>> GetTimedOutAckRemindersAsync(
-        DateTimeOffset now,
-        ReminderBatchSize maxCount,
-        CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<ScheduledReminder>> GetTimedOutAckRemindersAsync(DateTimeOffset now, ReminderBatchSize maxCount, CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
-
         var reminders = new List<ScheduledReminder>();
-
         await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
         await connection.OpenAsync(cancellationToken);
-
         await using var command = connection.CreateCommand();
-        command.CommandText = _dialect.GetTimedOutAckRemindersSql(
-            _settings.SchemaName, _settings.TableName, maxCount.Value);
+        command.CommandText = _dialect.GetTimedOutAckRemindersSql(_settings.SchemaName, _settings.TableName, maxCount.Value);
         command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
         _dialect.AddParameter(command, "@Now", TruncateToMicroseconds(now));
-
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
-
         while (await reader.ReadAsync(cancellationToken))
         {
-            var reminder = ReadReminderFromReader(reader);
-            reminders.Add(reminder);
+            reminders.Add(ReadReminderFromReader(reader));
         }
 
         return reminders;
     }
 
-    public async Task<AckResult> AcknowledgeReminderAsync(
-        ReminderEntity entity,
-        ReminderKey key,
-        DateTimeOffset ackedAt,
-        CancellationToken cancellationToken = default)
+    public async Task<AckResult> AcknowledgeReminderAsync(ReminderEntity entity, ReminderKey key, DateTimeOffset dueTimeUtc, DateTimeOffset ackedAt, CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
-
         try
         {
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
-
             await using var command = connection.CreateCommand();
             command.CommandText = _dialect.GetAcknowledgeReminderSql(_settings.SchemaName, _settings.TableName);
             command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
             _dialect.AddParameter(command, "@ShardRegionName", entity.ShardRegionName);
             _dialect.AddParameter(command, "@EntityId", entity.EntityId);
             _dialect.AddParameter(command, "@ReminderKey", key.Name);
+            _dialect.AddParameter(command, "@DueTimeUtc", TruncateToMicroseconds(dueTimeUtc));
             _dialect.AddParameter(command, "@AckedAtUtc", TruncateToMicroseconds(ackedAt));
-
-            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
-
-            if (!await reader.ReadAsync(cancellationToken))
-            {
-                // No row updated — reminder was not in AwaitingAck state
-                return new AckResult(Success: false, IsRecurring: false, OriginalReminder: null);
-            }
-
-            var original = ReadReminderFromReader(reader);
-            var isRecurring = original.RepeatInterval.HasValue;
-
-            return new AckResult(
-                Success: true,
-                IsRecurring: isRecurring,
-                OriginalReminder: isRecurring ? original : null);
+            var count = await command.ExecuteNonQueryAsync(cancellationToken);
+            return new AckResult(count > 0);
         }
-        catch (Exception)
+        catch
         {
-            return new AckResult(Success: false, IsRecurring: false, OriginalReminder: null);
+            return new AckResult(false);
         }
-    }
-
-    public async Task<int> ResetAwaitingAckToPendingAsync(CancellationToken cancellationToken = default)
-    {
-        await EnsureInitializedAsync(cancellationToken);
-
-        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
-        await connection.OpenAsync(cancellationToken);
-
-        await using var command = connection.CreateCommand();
-        command.CommandText = _dialect.GetResetAwaitingAckSql(_settings.SchemaName, _settings.TableName);
-        command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
-        return await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
     private Task EnsureInitializedAsync(CancellationToken cancellationToken)
@@ -555,11 +471,9 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
             {
                 await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
                 await connection.OpenAsync(cancellationToken);
-
                 await using var command = connection.CreateCommand();
                 command.CommandText = _dialect.GetCreateTableSql(_settings.SchemaName, _settings.TableName);
                 command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
                 await command.ExecuteNonQueryAsync(cancellationToken);
             }, cancellationToken).Wait(cancellationToken);
 
@@ -569,12 +483,40 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
         return Task.CompletedTask;
     }
 
+    private ScheduledReminder NormalizeReminder(ScheduledReminder reminder)
+    {
+        var when = TruncateToMicroseconds(reminder.When);
+        var due = TruncateToMicroseconds(reminder.DueTimeUtc);
+        DateTimeOffset? deadline = reminder.DeliveryDeadlineUtc.HasValue
+            ? TruncateToMicroseconds(reminder.DeliveryDeadlineUtc.Value)
+            : null;
+        return reminder with { When = when, DeliveryDeadlineUtc = deadline, OccurrenceDueTimeUtc = due };
+    }
+
+    private void BindReminderParameters(System.Data.Common.DbCommand command, int index, ScheduledReminder reminder)
+    {
+        var (serializerId, manifest, payload) = SerializeMessage(reminder.Message);
+
+        _dialect.AddParameter(command, $"@ShardRegionName{index}", reminder.Entity.ShardRegionName);
+        _dialect.AddParameter(command, $"@EntityId{index}", reminder.Entity.EntityId);
+        _dialect.AddParameter(command, $"@ReminderKey{index}", reminder.Key.Name);
+        _dialect.AddParameter(command, $"@WhenUtc{index}", TruncateToMicroseconds(reminder.When));
+        _dialect.AddParameter(command, $"@DueTimeUtc{index}", TruncateToMicroseconds(reminder.DueTimeUtc));
+        _dialect.AddParameter(command, $"@RepeatIntervalTicks{index}", reminder.RepeatInterval?.Ticks ?? (object)DBNull.Value);
+        _dialect.AddParameter(command, $"@SerializerId{index}", serializerId);
+        _dialect.AddParameter(command, $"@Manifest{index}", manifest ?? (object)DBNull.Value);
+        _dialect.AddParameter(command, $"@Payload{index}", payload);
+        _dialect.AddParameter(command, $"@AttemptCount{index}", reminder.AttemptCount);
+        _dialect.AddParameter(command, $"@LastFailureReason{index}", reminder.LastFailureReason ?? (object)DBNull.Value);
+        _dialect.AddParameter(command, $"@MaxDeliveryWindowTicks{index}", reminder.MaxDeliveryWindow?.Ticks ?? (object)DBNull.Value);
+        _dialect.AddParameter(command, $"@DeliveryDeadlineUtc{index}", reminder.DeliveryDeadlineUtc.HasValue ? TruncateToMicroseconds(reminder.DeliveryDeadlineUtc.Value) : (object)DBNull.Value);
+    }
+
     private (int serializerId, string? manifest, byte[] payload) SerializeMessage(object message)
     {
         var serializer = _serialization.FindSerializerFor(message);
         var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, message);
         var payload = serializer.ToBinary(message);
-
         return (serializer.Identifier, manifest, payload);
     }
 
@@ -589,6 +531,7 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
         var entityId = reader.GetString(reader.GetOrdinal("entity_id"));
         var reminderKey = reader.GetString(reader.GetOrdinal("reminder_key"));
         var whenUtc = reader.GetDateTime(reader.GetOrdinal("when_utc"));
+        var dueTimeUtc = reader.GetDateTime(reader.GetOrdinal("due_time_utc"));
 
         var repeatIntervalTicksOrdinal = reader.GetOrdinal("repeat_interval_ticks");
         var repeatInterval = reader.IsDBNull(repeatIntervalTicksOrdinal)
@@ -596,17 +539,23 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
             : TimeSpan.FromTicks(reader.GetInt64(repeatIntervalTicksOrdinal));
 
         var serializerId = reader.GetInt32(reader.GetOrdinal("serializer_id"));
-
         var manifestOrdinal = reader.GetOrdinal("manifest");
         var manifest = reader.IsDBNull(manifestOrdinal) ? null : reader.GetString(manifestOrdinal);
-
         var payload = (byte[])reader.GetValue(reader.GetOrdinal("payload"));
         var attemptCount = reader.GetInt32(reader.GetOrdinal("attempt_count"));
 
         var lastFailureReasonOrdinal = reader.GetOrdinal("last_failure_reason");
-        var lastFailureReason = reader.IsDBNull(lastFailureReasonOrdinal)
-            ? null
-            : reader.GetString(lastFailureReasonOrdinal);
+        var lastFailureReason = reader.IsDBNull(lastFailureReasonOrdinal) ? null : reader.GetString(lastFailureReasonOrdinal);
+
+        var maxWindowOrdinal = reader.GetOrdinal("max_delivery_window_ticks");
+        var maxDeliveryWindow = reader.IsDBNull(maxWindowOrdinal)
+            ? (TimeSpan?)null
+            : TimeSpan.FromTicks(reader.GetInt64(maxWindowOrdinal));
+
+        var deadlineOrdinal = reader.GetOrdinal("delivery_deadline_utc");
+        var deliveryDeadlineUtc = reader.IsDBNull(deadlineOrdinal)
+            ? (DateTimeOffset?)null
+            : new DateTimeOffset(DateTime.SpecifyKind(reader.GetDateTime(deadlineOrdinal), DateTimeKind.Utc));
 
         var message = DeserializeMessage(serializerId, manifest, payload);
 
@@ -617,6 +566,9 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
             message,
             repeatInterval,
             attemptCount,
-            lastFailureReason);
+            lastFailureReason,
+            maxDeliveryWindow,
+            deliveryDeadlineUtc,
+            new DateTimeOffset(DateTime.SpecifyKind(dueTimeUtc, DateTimeKind.Utc)));
     }
 }

--- a/src/Akka.Reminders.PostgreSql/PostgreSqlReminderStorage.cs
+++ b/src/Akka.Reminders.PostgreSql/PostgreSqlReminderStorage.cs
@@ -437,6 +437,21 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
         return reminders;
     }
 
+    public async Task<DateTimeOffset?> GetNextAwaitingAckDeadlineAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT MIN(ack_deadline_utc) FROM \"" + _settings.SchemaName + "\".\"" + _settings.TableName + "\" WHERE completion_status = 'AwaitingAck' AND is_completed = FALSE;";
+        command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+
+        return result is DateTime next
+            ? new DateTimeOffset(DateTime.SpecifyKind(next, DateTimeKind.Utc))
+            : (DateTimeOffset?)null;
+    }
+
     public async Task<AckResult> AcknowledgeReminderAsync(ReminderEntity entity, ReminderKey key, DateTimeOffset dueTimeUtc, DateTimeOffset ackedAt, CancellationToken cancellationToken = default)
         => (await AcknowledgeRemindersAsync([new ReminderAcknowledgement(entity, key, dueTimeUtc, ackedAt)], cancellationToken))[0];
 
@@ -445,40 +460,19 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
         CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
-        var results = new List<AckResult>();
+        var normalizedAcknowledgements = acknowledgements.Select(NormalizeAcknowledgement).ToList();
+        var results = new List<AckResult>(normalizedAcknowledgements.Count);
+
+        if (normalizedAcknowledgements.Count == 0)
+            return results;
 
         await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
         await connection.OpenAsync(cancellationToken);
 
-        foreach (var acknowledgement in acknowledgements.Select(NormalizeAcknowledgement))
+        for (var offset = 0; offset < normalizedAcknowledgements.Count; offset += MaxRemindersPerStatusUpdate)
         {
-            try
-            {
-                await using var command = CreateCommand(connection, null);
-                command.CommandText = _dialect.GetAcknowledgeReminderSql(_settings.SchemaName, _settings.TableName);
-                command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-                _dialect.AddParameter(command, "@ShardRegionName", acknowledgement.Entity.ShardRegionName);
-                _dialect.AddParameter(command, "@EntityId", acknowledgement.Entity.EntityId);
-                _dialect.AddParameter(command, "@ReminderKey", acknowledgement.Key.Name);
-                _dialect.AddParameter(command, "@DueTimeUtc", acknowledgement.DueTimeUtc);
-                _dialect.AddParameter(command, "@AckedAtUtc", acknowledgement.AckedAt);
-                var count = await command.ExecuteNonQueryAsync(cancellationToken);
-                results.Add(new AckResult(
-                    acknowledgement.Entity,
-                    acknowledgement.Key,
-                    acknowledgement.DueTimeUtc,
-                    count > 0 ? ReminderAckStorageStatus.Success : ReminderAckStorageStatus.NotFound,
-                    count > 0 ? null : "Reminder occurrence was not awaiting acknowledgement or was already stale."));
-            }
-            catch (Exception ex)
-            {
-                results.Add(new AckResult(
-                    acknowledgement.Entity,
-                    acknowledgement.Key,
-                    acknowledgement.DueTimeUtc,
-                    ReminderAckStorageStatus.Error,
-                    ex.Message));
-            }
+            var chunk = normalizedAcknowledgements.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
+            results.AddRange(await AcknowledgeReminderChunkAsync(connection, chunk, cancellationToken));
         }
 
         return results;
@@ -541,6 +535,103 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
             DueTimeUtc = TruncateToMicroseconds(acknowledgement.DueTimeUtc),
             AckedAt = TruncateToMicroseconds(acknowledgement.AckedAt)
         };
+
+    private async Task<IReadOnlyList<AckResult>> AcknowledgeReminderChunkAsync(
+        System.Data.Common.DbConnection connection,
+        IReadOnlyList<ReminderAcknowledgement> acknowledgements,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+            await using var command = CreateCommand(connection, transaction);
+            command.CommandText = _dialect.GetBatchAcknowledgeRemindersSql(_settings.SchemaName, _settings.TableName, acknowledgements.Count);
+            command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+            for (var i = 0; i < acknowledgements.Count; i++)
+            {
+                var acknowledgement = acknowledgements[i];
+                _dialect.AddParameter(command, $"@sr{i}", acknowledgement.Entity.ShardRegionName);
+                _dialect.AddParameter(command, $"@eid{i}", acknowledgement.Entity.EntityId);
+                _dialect.AddParameter(command, $"@rk{i}", acknowledgement.Key.Name);
+                _dialect.AddParameter(command, $"@due{i}", acknowledgement.DueTimeUtc);
+                _dialect.AddParameter(command, $"@acked{i}", acknowledgement.AckedAt);
+            }
+
+            var updated = await command.ExecuteNonQueryAsync(cancellationToken);
+            if (updated == acknowledgements.Count)
+            {
+                await transaction.CommitAsync(cancellationToken);
+                return acknowledgements.Select(ToSuccessfulAckResult).ToList();
+            }
+
+            await transaction.RollbackAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            return acknowledgements.Select(a => new AckResult(
+                a.Entity,
+                a.Key,
+                a.DueTimeUtc,
+                ReminderAckStorageStatus.Error,
+                ex.Message)).ToList();
+        }
+
+        return await AcknowledgeRemindersIndividuallyAsync(connection, acknowledgements, cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<AckResult>> AcknowledgeRemindersIndividuallyAsync(
+        System.Data.Common.DbConnection connection,
+        IReadOnlyList<ReminderAcknowledgement> acknowledgements,
+        CancellationToken cancellationToken)
+    {
+        var results = new List<AckResult>(acknowledgements.Count);
+
+        foreach (var acknowledgement in acknowledgements)
+        {
+            try
+            {
+                await using var command = CreateCommand(connection, null);
+                command.CommandText = _dialect.GetAcknowledgeReminderSql(_settings.SchemaName, _settings.TableName);
+                command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+                _dialect.AddParameter(command, "@ShardRegionName", acknowledgement.Entity.ShardRegionName);
+                _dialect.AddParameter(command, "@EntityId", acknowledgement.Entity.EntityId);
+                _dialect.AddParameter(command, "@ReminderKey", acknowledgement.Key.Name);
+                _dialect.AddParameter(command, "@DueTimeUtc", acknowledgement.DueTimeUtc);
+                _dialect.AddParameter(command, "@AckedAtUtc", acknowledgement.AckedAt);
+                var count = await command.ExecuteNonQueryAsync(cancellationToken);
+                results.Add(count > 0
+                    ? ToSuccessfulAckResult(acknowledgement)
+                    : ToMissingAckResult(acknowledgement));
+            }
+            catch (Exception ex)
+            {
+                results.Add(new AckResult(
+                    acknowledgement.Entity,
+                    acknowledgement.Key,
+                    acknowledgement.DueTimeUtc,
+                    ReminderAckStorageStatus.Error,
+                    ex.Message));
+            }
+        }
+
+        return results;
+    }
+
+    private static AckResult ToSuccessfulAckResult(ReminderAcknowledgement acknowledgement)
+        => new(
+            acknowledgement.Entity,
+            acknowledgement.Key,
+            acknowledgement.DueTimeUtc,
+            ReminderAckStorageStatus.Success);
+
+    private static AckResult ToMissingAckResult(ReminderAcknowledgement acknowledgement)
+        => new(
+            acknowledgement.Entity,
+            acknowledgement.Key,
+            acknowledgement.DueTimeUtc,
+            ReminderAckStorageStatus.NotFound,
+            "Reminder occurrence was not awaiting acknowledgement or was already stale.");
 
     private async Task<bool> MarkRemindersAsCompletedAsync(
         System.Data.Common.DbConnection connection,

--- a/src/Akka.Reminders.PostgreSql/PostgreSqlReminderStorage.cs
+++ b/src/Akka.Reminders.PostgreSql/PostgreSqlReminderStorage.cs
@@ -415,6 +415,118 @@ public sealed class PostgreSqlReminderStorage : IReminderStorage
         return reminders.Skip(skip).Take(take).ToList();
     }
 
+    public async Task<bool> MarkRemindersAsAwaitingAckAsync(
+        IEnumerable<AwaitingAckReminder> reminders,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+
+        var remindersList = reminders.ToList();
+        if (remindersList.Count == 0)
+            return true;
+
+        try
+        {
+            await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            foreach (var reminder in remindersList)
+            {
+                await using var command = connection.CreateCommand();
+                command.CommandText = _dialect.GetMarkAsAwaitingAckSql(_settings.SchemaName, _settings.TableName);
+                command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+                _dialect.AddParameter(command, "@ShardRegionName", reminder.Entity.ShardRegionName);
+                _dialect.AddParameter(command, "@EntityId", reminder.Entity.EntityId);
+                _dialect.AddParameter(command, "@ReminderKey", reminder.Key.Name);
+                _dialect.AddParameter(command, "@DeliveredAtUtc", TruncateToMicroseconds(reminder.DeliveredAt));
+                _dialect.AddParameter(command, "@AckDeadlineUtc", TruncateToMicroseconds(reminder.AckDeadline));
+
+                await command.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    public async Task<IReadOnlyList<ScheduledReminder>> GetTimedOutAckRemindersAsync(
+        DateTimeOffset now,
+        ReminderBatchSize maxCount,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+
+        var reminders = new List<ScheduledReminder>();
+
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = _dialect.GetTimedOutAckRemindersSql(
+            _settings.SchemaName, _settings.TableName, maxCount.Value);
+        command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+        _dialect.AddParameter(command, "@Now", TruncateToMicroseconds(now));
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            var reminder = ReadReminderFromReader(reader);
+            reminders.Add(reminder);
+        }
+
+        return reminders;
+    }
+
+    public async Task<AckResult> AcknowledgeReminderAsync(
+        ReminderEntity entity,
+        ReminderKey key,
+        DateTimeOffset ackedAt,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = _dialect.GetAcknowledgeReminderSql(_settings.SchemaName, _settings.TableName);
+            command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+            _dialect.AddParameter(command, "@ShardRegionName", entity.ShardRegionName);
+            _dialect.AddParameter(command, "@EntityId", entity.EntityId);
+            _dialect.AddParameter(command, "@ReminderKey", key.Name);
+            _dialect.AddParameter(command, "@AckedAtUtc", TruncateToMicroseconds(ackedAt));
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+            if (!await reader.ReadAsync(cancellationToken))
+            {
+                // No row updated — reminder was not in AwaitingAck state
+                return new AckResult(Success: false, IsRecurring: false, OriginalReminder: null);
+            }
+
+            var original = ReadReminderFromReader(reader);
+            var isRecurring = original.RepeatInterval.HasValue;
+
+            return new AckResult(
+                Success: true,
+                IsRecurring: isRecurring,
+                OriginalReminder: isRecurring ? original : null);
+        }
+        catch (Exception)
+        {
+            return new AckResult(Success: false, IsRecurring: false, OriginalReminder: null);
+        }
+    }
+
     private Task EnsureInitializedAsync(CancellationToken cancellationToken)
     {
         if (_initialized || !_settings.AutoInitialize)

--- a/src/Akka.Reminders.PostgreSql/Scripts/Migrations/V0_6_0__add_ack_columns.sql
+++ b/src/Akka.Reminders.PostgreSql/Scripts/Migrations/V0_6_0__add_ack_columns.sql
@@ -1,14 +1,37 @@
--- Migration for Akka.Reminders 0.6.0: Add acknowledgement columns
--- Adds delivered_at_utc and ack_deadline_utc to support reliable at-least-once delivery.
+-- Migration for Akka.Reminders 0.6.0: Full schema upgrade from 0.5.x
+-- Adds due_time_utc, max_delivery_window_ticks, delivery_deadline_utc, delivered_at_utc,
+-- ack_deadline_utc columns; expands PK to include due_time_utc; updates indexes.
 --
--- This script is idempotent: IF NOT EXISTS guards prevent errors on repeated runs.
+-- This script is idempotent: IF NOT EXISTS / ADD COLUMN IF NOT EXISTS guards
+-- prevent errors on repeated runs.
 --
 -- Note: This script uses the default schema 'reminders' and table 'scheduled_reminders'.
 --       If you use a custom schema or table name, replace them accordingly.
 
+-- 1. Add the five new columns
+ALTER TABLE reminders.scheduled_reminders ADD COLUMN IF NOT EXISTS due_time_utc TIMESTAMP WITH TIME ZONE NULL;
+ALTER TABLE reminders.scheduled_reminders ADD COLUMN IF NOT EXISTS max_delivery_window_ticks BIGINT NULL;
+ALTER TABLE reminders.scheduled_reminders ADD COLUMN IF NOT EXISTS delivery_deadline_utc TIMESTAMP WITH TIME ZONE NULL;
 ALTER TABLE reminders.scheduled_reminders ADD COLUMN IF NOT EXISTS delivered_at_utc TIMESTAMP WITH TIME ZONE NULL;
 ALTER TABLE reminders.scheduled_reminders ADD COLUMN IF NOT EXISTS ack_deadline_utc TIMESTAMP WITH TIME ZONE NULL;
 
+-- 2. Backfill due_time_utc from when_utc for existing rows, then make NOT NULL
+UPDATE reminders.scheduled_reminders SET due_time_utc = when_utc WHERE due_time_utc IS NULL;
+ALTER TABLE reminders.scheduled_reminders ALTER COLUMN due_time_utc SET NOT NULL;
+
+-- 3. Recreate primary key to include due_time_utc
+--    Drop the old PK (region, entity, key) and create the new one (region, entity, key, due_time_utc)
+ALTER TABLE reminders.scheduled_reminders DROP CONSTRAINT IF EXISTS pk_scheduled_reminders;
+ALTER TABLE reminders.scheduled_reminders
+    ADD CONSTRAINT pk_scheduled_reminders PRIMARY KEY (shard_region_name, entity_id, reminder_key, due_time_utc);
+
+-- 4. Recreate the due-reminders index with updated filter
+DROP INDEX IF EXISTS reminders.ix_scheduled_reminders_due_reminders;
+CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_due_reminders
+ON reminders.scheduled_reminders (when_utc, shard_region_name, entity_id)
+WHERE is_completed = FALSE AND completion_status = 'Pending';
+
+-- 5. Create the awaiting-ack index
 CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_awaiting_ack
 ON reminders.scheduled_reminders (ack_deadline_utc)
-WHERE completion_status = 'AwaitingAck';
+WHERE completion_status = 'AwaitingAck' AND is_completed = FALSE;

--- a/src/Akka.Reminders.PostgreSql/Scripts/Migrations/V0_6_0__add_ack_columns.sql
+++ b/src/Akka.Reminders.PostgreSql/Scripts/Migrations/V0_6_0__add_ack_columns.sql
@@ -1,0 +1,14 @@
+-- Migration for Akka.Reminders 0.6.0: Add acknowledgement columns
+-- Adds delivered_at_utc and ack_deadline_utc to support reliable at-least-once delivery.
+--
+-- This script is idempotent: IF NOT EXISTS guards prevent errors on repeated runs.
+--
+-- Note: This script uses the default schema 'reminders' and table 'scheduled_reminders'.
+--       If you use a custom schema or table name, replace them accordingly.
+
+ALTER TABLE reminders.scheduled_reminders ADD COLUMN IF NOT EXISTS delivered_at_utc TIMESTAMP WITH TIME ZONE NULL;
+ALTER TABLE reminders.scheduled_reminders ADD COLUMN IF NOT EXISTS ack_deadline_utc TIMESTAMP WITH TIME ZONE NULL;
+
+CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_awaiting_ack
+ON reminders.scheduled_reminders (ack_deadline_utc)
+WHERE completion_status = 'AwaitingAck';

--- a/src/Akka.Reminders.PostgreSql/Scripts/PostgreSql-Create.sql
+++ b/src/Akka.Reminders.PostgreSql/Scripts/PostgreSql-Create.sql
@@ -17,25 +17,28 @@ CREATE TABLE IF NOT EXISTS reminders.scheduled_reminders (
     entity_id VARCHAR(255) NOT NULL,
     reminder_key VARCHAR(255) NOT NULL,
     when_utc TIMESTAMP WITH TIME ZONE NOT NULL,
+    due_time_utc TIMESTAMP WITH TIME ZONE NOT NULL,
     repeat_interval_ticks BIGINT NULL,
     serializer_id INTEGER NOT NULL,
     manifest VARCHAR(500) NULL,
     payload BYTEA NOT NULL,
     attempt_count INTEGER NOT NULL DEFAULT 0,
     last_failure_reason TEXT NULL,
+    max_delivery_window_ticks BIGINT NULL,
+    delivery_deadline_utc TIMESTAMP WITH TIME ZONE NULL,
     is_completed BOOLEAN NOT NULL DEFAULT FALSE,
     completed_at_utc TIMESTAMP WITH TIME ZONE NULL,
     completion_status VARCHAR(20) NOT NULL DEFAULT 'Pending',
     delivered_at_utc TIMESTAMP WITH TIME ZONE NULL,
     ack_deadline_utc TIMESTAMP WITH TIME ZONE NULL,
 
-    CONSTRAINT pk_scheduled_reminders PRIMARY KEY (shard_region_name, entity_id, reminder_key)
+    CONSTRAINT pk_scheduled_reminders PRIMARY KEY (shard_region_name, entity_id, reminder_key, due_time_utc)
 );
 
 -- Create filtered index for efficient queries on pending reminders
 CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_due_reminders
 ON reminders.scheduled_reminders (when_utc, shard_region_name, entity_id)
-WHERE is_completed = FALSE;
+WHERE is_completed = FALSE AND completion_status = 'Pending';
 
 -- Create index for cleanup operations
 CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_cleanup
@@ -45,7 +48,7 @@ WHERE is_completed = TRUE;
 -- Create filtered index for efficient ack timeout scanning
 CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_awaiting_ack
 ON reminders.scheduled_reminders (ack_deadline_utc)
-WHERE completion_status = 'AwaitingAck';
+WHERE completion_status = 'AwaitingAck' AND is_completed = FALSE;
 
 -- Display confirmation
 DO $$

--- a/src/Akka.Reminders.PostgreSql/Scripts/PostgreSql-Create.sql
+++ b/src/Akka.Reminders.PostgreSql/Scripts/PostgreSql-Create.sql
@@ -26,6 +26,8 @@ CREATE TABLE IF NOT EXISTS reminders.scheduled_reminders (
     is_completed BOOLEAN NOT NULL DEFAULT FALSE,
     completed_at_utc TIMESTAMP WITH TIME ZONE NULL,
     completion_status VARCHAR(20) NOT NULL DEFAULT 'Pending',
+    delivered_at_utc TIMESTAMP WITH TIME ZONE NULL,
+    ack_deadline_utc TIMESTAMP WITH TIME ZONE NULL,
 
     CONSTRAINT pk_scheduled_reminders PRIMARY KEY (shard_region_name, entity_id, reminder_key)
 );
@@ -39,6 +41,11 @@ WHERE is_completed = FALSE;
 CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_cleanup
 ON reminders.scheduled_reminders (completed_at_utc)
 WHERE is_completed = TRUE;
+
+-- Create filtered index for efficient ack timeout scanning
+CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_awaiting_ack
+ON reminders.scheduled_reminders (ack_deadline_utc)
+WHERE completion_status = 'AwaitingAck';
 
 -- Display confirmation
 DO $$

--- a/src/Akka.Reminders.Sql/SqlReminderStorage.cs
+++ b/src/Akka.Reminders.Sql/SqlReminderStorage.cs
@@ -32,6 +32,11 @@ public sealed class SqlReminderStorage : IReminderStorage
         CancellationToken cancellationToken = default)
         => _storage.ScheduleReminderAsync(reminder, cancellationToken);
 
+    public Task<bool> UpsertReminderOccurrencesAsync(
+        IEnumerable<ScheduledReminder> reminders,
+        CancellationToken cancellationToken = default)
+        => _storage.UpsertReminderOccurrencesAsync(reminders, cancellationToken);
+
     public Task<ReminderProtocol.RemindersCancelled> CancelReminderAsync(
         ReminderEntity entity,
         ReminderKey key,
@@ -72,6 +77,11 @@ public sealed class SqlReminderStorage : IReminderStorage
         CancellationToken cancellationToken = default)
         => _storage.CleanUpCompletedRemindersAsync(olderThan, cancellationToken);
 
+    public Task<int> ExpireRemindersAsync(
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+        => _storage.ExpireRemindersAsync(now, cancellationToken);
+
     public Task<bool> MarkRemindersAsAwaitingAckAsync(
         IEnumerable<AwaitingAckReminder> reminders,
         CancellationToken ct = default)
@@ -86,10 +96,8 @@ public sealed class SqlReminderStorage : IReminderStorage
     public Task<AckResult> AcknowledgeReminderAsync(
         ReminderEntity entity,
         ReminderKey key,
+        DateTimeOffset dueTimeUtc,
         DateTimeOffset ackedAt,
         CancellationToken ct = default)
-        => _storage.AcknowledgeReminderAsync(entity, key, ackedAt, ct);
-
-    public Task<int> ResetAwaitingAckToPendingAsync(CancellationToken ct = default)
-        => _storage.ResetAwaitingAckToPendingAsync(ct);
+        => _storage.AcknowledgeReminderAsync(entity, key, dueTimeUtc, ackedAt, ct);
 }

--- a/src/Akka.Reminders.Sql/SqlReminderStorage.cs
+++ b/src/Akka.Reminders.Sql/SqlReminderStorage.cs
@@ -98,6 +98,9 @@ public sealed class SqlReminderStorage : IReminderStorage
         CancellationToken ct = default)
         => _storage.GetTimedOutAckRemindersAsync(now, maxCount, ct);
 
+    public Task<DateTimeOffset?> GetNextAwaitingAckDeadlineAsync(CancellationToken ct = default)
+        => _storage.GetNextAwaitingAckDeadlineAsync(ct);
+
     public Task<AckResult> AcknowledgeReminderAsync(
         ReminderEntity entity,
         ReminderKey key,

--- a/src/Akka.Reminders.Sql/SqlReminderStorage.cs
+++ b/src/Akka.Reminders.Sql/SqlReminderStorage.cs
@@ -71,4 +71,22 @@ public sealed class SqlReminderStorage : IReminderStorage
         DateTimeOffset olderThan,
         CancellationToken cancellationToken = default)
         => _storage.CleanUpCompletedRemindersAsync(olderThan, cancellationToken);
+
+    public Task<bool> MarkRemindersAsAwaitingAckAsync(
+        IEnumerable<AwaitingAckReminder> reminders,
+        CancellationToken ct = default)
+        => _storage.MarkRemindersAsAwaitingAckAsync(reminders, ct);
+
+    public Task<IReadOnlyList<ScheduledReminder>> GetTimedOutAckRemindersAsync(
+        DateTimeOffset now,
+        ReminderBatchSize maxCount,
+        CancellationToken ct = default)
+        => _storage.GetTimedOutAckRemindersAsync(now, maxCount, ct);
+
+    public Task<AckResult> AcknowledgeReminderAsync(
+        ReminderEntity entity,
+        ReminderKey key,
+        DateTimeOffset ackedAt,
+        CancellationToken ct = default)
+        => _storage.AcknowledgeReminderAsync(entity, key, ackedAt, ct);
 }

--- a/src/Akka.Reminders.Sql/SqlReminderStorage.cs
+++ b/src/Akka.Reminders.Sql/SqlReminderStorage.cs
@@ -37,6 +37,11 @@ public sealed class SqlReminderStorage : IReminderStorage
         CancellationToken cancellationToken = default)
         => _storage.UpsertReminderOccurrencesAsync(reminders, cancellationToken);
 
+    public Task<bool> CommitReminderMutationsAsync(
+        ReminderMutationBatch mutationBatch,
+        CancellationToken cancellationToken = default)
+        => _storage.CommitReminderMutationsAsync(mutationBatch, cancellationToken);
+
     public Task<ReminderProtocol.RemindersCancelled> CancelReminderAsync(
         ReminderEntity entity,
         ReminderKey key,
@@ -100,4 +105,9 @@ public sealed class SqlReminderStorage : IReminderStorage
         DateTimeOffset ackedAt,
         CancellationToken ct = default)
         => _storage.AcknowledgeReminderAsync(entity, key, dueTimeUtc, ackedAt, ct);
+
+    public Task<IReadOnlyList<AckResult>> AcknowledgeRemindersAsync(
+        IEnumerable<ReminderAcknowledgement> acknowledgements,
+        CancellationToken ct = default)
+        => _storage.AcknowledgeRemindersAsync(acknowledgements, ct);
 }

--- a/src/Akka.Reminders.Sql/SqlReminderStorage.cs
+++ b/src/Akka.Reminders.Sql/SqlReminderStorage.cs
@@ -89,4 +89,7 @@ public sealed class SqlReminderStorage : IReminderStorage
         DateTimeOffset ackedAt,
         CancellationToken ct = default)
         => _storage.AcknowledgeReminderAsync(entity, key, ackedAt, ct);
+
+    public Task<int> ResetAwaitingAckToPendingAsync(CancellationToken ct = default)
+        => _storage.ResetAwaitingAckToPendingAsync(ct);
 }

--- a/src/Akka.Reminders.SqlServer/Internal/ISqlDialect.cs
+++ b/src/Akka.Reminders.SqlServer/Internal/ISqlDialect.cs
@@ -18,6 +18,7 @@ internal interface ISqlDialect
     string GetBatchMarkAsAwaitingAckSql(string schemaName, string tableName, int count);
     string GetTimedOutAckRemindersSql(string schemaName, string tableName, int maxCount);
     string GetAcknowledgeReminderSql(string schemaName, string tableName);
+    string GetBatchAcknowledgeRemindersSql(string schemaName, string tableName, int count);
     DbConnection CreateConnection(string connectionString);
     void AddParameter(DbCommand command, string name, object value);
 }

--- a/src/Akka.Reminders.SqlServer/Internal/ISqlDialect.cs
+++ b/src/Akka.Reminders.SqlServer/Internal/ISqlDialect.cs
@@ -5,20 +5,19 @@ namespace Akka.Reminders.SqlServer.Internal;
 internal interface ISqlDialect
 {
     string GetCreateTableSql(string schemaName, string tableName);
-    string GetUpsertReminderSql(string schemaName, string tableName);
+    string GetBatchUpsertRemindersSql(string schemaName, string tableName, int count);
     string GetSelectDueRemindersSql(string schemaName, string tableName, int maxCount);
-    string GetMarkCompletedSql(string schemaName, string tableName);
     string GetBatchMarkCompletedSql(string schemaName, string tableName, int count);
+    string GetExpireRemindersSql(string schemaName, string tableName);
     string GetCleanupSql(string schemaName, string tableName);
     string GetOverviewAggregateSql(string schemaName, string tableName);
     string GetNextReminderTimeSql(string schemaName, string tableName);
     string GetCancelReminderSql(string schemaName, string tableName);
     string GetCancelAllRemindersSql(string schemaName, string tableName);
     string GetFetchRemindersSql(string schemaName, string tableName);
-    string GetMarkAsAwaitingAckSql(string schemaName, string tableName);
+    string GetBatchMarkAsAwaitingAckSql(string schemaName, string tableName, int count);
     string GetTimedOutAckRemindersSql(string schemaName, string tableName, int maxCount);
     string GetAcknowledgeReminderSql(string schemaName, string tableName);
-    string GetResetAwaitingAckSql(string schemaName, string tableName);
     DbConnection CreateConnection(string connectionString);
     void AddParameter(DbCommand command, string name, object value);
 }

--- a/src/Akka.Reminders.SqlServer/Internal/ISqlDialect.cs
+++ b/src/Akka.Reminders.SqlServer/Internal/ISqlDialect.cs
@@ -15,6 +15,9 @@ internal interface ISqlDialect
     string GetCancelReminderSql(string schemaName, string tableName);
     string GetCancelAllRemindersSql(string schemaName, string tableName);
     string GetFetchRemindersSql(string schemaName, string tableName);
+    string GetMarkAsAwaitingAckSql(string schemaName, string tableName);
+    string GetTimedOutAckRemindersSql(string schemaName, string tableName, int maxCount);
+    string GetAcknowledgeReminderSql(string schemaName, string tableName);
     DbConnection CreateConnection(string connectionString);
     void AddParameter(DbCommand command, string name, object value);
 }

--- a/src/Akka.Reminders.SqlServer/Internal/ISqlDialect.cs
+++ b/src/Akka.Reminders.SqlServer/Internal/ISqlDialect.cs
@@ -18,6 +18,7 @@ internal interface ISqlDialect
     string GetMarkAsAwaitingAckSql(string schemaName, string tableName);
     string GetTimedOutAckRemindersSql(string schemaName, string tableName, int maxCount);
     string GetAcknowledgeReminderSql(string schemaName, string tableName);
+    string GetResetAwaitingAckSql(string schemaName, string tableName);
     DbConnection CreateConnection(string connectionString);
     void AddParameter(DbCommand command, string name, object value);
 }

--- a/src/Akka.Reminders.SqlServer/Internal/SqlServerDialect.cs
+++ b/src/Akka.Reminders.SqlServer/Internal/SqlServerDialect.cs
@@ -38,6 +38,8 @@ internal sealed class SqlServerDialect : ISqlDialect
                     IsCompleted BIT NOT NULL DEFAULT 0,
                     CompletedAtUtc DATETIME2 NULL,
                     CompletionStatus VARCHAR(20) NOT NULL DEFAULT 'Pending',
+                    DeliveredAtUtc DATETIME2 NULL,
+                    AckDeadlineUtc DATETIME2 NULL,
 
                     CONSTRAINT PK_{tableName} PRIMARY KEY (ShardRegionName, EntityId, ReminderKey)
                 );
@@ -49,6 +51,10 @@ internal sealed class SqlServerDialect : ISqlDialect
                 CREATE INDEX IX_{tableName}_Cleanup
                 ON {fullTableName} (CompletedAtUtc)
                 WHERE IsCompleted = 1;
+
+                CREATE INDEX IX_{tableName}_AwaitingAck
+                ON {fullTableName} (AckDeadlineUtc)
+                WHERE CompletionStatus = 'AwaitingAck';
             END
             """;
     }
@@ -108,6 +114,7 @@ internal sealed class SqlServerDialect : ISqlDialect
                    SerializerId, Manifest, Payload, AttemptCount, LastFailureReason
             FROM {fullTableName}
             WHERE IsCompleted = 0
+              AND CompletionStatus = 'Pending'
               AND WhenUtc <= @UntilDeadline
             ORDER BY WhenUtc ASC;
             """;
@@ -229,6 +236,64 @@ internal sealed class SqlServerDialect : ISqlDialect
               AND EntityId = @EntityId
               AND IsCompleted = 0
             ORDER BY WhenUtc ASC;
+            """;
+    }
+
+    public string GetMarkAsAwaitingAckSql(string schemaName, string tableName)
+    {
+        var fullTableName = $"[{schemaName}].[{tableName}]";
+
+        return $"""
+            UPDATE {fullTableName}
+            SET CompletionStatus = 'AwaitingAck',
+                DeliveredAtUtc = @DeliveredAtUtc,
+                AckDeadlineUtc = @AckDeadlineUtc
+            WHERE ShardRegionName = @ShardRegionName
+              AND EntityId = @EntityId
+              AND ReminderKey = @ReminderKey
+              AND IsCompleted = 0;
+            """;
+    }
+
+    public string GetTimedOutAckRemindersSql(string schemaName, string tableName, int maxCount)
+    {
+        if (maxCount < 1)
+            throw new ArgumentOutOfRangeException(nameof(maxCount), "maxCount must be greater than or equal to 1.");
+
+        var fullTableName = $"[{schemaName}].[{tableName}]";
+
+        return $"""
+            SELECT TOP ({maxCount}) ShardRegionName, EntityId, ReminderKey, WhenUtc, RepeatIntervalTicks,
+                   SerializerId, Manifest, Payload, AttemptCount, LastFailureReason
+            FROM {fullTableName}
+            WHERE CompletionStatus = 'AwaitingAck'
+              AND IsCompleted = 0
+              AND AckDeadlineUtc <= @Now
+            ORDER BY AckDeadlineUtc ASC;
+            """;
+    }
+
+    public string GetAcknowledgeReminderSql(string schemaName, string tableName)
+    {
+        var fullTableName = $"[{schemaName}].[{tableName}]";
+
+        // SQL Server does not support a RETURNING / OUTPUT ... FROM UPDATE with a WHERE clause
+        // on the same table directly in older syntax, so we SELECT first then UPDATE.
+        // The storage layer will execute this as two statements within the same connection.
+        return $"""
+            UPDATE {fullTableName}
+            SET IsCompleted = 1,
+                CompletedAtUtc = @AckedAtUtc,
+                CompletionStatus = 'Delivered'
+            OUTPUT INSERTED.ShardRegionName, INSERTED.EntityId, INSERTED.ReminderKey,
+                   INSERTED.WhenUtc, INSERTED.RepeatIntervalTicks,
+                   INSERTED.SerializerId, INSERTED.Manifest, INSERTED.Payload,
+                   INSERTED.AttemptCount, INSERTED.LastFailureReason
+            WHERE ShardRegionName = @ShardRegionName
+              AND EntityId = @EntityId
+              AND ReminderKey = @ReminderKey
+              AND CompletionStatus = 'AwaitingAck'
+              AND IsCompleted = 0;
             """;
     }
 

--- a/src/Akka.Reminders.SqlServer/Internal/SqlServerDialect.cs
+++ b/src/Akka.Reminders.SqlServer/Internal/SqlServerDialect.cs
@@ -297,6 +297,20 @@ internal sealed class SqlServerDialect : ISqlDialect
             """;
     }
 
+    public string GetResetAwaitingAckSql(string schemaName, string tableName)
+    {
+        var fullTableName = $"[{schemaName}].[{tableName}]";
+
+        return $"""
+            UPDATE {fullTableName}
+            SET CompletionStatus = 'Pending',
+                DeliveredAtUtc = NULL,
+                AckDeadlineUtc = NULL
+            WHERE CompletionStatus = 'AwaitingAck'
+              AND IsCompleted = 0;
+            """;
+    }
+
     public DbConnection CreateConnection(string connectionString)
     {
         return new SqlConnection(connectionString);

--- a/src/Akka.Reminders.SqlServer/Internal/SqlServerDialect.cs
+++ b/src/Akka.Reminders.SqlServer/Internal/SqlServerDialect.cs
@@ -29,24 +29,27 @@ internal sealed class SqlServerDialect : ISqlDialect
                     EntityId NVARCHAR(255) NOT NULL,
                     ReminderKey NVARCHAR(255) NOT NULL,
                     WhenUtc DATETIME2 NOT NULL,
+                    DueTimeUtc DATETIME2 NOT NULL,
                     RepeatIntervalTicks BIGINT NULL,
                     SerializerId INT NOT NULL,
                     Manifest NVARCHAR(500) NULL,
                     Payload VARBINARY(MAX) NOT NULL,
                     AttemptCount INT NOT NULL DEFAULT 0,
                     LastFailureReason NVARCHAR(MAX) NULL,
+                    MaxDeliveryWindowTicks BIGINT NULL,
+                    DeliveryDeadlineUtc DATETIME2 NULL,
                     IsCompleted BIT NOT NULL DEFAULT 0,
                     CompletedAtUtc DATETIME2 NULL,
                     CompletionStatus VARCHAR(20) NOT NULL DEFAULT 'Pending',
                     DeliveredAtUtc DATETIME2 NULL,
                     AckDeadlineUtc DATETIME2 NULL,
 
-                    CONSTRAINT PK_{tableName} PRIMARY KEY (ShardRegionName, EntityId, ReminderKey)
+                    CONSTRAINT PK_{tableName} PRIMARY KEY (ShardRegionName, EntityId, ReminderKey, DueTimeUtc)
                 );
 
                 CREATE INDEX IX_{tableName}_DueReminders
                 ON {fullTableName} (WhenUtc, ShardRegionName, EntityId)
-                WHERE IsCompleted = 0;
+                WHERE IsCompleted = 0 AND CompletionStatus = 'Pending';
 
                 CREATE INDEX IX_{tableName}_Cleanup
                 ON {fullTableName} (CompletedAtUtc)
@@ -54,32 +57,29 @@ internal sealed class SqlServerDialect : ISqlDialect
 
                 CREATE INDEX IX_{tableName}_AwaitingAck
                 ON {fullTableName} (AckDeadlineUtc)
-                WHERE CompletionStatus = 'AwaitingAck';
+                WHERE CompletionStatus = 'AwaitingAck' AND IsCompleted = 0;
             END
             """;
     }
 
-    public string GetUpsertReminderSql(string schemaName, string tableName)
+    public string GetBatchUpsertRemindersSql(string schemaName, string tableName, int count)
     {
         var fullTableName = $"[{schemaName}].[{tableName}]";
+        var values = string.Join(",\n                ",
+            Enumerable.Range(0, count).Select(i =>
+                $"(@ShardRegionName{i}, @EntityId{i}, @ReminderKey{i}, @WhenUtc{i}, @DueTimeUtc{i}, @RepeatIntervalTicks{i}, @SerializerId{i}, @Manifest{i}, @Payload{i}, @AttemptCount{i}, @LastFailureReason{i}, @MaxDeliveryWindowTicks{i}, @DeliveryDeadlineUtc{i})"));
 
         return $"""
             MERGE {fullTableName} AS target
-            USING (SELECT
-                @ShardRegionName AS ShardRegionName,
-                @EntityId AS EntityId,
-                @ReminderKey AS ReminderKey,
-                @WhenUtc AS WhenUtc,
-                @RepeatIntervalTicks AS RepeatIntervalTicks,
-                @SerializerId AS SerializerId,
-                @Manifest AS Manifest,
-                @Payload AS Payload,
-                @AttemptCount AS AttemptCount,
-                @LastFailureReason AS LastFailureReason
-            ) AS source
+            USING (VALUES
+                {values}
+            ) AS source(ShardRegionName, EntityId, ReminderKey, WhenUtc, DueTimeUtc, RepeatIntervalTicks,
+                        SerializerId, Manifest, Payload, AttemptCount, LastFailureReason,
+                        MaxDeliveryWindowTicks, DeliveryDeadlineUtc)
             ON target.ShardRegionName = source.ShardRegionName
                AND target.EntityId = source.EntityId
                AND target.ReminderKey = source.ReminderKey
+               AND target.DueTimeUtc = source.DueTimeUtc
             WHEN MATCHED THEN
                 UPDATE SET
                     WhenUtc = source.WhenUtc,
@@ -89,16 +89,22 @@ internal sealed class SqlServerDialect : ISqlDialect
                     Payload = source.Payload,
                     AttemptCount = source.AttemptCount,
                     LastFailureReason = source.LastFailureReason,
+                    MaxDeliveryWindowTicks = source.MaxDeliveryWindowTicks,
+                    DeliveryDeadlineUtc = source.DeliveryDeadlineUtc,
                     IsCompleted = 0,
                     CompletedAtUtc = NULL,
-                    CompletionStatus = 'Pending'
+                    CompletionStatus = 'Pending',
+                    DeliveredAtUtc = NULL,
+                    AckDeadlineUtc = NULL
             WHEN NOT MATCHED THEN
-                INSERT (ShardRegionName, EntityId, ReminderKey, WhenUtc, RepeatIntervalTicks,
+                INSERT (ShardRegionName, EntityId, ReminderKey, WhenUtc, DueTimeUtc, RepeatIntervalTicks,
                         SerializerId, Manifest, Payload, AttemptCount, LastFailureReason,
-                        IsCompleted, CompletedAtUtc, CompletionStatus)
-                VALUES (source.ShardRegionName, source.EntityId, source.ReminderKey, source.WhenUtc,
+                        MaxDeliveryWindowTicks, DeliveryDeadlineUtc,
+                        IsCompleted, CompletedAtUtc, CompletionStatus, DeliveredAtUtc, AckDeadlineUtc)
+                VALUES (source.ShardRegionName, source.EntityId, source.ReminderKey, source.WhenUtc, source.DueTimeUtc,
                         source.RepeatIntervalTicks, source.SerializerId, source.Manifest, source.Payload,
-                        source.AttemptCount, source.LastFailureReason, 0, NULL, 'Pending');
+                        source.AttemptCount, source.LastFailureReason, source.MaxDeliveryWindowTicks,
+                        source.DeliveryDeadlineUtc, 0, NULL, 'Pending', NULL, NULL);
             """;
     }
 
@@ -110,51 +116,56 @@ internal sealed class SqlServerDialect : ISqlDialect
         var fullTableName = $"[{schemaName}].[{tableName}]";
 
         return $"""
-            SELECT TOP ({maxCount}) ShardRegionName, EntityId, ReminderKey, WhenUtc, RepeatIntervalTicks,
-                   SerializerId, Manifest, Payload, AttemptCount, LastFailureReason
+            SELECT TOP ({maxCount}) ShardRegionName, EntityId, ReminderKey, WhenUtc, DueTimeUtc, RepeatIntervalTicks,
+                   SerializerId, Manifest, Payload, AttemptCount, LastFailureReason,
+                   MaxDeliveryWindowTicks, DeliveryDeadlineUtc
             FROM {fullTableName}
             WHERE IsCompleted = 0
               AND CompletionStatus = 'Pending'
               AND WhenUtc <= @UntilDeadline
+              AND (DeliveryDeadlineUtc IS NULL OR DeliveryDeadlineUtc > @Now)
             ORDER BY WhenUtc ASC;
-            """;
-    }
-
-    public string GetMarkCompletedSql(string schemaName, string tableName)
-    {
-        var fullTableName = $"[{schemaName}].[{tableName}]";
-
-        return $"""
-            UPDATE {fullTableName}
-            SET IsCompleted = 1,
-                CompletedAtUtc = @CompletedAtUtc,
-                CompletionStatus = @CompletionStatus
-            WHERE ShardRegionName = @ShardRegionName
-              AND EntityId = @EntityId
-              AND ReminderKey = @ReminderKey;
             """;
     }
 
     public string GetBatchMarkCompletedSql(string schemaName, string tableName, int count)
     {
         var fullTableName = $"[{schemaName}].[{tableName}]";
-
         var values = string.Join(",\n                ",
-            Enumerable.Range(0, count).Select(i =>
-                $"(@sr{i}, @eid{i}, @rk{i})"));
+            Enumerable.Range(0, count).Select(i => $"(@sr{i}, @eid{i}, @rk{i}, @due{i})"));
 
         return $"""
             UPDATE t
             SET t.IsCompleted = 1,
                 t.CompletedAtUtc = @CompletedAtUtc,
-                t.CompletionStatus = @CompletionStatus
+                t.CompletionStatus = @CompletionStatus,
+                t.DeliveredAtUtc = NULL,
+                t.AckDeadlineUtc = NULL
             FROM {fullTableName} t
             INNER JOIN (VALUES
                 {values}
-            ) AS v(ShardRegionName, EntityId, ReminderKey)
+            ) AS v(ShardRegionName, EntityId, ReminderKey, DueTimeUtc)
             ON t.ShardRegionName = v.ShardRegionName
                AND t.EntityId = v.EntityId
-               AND t.ReminderKey = v.ReminderKey;
+               AND t.ReminderKey = v.ReminderKey
+               AND t.DueTimeUtc = v.DueTimeUtc;
+            """;
+    }
+
+    public string GetExpireRemindersSql(string schemaName, string tableName)
+    {
+        var fullTableName = $"[{schemaName}].[{tableName}]";
+
+        return $"""
+            UPDATE {fullTableName}
+            SET IsCompleted = 1,
+                CompletedAtUtc = @Now,
+                CompletionStatus = 'Expired',
+                DeliveredAtUtc = NULL,
+                AckDeadlineUtc = NULL
+            WHERE IsCompleted = 0
+              AND DeliveryDeadlineUtc IS NOT NULL
+              AND DeliveryDeadlineUtc <= @Now;
             """;
     }
 
@@ -176,7 +187,9 @@ internal sealed class SqlServerDialect : ISqlDialect
         return $"""
             SELECT COUNT(*) AS TotalCount, MIN(WhenUtc) AS NextWhenUtc
             FROM {fullTableName}
-            WHERE IsCompleted = 0;
+            WHERE IsCompleted = 0
+              AND CompletionStatus = 'Pending'
+              AND (DeliveryDeadlineUtc IS NULL OR DeliveryDeadlineUtc > @Now);
             """;
     }
 
@@ -188,6 +201,8 @@ internal sealed class SqlServerDialect : ISqlDialect
             SELECT WhenUtc
             FROM {fullTableName}
             WHERE IsCompleted = 0
+              AND CompletionStatus = 'Pending'
+              AND (DeliveryDeadlineUtc IS NULL OR DeliveryDeadlineUtc > @Now)
             ORDER BY WhenUtc ASC
             OFFSET @Skip ROWS FETCH NEXT 1 ROW ONLY;
             """;
@@ -201,7 +216,9 @@ internal sealed class SqlServerDialect : ISqlDialect
             UPDATE {fullTableName}
             SET IsCompleted = 1,
                 CompletedAtUtc = @CompletedAtUtc,
-                CompletionStatus = 'Cancelled'
+                CompletionStatus = 'Cancelled',
+                DeliveredAtUtc = NULL,
+                AckDeadlineUtc = NULL
             WHERE ShardRegionName = @ShardRegionName
               AND EntityId = @EntityId
               AND ReminderKey = @ReminderKey
@@ -217,7 +234,9 @@ internal sealed class SqlServerDialect : ISqlDialect
             UPDATE {fullTableName}
             SET IsCompleted = 1,
                 CompletedAtUtc = @CompletedAtUtc,
-                CompletionStatus = 'Cancelled'
+                CompletionStatus = 'Cancelled',
+                DeliveredAtUtc = NULL,
+                AckDeadlineUtc = NULL
             WHERE ShardRegionName = @ShardRegionName
               AND EntityId = @EntityId
               AND IsCompleted = 0;
@@ -229,29 +248,39 @@ internal sealed class SqlServerDialect : ISqlDialect
         var fullTableName = $"[{schemaName}].[{tableName}]";
 
         return $"""
-            SELECT ShardRegionName, EntityId, ReminderKey, WhenUtc, RepeatIntervalTicks,
-                   SerializerId, Manifest, Payload, AttemptCount, LastFailureReason, IsCompleted
+            SELECT ShardRegionName, EntityId, ReminderKey, WhenUtc, DueTimeUtc, RepeatIntervalTicks,
+                   SerializerId, Manifest, Payload, AttemptCount, LastFailureReason,
+                   MaxDeliveryWindowTicks, DeliveryDeadlineUtc
             FROM {fullTableName}
             WHERE ShardRegionName = @ShardRegionName
               AND EntityId = @EntityId
               AND IsCompleted = 0
+              AND (DeliveryDeadlineUtc IS NULL OR DeliveryDeadlineUtc > @Now)
             ORDER BY WhenUtc ASC;
             """;
     }
 
-    public string GetMarkAsAwaitingAckSql(string schemaName, string tableName)
+    public string GetBatchMarkAsAwaitingAckSql(string schemaName, string tableName, int count)
     {
         var fullTableName = $"[{schemaName}].[{tableName}]";
+        var values = string.Join(",\n                ",
+            Enumerable.Range(0, count).Select(i => $"(@sr{i}, @eid{i}, @rk{i}, @due{i}, @del{i}, @ack{i})"));
 
         return $"""
-            UPDATE {fullTableName}
-            SET CompletionStatus = 'AwaitingAck',
-                DeliveredAtUtc = @DeliveredAtUtc,
-                AckDeadlineUtc = @AckDeadlineUtc
-            WHERE ShardRegionName = @ShardRegionName
-              AND EntityId = @EntityId
-              AND ReminderKey = @ReminderKey
-              AND IsCompleted = 0;
+            UPDATE t
+            SET t.CompletionStatus = 'AwaitingAck',
+                t.DeliveredAtUtc = v.DeliveredAtUtc,
+                t.AckDeadlineUtc = v.AckDeadlineUtc
+            FROM {fullTableName} t
+            INNER JOIN (VALUES
+                {values}
+            ) AS v(ShardRegionName, EntityId, ReminderKey, DueTimeUtc, DeliveredAtUtc, AckDeadlineUtc)
+            ON t.ShardRegionName = v.ShardRegionName
+               AND t.EntityId = v.EntityId
+               AND t.ReminderKey = v.ReminderKey
+               AND t.DueTimeUtc = v.DueTimeUtc
+            WHERE t.IsCompleted = 0
+              AND t.CompletionStatus = 'Pending';
             """;
     }
 
@@ -263,8 +292,9 @@ internal sealed class SqlServerDialect : ISqlDialect
         var fullTableName = $"[{schemaName}].[{tableName}]";
 
         return $"""
-            SELECT TOP ({maxCount}) ShardRegionName, EntityId, ReminderKey, WhenUtc, RepeatIntervalTicks,
-                   SerializerId, Manifest, Payload, AttemptCount, LastFailureReason
+            SELECT TOP ({maxCount}) ShardRegionName, EntityId, ReminderKey, WhenUtc, DueTimeUtc, RepeatIntervalTicks,
+                   SerializerId, Manifest, Payload, AttemptCount, LastFailureReason,
+                   MaxDeliveryWindowTicks, DeliveryDeadlineUtc
             FROM {fullTableName}
             WHERE CompletionStatus = 'AwaitingAck'
               AND IsCompleted = 0
@@ -277,37 +307,20 @@ internal sealed class SqlServerDialect : ISqlDialect
     {
         var fullTableName = $"[{schemaName}].[{tableName}]";
 
-        // SQL Server does not support a RETURNING / OUTPUT ... FROM UPDATE with a WHERE clause
-        // on the same table directly in older syntax, so we SELECT first then UPDATE.
-        // The storage layer will execute this as two statements within the same connection.
         return $"""
             UPDATE {fullTableName}
             SET IsCompleted = 1,
                 CompletedAtUtc = @AckedAtUtc,
-                CompletionStatus = 'Delivered'
-            OUTPUT INSERTED.ShardRegionName, INSERTED.EntityId, INSERTED.ReminderKey,
-                   INSERTED.WhenUtc, INSERTED.RepeatIntervalTicks,
-                   INSERTED.SerializerId, INSERTED.Manifest, INSERTED.Payload,
-                   INSERTED.AttemptCount, INSERTED.LastFailureReason
+                CompletionStatus = 'Delivered',
+                DeliveredAtUtc = NULL,
+                AckDeadlineUtc = NULL
             WHERE ShardRegionName = @ShardRegionName
               AND EntityId = @EntityId
               AND ReminderKey = @ReminderKey
+              AND DueTimeUtc = @DueTimeUtc
               AND CompletionStatus = 'AwaitingAck'
-              AND IsCompleted = 0;
-            """;
-    }
-
-    public string GetResetAwaitingAckSql(string schemaName, string tableName)
-    {
-        var fullTableName = $"[{schemaName}].[{tableName}]";
-
-        return $"""
-            UPDATE {fullTableName}
-            SET CompletionStatus = 'Pending',
-                DeliveredAtUtc = NULL,
-                AckDeadlineUtc = NULL
-            WHERE CompletionStatus = 'AwaitingAck'
-              AND IsCompleted = 0;
+              AND IsCompleted = 0
+              AND (DeliveryDeadlineUtc IS NULL OR DeliveryDeadlineUtc > @AckedAtUtc);
             """;
     }
 

--- a/src/Akka.Reminders.SqlServer/Internal/SqlServerDialect.cs
+++ b/src/Akka.Reminders.SqlServer/Internal/SqlServerDialect.cs
@@ -324,6 +324,33 @@ internal sealed class SqlServerDialect : ISqlDialect
             """;
     }
 
+    public string GetBatchAcknowledgeRemindersSql(string schemaName, string tableName, int count)
+    {
+        var fullTableName = $"[{schemaName}].[{tableName}]";
+        var values = string.Join(",\n                ",
+            Enumerable.Range(0, count).Select(i => $"(@sr{i}, @eid{i}, @rk{i}, @due{i}, @acked{i})"));
+
+        return $"""
+            UPDATE t
+            SET t.IsCompleted = 1,
+                t.CompletedAtUtc = v.AckedAtUtc,
+                t.CompletionStatus = 'Delivered',
+                t.DeliveredAtUtc = NULL,
+                t.AckDeadlineUtc = NULL
+            FROM {fullTableName} t
+            INNER JOIN (VALUES
+                {values}
+            ) AS v(ShardRegionName, EntityId, ReminderKey, DueTimeUtc, AckedAtUtc)
+            ON t.ShardRegionName = v.ShardRegionName
+               AND t.EntityId = v.EntityId
+               AND t.ReminderKey = v.ReminderKey
+               AND t.DueTimeUtc = v.DueTimeUtc
+            WHERE t.CompletionStatus = 'AwaitingAck'
+              AND t.IsCompleted = 0
+              AND (t.DeliveryDeadlineUtc IS NULL OR t.DeliveryDeadlineUtc > v.AckedAtUtc);
+            """;
+    }
+
     public DbConnection CreateConnection(string connectionString)
     {
         return new SqlConnection(connectionString);

--- a/src/Akka.Reminders.SqlServer/Scripts/Migrations/V0_6_0__add_ack_columns.sql
+++ b/src/Akka.Reminders.SqlServer/Scripts/Migrations/V0_6_0__add_ack_columns.sql
@@ -1,0 +1,76 @@
+-- Migration for Akka.Reminders 0.6.0: Add acknowledgement columns
+-- Adds DeliveredAtUtc and AckDeadlineUtc to support reliable at-least-once delivery.
+--
+-- This script is idempotent: each operation is guarded by a sys.columns existence check.
+--
+-- Note: This script uses the default schema 'reminders' and table 'scheduled_reminders'.
+--       If you use a custom schema or table name, replace them accordingly.
+
+DECLARE @SchemaName NVARCHAR(255) = 'reminders';
+DECLARE @TableName  NVARCHAR(255) = 'scheduled_reminders';
+DECLARE @FullTableName NVARCHAR(500) = '[' + @SchemaName + '].[' + @TableName + ']';
+
+-- Add DeliveredAtUtc column if it does not already exist
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.columns c
+    JOIN sys.tables  t ON c.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = @SchemaName
+      AND t.name = @TableName
+      AND c.name = 'DeliveredAtUtc'
+)
+BEGIN
+    EXEC('ALTER TABLE ' + @FullTableName + ' ADD DeliveredAtUtc DATETIME2 NULL');
+    PRINT 'Added column DeliveredAtUtc to ' + @FullTableName;
+END
+ELSE
+BEGIN
+    PRINT 'Column DeliveredAtUtc already exists on ' + @FullTableName;
+END
+
+-- Add AckDeadlineUtc column if it does not already exist
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.columns c
+    JOIN sys.tables  t ON c.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = @SchemaName
+      AND t.name = @TableName
+      AND c.name = 'AckDeadlineUtc'
+)
+BEGIN
+    EXEC('ALTER TABLE ' + @FullTableName + ' ADD AckDeadlineUtc DATETIME2 NULL');
+    PRINT 'Added column AckDeadlineUtc to ' + @FullTableName;
+END
+ELSE
+BEGIN
+    PRINT 'Column AckDeadlineUtc already exists on ' + @FullTableName;
+END
+
+-- Create the awaiting-ack index if it does not already exist
+DECLARE @IndexName NVARCHAR(500) = 'IX_' + @TableName + '_AwaitingAck';
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes i
+    JOIN sys.tables  t ON i.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = @SchemaName
+      AND t.name = @TableName
+      AND i.name = @IndexName
+)
+BEGIN
+    DECLARE @CreateIndexSql NVARCHAR(MAX) =
+        'CREATE INDEX ' + @IndexName +
+        ' ON ' + @FullTableName + ' (AckDeadlineUtc)' +
+        ' WHERE CompletionStatus = ''AwaitingAck'';';
+    EXEC(@CreateIndexSql);
+    PRINT 'Created index: ' + @IndexName;
+END
+ELSE
+BEGIN
+    PRINT 'Index ' + @IndexName + ' already exists.';
+END
+
+PRINT 'Migration V0_6_0 complete.';

--- a/src/Akka.Reminders.SqlServer/Scripts/Migrations/V0_6_0__add_ack_columns.sql
+++ b/src/Akka.Reminders.SqlServer/Scripts/Migrations/V0_6_0__add_ack_columns.sql
@@ -1,7 +1,8 @@
--- Migration for Akka.Reminders 0.6.0: Add acknowledgement columns
--- Adds DeliveredAtUtc and AckDeadlineUtc to support reliable at-least-once delivery.
+-- Migration for Akka.Reminders 0.6.0: Full schema upgrade from 0.5.x
+-- Adds DueTimeUtc, MaxDeliveryWindowTicks, DeliveryDeadlineUtc, DeliveredAtUtc,
+-- AckDeadlineUtc columns; expands PK to include DueTimeUtc; updates indexes.
 --
--- This script is idempotent: each operation is guarded by a sys.columns existence check.
+-- This script is idempotent: each operation is guarded by sys.columns / sys.indexes checks.
 --
 -- Note: This script uses the default schema 'reminders' and table 'scheduled_reminders'.
 --       If you use a custom schema or table name, replace them accordingly.
@@ -10,15 +11,64 @@ DECLARE @SchemaName NVARCHAR(255) = 'reminders';
 DECLARE @TableName  NVARCHAR(255) = 'scheduled_reminders';
 DECLARE @FullTableName NVARCHAR(500) = '[' + @SchemaName + '].[' + @TableName + ']';
 
--- Add DeliveredAtUtc column if it does not already exist
+-- ============================================================
+-- 1. Add the five new columns
+-- ============================================================
+
+-- Add DueTimeUtc (initially nullable so we can backfill)
 IF NOT EXISTS (
-    SELECT 1
-    FROM sys.columns c
+    SELECT 1 FROM sys.columns c
     JOIN sys.tables  t ON c.object_id = t.object_id
     JOIN sys.schemas s ON t.schema_id = s.schema_id
-    WHERE s.name = @SchemaName
-      AND t.name = @TableName
-      AND c.name = 'DeliveredAtUtc'
+    WHERE s.name = @SchemaName AND t.name = @TableName AND c.name = 'DueTimeUtc'
+)
+BEGIN
+    EXEC('ALTER TABLE ' + @FullTableName + ' ADD DueTimeUtc DATETIME2 NULL');
+    PRINT 'Added column DueTimeUtc to ' + @FullTableName;
+END
+ELSE
+BEGIN
+    PRINT 'Column DueTimeUtc already exists on ' + @FullTableName;
+END
+
+-- Add MaxDeliveryWindowTicks
+IF NOT EXISTS (
+    SELECT 1 FROM sys.columns c
+    JOIN sys.tables  t ON c.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = @SchemaName AND t.name = @TableName AND c.name = 'MaxDeliveryWindowTicks'
+)
+BEGIN
+    EXEC('ALTER TABLE ' + @FullTableName + ' ADD MaxDeliveryWindowTicks BIGINT NULL');
+    PRINT 'Added column MaxDeliveryWindowTicks to ' + @FullTableName;
+END
+ELSE
+BEGIN
+    PRINT 'Column MaxDeliveryWindowTicks already exists on ' + @FullTableName;
+END
+
+-- Add DeliveryDeadlineUtc
+IF NOT EXISTS (
+    SELECT 1 FROM sys.columns c
+    JOIN sys.tables  t ON c.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = @SchemaName AND t.name = @TableName AND c.name = 'DeliveryDeadlineUtc'
+)
+BEGIN
+    EXEC('ALTER TABLE ' + @FullTableName + ' ADD DeliveryDeadlineUtc DATETIME2 NULL');
+    PRINT 'Added column DeliveryDeadlineUtc to ' + @FullTableName;
+END
+ELSE
+BEGIN
+    PRINT 'Column DeliveryDeadlineUtc already exists on ' + @FullTableName;
+END
+
+-- Add DeliveredAtUtc
+IF NOT EXISTS (
+    SELECT 1 FROM sys.columns c
+    JOIN sys.tables  t ON c.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = @SchemaName AND t.name = @TableName AND c.name = 'DeliveredAtUtc'
 )
 BEGIN
     EXEC('ALTER TABLE ' + @FullTableName + ' ADD DeliveredAtUtc DATETIME2 NULL');
@@ -29,15 +79,12 @@ BEGIN
     PRINT 'Column DeliveredAtUtc already exists on ' + @FullTableName;
 END
 
--- Add AckDeadlineUtc column if it does not already exist
+-- Add AckDeadlineUtc
 IF NOT EXISTS (
-    SELECT 1
-    FROM sys.columns c
+    SELECT 1 FROM sys.columns c
     JOIN sys.tables  t ON c.object_id = t.object_id
     JOIN sys.schemas s ON t.schema_id = s.schema_id
-    WHERE s.name = @SchemaName
-      AND t.name = @TableName
-      AND c.name = 'AckDeadlineUtc'
+    WHERE s.name = @SchemaName AND t.name = @TableName AND c.name = 'AckDeadlineUtc'
 )
 BEGIN
     EXEC('ALTER TABLE ' + @FullTableName + ' ADD AckDeadlineUtc DATETIME2 NULL');
@@ -48,29 +95,80 @@ BEGIN
     PRINT 'Column AckDeadlineUtc already exists on ' + @FullTableName;
 END
 
--- Create the awaiting-ack index if it does not already exist
-DECLARE @IndexName NVARCHAR(500) = 'IX_' + @TableName + '_AwaitingAck';
+-- ============================================================
+-- 2. Backfill DueTimeUtc from WhenUtc, then make NOT NULL
+-- ============================================================
+EXEC('UPDATE ' + @FullTableName + ' SET DueTimeUtc = WhenUtc WHERE DueTimeUtc IS NULL');
+PRINT 'Backfilled DueTimeUtc from WhenUtc for existing rows.';
 
-IF NOT EXISTS (
-    SELECT 1
-    FROM sys.indexes i
-    JOIN sys.tables  t ON i.object_id = t.object_id
+-- Make DueTimeUtc NOT NULL
+EXEC('ALTER TABLE ' + @FullTableName + ' ALTER COLUMN DueTimeUtc DATETIME2 NOT NULL');
+PRINT 'Set DueTimeUtc to NOT NULL.';
+
+-- ============================================================
+-- 3. Recreate primary key to include DueTimeUtc
+-- ============================================================
+DECLARE @PKName NVARCHAR(500) = 'PK_' + @TableName;
+
+IF EXISTS (
+    SELECT 1 FROM sys.key_constraints kc
+    JOIN sys.tables  t ON kc.parent_object_id = t.object_id
     JOIN sys.schemas s ON t.schema_id = s.schema_id
-    WHERE s.name = @SchemaName
-      AND t.name = @TableName
-      AND i.name = @IndexName
+    WHERE s.name = @SchemaName AND t.name = @TableName AND kc.name = @PKName AND kc.type = 'PK'
 )
 BEGIN
-    DECLARE @CreateIndexSql NVARCHAR(MAX) =
-        'CREATE INDEX ' + @IndexName +
+    EXEC('ALTER TABLE ' + @FullTableName + ' DROP CONSTRAINT ' + @PKName);
+    PRINT 'Dropped old primary key: ' + @PKName;
+END
+
+EXEC('ALTER TABLE ' + @FullTableName + ' ADD CONSTRAINT ' + @PKName + ' PRIMARY KEY (ShardRegionName, EntityId, ReminderKey, DueTimeUtc)');
+PRINT 'Created new primary key: ' + @PKName;
+
+-- ============================================================
+-- 4. Recreate the due-reminders index with updated filter
+-- ============================================================
+DECLARE @DueIndexName NVARCHAR(500) = 'IX_' + @TableName + '_DueReminders';
+
+IF EXISTS (
+    SELECT 1 FROM sys.indexes i
+    JOIN sys.tables  t ON i.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = @SchemaName AND t.name = @TableName AND i.name = @DueIndexName
+)
+BEGIN
+    EXEC('DROP INDEX ' + @DueIndexName + ' ON ' + @FullTableName);
+    PRINT 'Dropped old index: ' + @DueIndexName;
+END
+
+DECLARE @CreateDueIndexSql NVARCHAR(MAX) =
+    'CREATE INDEX ' + @DueIndexName +
+    ' ON ' + @FullTableName + ' (WhenUtc, ShardRegionName, EntityId)' +
+    ' WHERE IsCompleted = 0 AND CompletionStatus = ''Pending'';';
+EXEC(@CreateDueIndexSql);
+PRINT 'Created index: ' + @DueIndexName;
+
+-- ============================================================
+-- 5. Create the awaiting-ack index
+-- ============================================================
+DECLARE @AckIndexName NVARCHAR(500) = 'IX_' + @TableName + '_AwaitingAck';
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes i
+    JOIN sys.tables  t ON i.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = @SchemaName AND t.name = @TableName AND i.name = @AckIndexName
+)
+BEGIN
+    DECLARE @CreateAckIndexSql NVARCHAR(MAX) =
+        'CREATE INDEX ' + @AckIndexName +
         ' ON ' + @FullTableName + ' (AckDeadlineUtc)' +
-        ' WHERE CompletionStatus = ''AwaitingAck'';';
-    EXEC(@CreateIndexSql);
-    PRINT 'Created index: ' + @IndexName;
+        ' WHERE CompletionStatus = ''AwaitingAck'' AND IsCompleted = 0;';
+    EXEC(@CreateAckIndexSql);
+    PRINT 'Created index: ' + @AckIndexName;
 END
 ELSE
 BEGIN
-    PRINT 'Index ' + @IndexName + ' already exists.';
+    PRINT 'Index ' + @AckIndexName + ' already exists.';
 END
 
 PRINT 'Migration V0_6_0 complete.';

--- a/src/Akka.Reminders.SqlServer/Scripts/SqlServer-Create.sql
+++ b/src/Akka.Reminders.SqlServer/Scripts/SqlServer-Create.sql
@@ -38,19 +38,22 @@ BEGIN
         EntityId NVARCHAR(255) NOT NULL,
         ReminderKey NVARCHAR(255) NOT NULL,
         WhenUtc DATETIME2 NOT NULL,
+        DueTimeUtc DATETIME2 NOT NULL,
         RepeatIntervalTicks BIGINT NULL,
         SerializerId INT NOT NULL,
         Manifest NVARCHAR(500) NULL,
         Payload VARBINARY(MAX) NOT NULL,
         AttemptCount INT NOT NULL DEFAULT 0,
         LastFailureReason NVARCHAR(MAX) NULL,
+        MaxDeliveryWindowTicks BIGINT NULL,
+        DeliveryDeadlineUtc DATETIME2 NULL,
         IsCompleted BIT NOT NULL DEFAULT 0,
         CompletedAtUtc DATETIME2 NULL,
         CompletionStatus VARCHAR(20) NOT NULL DEFAULT ''Pending'',
         DeliveredAtUtc DATETIME2 NULL,
         AckDeadlineUtc DATETIME2 NULL,
 
-        CONSTRAINT PK_' + @TableName + ' PRIMARY KEY (ShardRegionName, EntityId, ReminderKey)
+        CONSTRAINT PK_' + @TableName + ' PRIMARY KEY (ShardRegionName, EntityId, ReminderKey, DueTimeUtc)
     );';
 
     EXEC(@CreateTableSql);
@@ -60,7 +63,7 @@ BEGIN
     DECLARE @CreateIndex1Sql NVARCHAR(MAX) = '
     CREATE INDEX ' + @IndexName1 + '
     ON ' + @FullTableName + ' (WhenUtc, ShardRegionName, EntityId)
-    WHERE IsCompleted = 0;';
+    WHERE IsCompleted = 0 AND CompletionStatus = ''Pending'';';
 
     EXEC(@CreateIndex1Sql);
     PRINT 'Created index: ' + @IndexName1
@@ -78,7 +81,7 @@ BEGIN
     DECLARE @CreateIndex3Sql NVARCHAR(MAX) = '
     CREATE INDEX ' + @IndexName3 + '
     ON ' + @FullTableName + ' (AckDeadlineUtc)
-    WHERE CompletionStatus = ''AwaitingAck'';';
+    WHERE CompletionStatus = ''AwaitingAck'' AND IsCompleted = 0;';
 
     EXEC(@CreateIndex3Sql);
     PRINT 'Created index: ' + @IndexName3

--- a/src/Akka.Reminders.SqlServer/Scripts/SqlServer-Create.sql
+++ b/src/Akka.Reminders.SqlServer/Scripts/SqlServer-Create.sql
@@ -47,6 +47,8 @@ BEGIN
         IsCompleted BIT NOT NULL DEFAULT 0,
         CompletedAtUtc DATETIME2 NULL,
         CompletionStatus VARCHAR(20) NOT NULL DEFAULT ''Pending'',
+        DeliveredAtUtc DATETIME2 NULL,
+        AckDeadlineUtc DATETIME2 NULL,
 
         CONSTRAINT PK_' + @TableName + ' PRIMARY KEY (ShardRegionName, EntityId, ReminderKey)
     );';
@@ -71,6 +73,15 @@ BEGIN
 
     EXEC(@CreateIndex2Sql);
     PRINT 'Created index: ' + @IndexName2
+
+    DECLARE @IndexName3 NVARCHAR(500) = 'IX_' + @TableName + '_AwaitingAck';
+    DECLARE @CreateIndex3Sql NVARCHAR(MAX) = '
+    CREATE INDEX ' + @IndexName3 + '
+    ON ' + @FullTableName + ' (AckDeadlineUtc)
+    WHERE CompletionStatus = ''AwaitingAck'';';
+
+    EXEC(@CreateIndex3Sql);
+    PRINT 'Created index: ' + @IndexName3
 END
 ELSE
 BEGIN

--- a/src/Akka.Reminders.SqlServer/SqlServerReminderStorage.cs
+++ b/src/Akka.Reminders.SqlServer/SqlServerReminderStorage.cs
@@ -518,6 +518,20 @@ public sealed class SqlServerReminderStorage : IReminderStorage
         }
     }
 
+    public async Task<int> ResetAwaitingAckToPendingAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = _dialect.GetResetAwaitingAckSql(_settings.SchemaName, _settings.TableName);
+        command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+        return await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
     private Task EnsureInitializedAsync(CancellationToken cancellationToken)
     {
         if (_initialized || !_settings.AutoInitialize)

--- a/src/Akka.Reminders.SqlServer/SqlServerReminderStorage.cs
+++ b/src/Akka.Reminders.SqlServer/SqlServerReminderStorage.cs
@@ -406,6 +406,118 @@ public sealed class SqlServerReminderStorage : IReminderStorage
         return reminders.Skip(skip).Take(take).ToList();
     }
 
+    public async Task<bool> MarkRemindersAsAwaitingAckAsync(
+        IEnumerable<AwaitingAckReminder> reminders,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+
+        var remindersList = reminders.ToList();
+        if (remindersList.Count == 0)
+            return true;
+
+        try
+        {
+            await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            foreach (var reminder in remindersList)
+            {
+                await using var command = connection.CreateCommand();
+                command.CommandText = _dialect.GetMarkAsAwaitingAckSql(_settings.SchemaName, _settings.TableName);
+                command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+                _dialect.AddParameter(command, "@ShardRegionName", reminder.Entity.ShardRegionName);
+                _dialect.AddParameter(command, "@EntityId", reminder.Entity.EntityId);
+                _dialect.AddParameter(command, "@ReminderKey", reminder.Key.Name);
+                _dialect.AddParameter(command, "@DeliveredAtUtc", reminder.DeliveredAt.UtcDateTime);
+                _dialect.AddParameter(command, "@AckDeadlineUtc", reminder.AckDeadline.UtcDateTime);
+
+                await command.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    public async Task<IReadOnlyList<ScheduledReminder>> GetTimedOutAckRemindersAsync(
+        DateTimeOffset now,
+        ReminderBatchSize maxCount,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+
+        var reminders = new List<ScheduledReminder>();
+
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = _dialect.GetTimedOutAckRemindersSql(
+            _settings.SchemaName, _settings.TableName, maxCount.Value);
+        command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+        _dialect.AddParameter(command, "@Now", now.UtcDateTime);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            var reminder = ReadReminderFromReader(reader);
+            reminders.Add(reminder);
+        }
+
+        return reminders;
+    }
+
+    public async Task<AckResult> AcknowledgeReminderAsync(
+        ReminderEntity entity,
+        ReminderKey key,
+        DateTimeOffset ackedAt,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = _dialect.GetAcknowledgeReminderSql(_settings.SchemaName, _settings.TableName);
+            command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+            _dialect.AddParameter(command, "@ShardRegionName", entity.ShardRegionName);
+            _dialect.AddParameter(command, "@EntityId", entity.EntityId);
+            _dialect.AddParameter(command, "@ReminderKey", key.Name);
+            _dialect.AddParameter(command, "@AckedAtUtc", ackedAt.UtcDateTime);
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+            if (!await reader.ReadAsync(cancellationToken))
+            {
+                // No row updated — reminder was not in AwaitingAck state
+                return new AckResult(Success: false, IsRecurring: false, OriginalReminder: null);
+            }
+
+            var original = ReadReminderFromReader(reader);
+            var isRecurring = original.RepeatInterval.HasValue;
+
+            return new AckResult(
+                Success: true,
+                IsRecurring: isRecurring,
+                OriginalReminder: isRecurring ? original : null);
+        }
+        catch (Exception)
+        {
+            return new AckResult(Success: false, IsRecurring: false, OriginalReminder: null);
+        }
+    }
+
     private Task EnsureInitializedAsync(CancellationToken cancellationToken)
     {
         if (_initialized || !_settings.AutoInitialize)

--- a/src/Akka.Reminders.SqlServer/SqlServerReminderStorage.cs
+++ b/src/Akka.Reminders.SqlServer/SqlServerReminderStorage.cs
@@ -439,6 +439,21 @@ public sealed class SqlServerReminderStorage : IReminderStorage
         return reminders;
     }
 
+    public async Task<DateTimeOffset?> GetNextAwaitingAckDeadlineAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"SELECT MIN(AckDeadlineUtc) FROM [{_settings.SchemaName}].[{_settings.TableName}] WHERE CompletionStatus = 'AwaitingAck' AND IsCompleted = 0;";
+        command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+
+        return result is DateTime next
+            ? new DateTimeOffset(DateTime.SpecifyKind(next, DateTimeKind.Utc))
+            : (DateTimeOffset?)null;
+    }
+
     public async Task<AckResult> AcknowledgeReminderAsync(ReminderEntity entity, ReminderKey key, DateTimeOffset dueTimeUtc, DateTimeOffset ackedAt, CancellationToken cancellationToken = default)
         => (await AcknowledgeRemindersAsync([new ReminderAcknowledgement(entity, key, dueTimeUtc, ackedAt)], cancellationToken))[0];
 
@@ -447,10 +462,74 @@ public sealed class SqlServerReminderStorage : IReminderStorage
         CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
-        var results = new List<AckResult>();
+        var acknowledgementList = acknowledgements.ToList();
+        var results = new List<AckResult>(acknowledgementList.Count);
+
+        if (acknowledgementList.Count == 0)
+            return results;
 
         await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
         await connection.OpenAsync(cancellationToken);
+
+        for (var offset = 0; offset < acknowledgementList.Count; offset += MaxRemindersPerStatusUpdate)
+        {
+            var chunk = acknowledgementList.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
+            results.AddRange(await AcknowledgeReminderChunkAsync(connection, chunk, cancellationToken));
+        }
+
+        return results;
+    }
+
+    private async Task<IReadOnlyList<AckResult>> AcknowledgeReminderChunkAsync(
+        System.Data.Common.DbConnection connection,
+        IReadOnlyList<ReminderAcknowledgement> acknowledgements,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+            await using var command = CreateCommand(connection, transaction);
+            command.CommandText = _dialect.GetBatchAcknowledgeRemindersSql(_settings.SchemaName, _settings.TableName, acknowledgements.Count);
+            command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+            for (var i = 0; i < acknowledgements.Count; i++)
+            {
+                var acknowledgement = acknowledgements[i];
+                _dialect.AddParameter(command, $"@sr{i}", acknowledgement.Entity.ShardRegionName);
+                _dialect.AddParameter(command, $"@eid{i}", acknowledgement.Entity.EntityId);
+                _dialect.AddParameter(command, $"@rk{i}", acknowledgement.Key.Name);
+                _dialect.AddParameter(command, $"@due{i}", acknowledgement.DueTimeUtc.UtcDateTime);
+                _dialect.AddParameter(command, $"@acked{i}", acknowledgement.AckedAt.UtcDateTime);
+            }
+
+            var updated = await command.ExecuteNonQueryAsync(cancellationToken);
+            if (updated == acknowledgements.Count)
+            {
+                await transaction.CommitAsync(cancellationToken);
+                return acknowledgements.Select(ToSuccessfulAckResult).ToList();
+            }
+
+            await transaction.RollbackAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            return acknowledgements.Select(a => new AckResult(
+                a.Entity,
+                a.Key,
+                a.DueTimeUtc,
+                ReminderAckStorageStatus.Error,
+                ex.Message)).ToList();
+        }
+
+        return await AcknowledgeRemindersIndividuallyAsync(connection, acknowledgements, cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<AckResult>> AcknowledgeRemindersIndividuallyAsync(
+        System.Data.Common.DbConnection connection,
+        IReadOnlyList<ReminderAcknowledgement> acknowledgements,
+        CancellationToken cancellationToken)
+    {
+        var results = new List<AckResult>(acknowledgements.Count);
 
         foreach (var acknowledgement in acknowledgements)
         {
@@ -465,12 +544,9 @@ public sealed class SqlServerReminderStorage : IReminderStorage
                 _dialect.AddParameter(command, "@DueTimeUtc", acknowledgement.DueTimeUtc.UtcDateTime);
                 _dialect.AddParameter(command, "@AckedAtUtc", acknowledgement.AckedAt.UtcDateTime);
                 var count = await command.ExecuteNonQueryAsync(cancellationToken);
-                results.Add(new AckResult(
-                    acknowledgement.Entity,
-                    acknowledgement.Key,
-                    acknowledgement.DueTimeUtc,
-                    count > 0 ? ReminderAckStorageStatus.Success : ReminderAckStorageStatus.NotFound,
-                    count > 0 ? null : "Reminder occurrence was not awaiting acknowledgement or was already stale."));
+                results.Add(count > 0
+                    ? ToSuccessfulAckResult(acknowledgement)
+                    : ToMissingAckResult(acknowledgement));
             }
             catch (Exception ex)
             {
@@ -485,6 +561,21 @@ public sealed class SqlServerReminderStorage : IReminderStorage
 
         return results;
     }
+
+    private static AckResult ToSuccessfulAckResult(ReminderAcknowledgement acknowledgement)
+        => new(
+            acknowledgement.Entity,
+            acknowledgement.Key,
+            acknowledgement.DueTimeUtc,
+            ReminderAckStorageStatus.Success);
+
+    private static AckResult ToMissingAckResult(ReminderAcknowledgement acknowledgement)
+        => new(
+            acknowledgement.Entity,
+            acknowledgement.Key,
+            acknowledgement.DueTimeUtc,
+            ReminderAckStorageStatus.NotFound,
+            "Reminder occurrence was not awaiting acknowledgement or was already stale.");
 
     private Task EnsureInitializedAsync(CancellationToken cancellationToken)
     {

--- a/src/Akka.Reminders.SqlServer/SqlServerReminderStorage.cs
+++ b/src/Akka.Reminders.SqlServer/SqlServerReminderStorage.cs
@@ -17,6 +17,9 @@ public sealed class SqlServerReminderStorage : IReminderStorage
     private readonly object _initLock = new();
     private volatile bool _initialized;
 
+    private const int MaxUpsertedRemindersPerStatement = 120;
+    private const int MaxRemindersPerStatusUpdate = 300;
+
     public SqlServerReminderStorage(SqlServerReminderStorageSettings settings, ActorSystem system)
     {
         _settings = settings ?? throw new ArgumentNullException(nameof(settings));
@@ -34,38 +37,78 @@ public sealed class SqlServerReminderStorage : IReminderStorage
 
         try
         {
-            var (serializerId, manifest, payload) = SerializeMessage(reminder.Message);
-
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
 
-            await using var command = connection.CreateCommand();
-            command.CommandText = _dialect.GetUpsertReminderSql(_settings.SchemaName, _settings.TableName);
-            command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+            await using (var cancelCommand = connection.CreateCommand())
+            {
+                cancelCommand.CommandText = _dialect.GetCancelReminderSql(_settings.SchemaName, _settings.TableName);
+                cancelCommand.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+                _dialect.AddParameter(cancelCommand, "@ShardRegionName", reminder.Entity.ShardRegionName);
+                _dialect.AddParameter(cancelCommand, "@EntityId", reminder.Entity.EntityId);
+                _dialect.AddParameter(cancelCommand, "@ReminderKey", reminder.Key.Name);
+                _dialect.AddParameter(cancelCommand, "@CompletedAtUtc", DateTimeOffset.UtcNow.UtcDateTime);
+                await cancelCommand.ExecuteNonQueryAsync(cancellationToken);
+            }
 
-            _dialect.AddParameter(command, "@ShardRegionName", reminder.Entity.ShardRegionName);
-            _dialect.AddParameter(command, "@EntityId", reminder.Entity.EntityId);
-            _dialect.AddParameter(command, "@ReminderKey", reminder.Key.Name);
-            _dialect.AddParameter(command, "@WhenUtc", reminder.When);
-            _dialect.AddParameter(command, "@RepeatIntervalTicks", reminder.RepeatInterval?.Ticks ?? (object)DBNull.Value);
-            _dialect.AddParameter(command, "@SerializerId", serializerId);
-            _dialect.AddParameter(command, "@Manifest", manifest ?? (object)DBNull.Value);
-            _dialect.AddParameter(command, "@Payload", payload);
-            _dialect.AddParameter(command, "@AttemptCount", reminder.AttemptCount);
-            _dialect.AddParameter(command, "@LastFailureReason", reminder.LastFailureReason ?? (object)DBNull.Value);
+            if (!await UpsertReminderOccurrencesAsync(connection, [reminder], cancellationToken))
+            {
+                return new ReminderProtocol.ReminderScheduled(
+                    reminder.ToScheduleReminder(),
+                    ReminderScheduleResponseCode.Error,
+                    "Failed to persist reminder occurrence");
+            }
 
-            await command.ExecuteNonQueryAsync(cancellationToken);
-
-            return new ReminderProtocol.ReminderScheduled(
-                reminder.ToScheduleReminder(),
-                ReminderScheduleResponseCode.Success);
+            return new ReminderProtocol.ReminderScheduled(reminder.ToScheduleReminder(), ReminderScheduleResponseCode.Success);
         }
         catch (Exception ex)
         {
-            return new ReminderProtocol.ReminderScheduled(
-                reminder.ToScheduleReminder(),
-                ReminderScheduleResponseCode.Error,
-                ex.Message);
+            return new ReminderProtocol.ReminderScheduled(reminder.ToScheduleReminder(), ReminderScheduleResponseCode.Error, ex.Message);
+        }
+    }
+
+    public async Task<bool> UpsertReminderOccurrencesAsync(
+        IEnumerable<ScheduledReminder> reminders,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+        return await UpsertReminderOccurrencesAsync(connection, reminders, cancellationToken);
+    }
+
+    private async Task<bool> UpsertReminderOccurrencesAsync(
+        System.Data.Common.DbConnection connection,
+        IEnumerable<ScheduledReminder> reminders,
+        CancellationToken cancellationToken)
+    {
+        var remindersList = reminders.ToList();
+        if (remindersList.Count == 0)
+            return true;
+
+        try
+        {
+            for (var offset = 0; offset < remindersList.Count; offset += MaxUpsertedRemindersPerStatement)
+            {
+                var chunk = remindersList.Skip(offset).Take(MaxUpsertedRemindersPerStatement).ToList();
+                await using var command = connection.CreateCommand();
+                command.CommandText = _dialect.GetBatchUpsertRemindersSql(_settings.SchemaName, _settings.TableName, chunk.Count);
+                command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+                for (var i = 0; i < chunk.Count; i++)
+                {
+                    BindReminderParameters(command, i, chunk[i]);
+                }
+
+                await command.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            return true;
+        }
+        catch
+        {
+            return false;
         }
     }
 
@@ -83,23 +126,17 @@ public sealed class SqlServerReminderStorage : IReminderStorage
         await connection.OpenAsync(cancellationToken);
 
         await using var command = connection.CreateCommand();
-        command.CommandText = _dialect.GetSelectDueRemindersSql(
-            _settings.SchemaName,
-            _settings.TableName,
-            maxCount.Value);
+        command.CommandText = _dialect.GetSelectDueRemindersSql(_settings.SchemaName, _settings.TableName, maxCount.Value);
         command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
         _dialect.AddParameter(command, "@UntilDeadline", untilDeadline.UtcDateTime);
+        _dialect.AddParameter(command, "@Now", now.UtcDateTime);
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
-
         while (await reader.ReadAsync(cancellationToken))
         {
-            var reminder = ReadReminderFromReader(reader);
-            reminders.Add(reminder);
+            reminders.Add(ReadReminderFromReader(reader));
         }
 
-        // Get overview of remaining reminders using aggregate queries
         await using var conn2 = _dialect.CreateConnection(_settings.ConnectionString);
         await conn2.OpenAsync(cancellationToken);
 
@@ -108,11 +145,10 @@ public sealed class SqlServerReminderStorage : IReminderStorage
         {
             cmd2.CommandText = _dialect.GetOverviewAggregateSql(_settings.SchemaName, _settings.TableName);
             cmd2.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+            _dialect.AddParameter(cmd2, "@Now", now.UtcDateTime);
             await using var reader2 = await cmd2.ExecuteReaderAsync(cancellationToken);
             if (await reader2.ReadAsync(cancellationToken))
-            {
                 totalPending = reader2.GetInt32(reader2.GetOrdinal("TotalCount"));
-            }
         }
 
         var remainingCount = totalPending - reminders.Count;
@@ -124,6 +160,7 @@ public sealed class SqlServerReminderStorage : IReminderStorage
             cmd3.CommandText = _dialect.GetNextReminderTimeSql(_settings.SchemaName, _settings.TableName);
             cmd3.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
             _dialect.AddParameter(cmd3, "@Skip", reminders.Count);
+            _dialect.AddParameter(cmd3, "@Now", now.UtcDateTime);
 
             var result = await cmd3.ExecuteScalarAsync(cancellationToken);
             if (result is DateTime nextWhenUtc)
@@ -132,16 +169,12 @@ public sealed class SqlServerReminderStorage : IReminderStorage
             }
         }
 
-        var adjustedOverview = new ReminderOverview
+        return new PendingRemindersWithSummary(reminders, new ReminderOverview
         {
             TimeUntilNext = timeUntilNext,
             TotalPendingReminders = remainingCount
-        };
-
-        return new PendingRemindersWithSummary(reminders, adjustedOverview);
+        });
     }
-
-    private const int MaxRemindersPerStatement = 500;
 
     public async Task<bool> MarkRemindersAsCompletedAsync(
         IEnumerable<CompletedReminder> completedReminders,
@@ -158,22 +191,17 @@ public sealed class SqlServerReminderStorage : IReminderStorage
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
 
-            var groups = remindersList.GroupBy(r => (r.Status, r.When));
-
+            var groups = remindersList.GroupBy(r => (r.Status, r.CompletedAt));
             foreach (var group in groups)
             {
                 var items = group.ToList();
-
-                for (var offset = 0; offset < items.Count; offset += MaxRemindersPerStatement)
+                for (var offset = 0; offset < items.Count; offset += MaxRemindersPerStatusUpdate)
                 {
-                    var chunk = items.Skip(offset).Take(MaxRemindersPerStatement).ToList();
-
+                    var chunk = items.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
                     await using var command = connection.CreateCommand();
-                    command.CommandText = _dialect.GetBatchMarkCompletedSql(
-                        _settings.SchemaName, _settings.TableName, chunk.Count);
+                    command.CommandText = _dialect.GetBatchMarkCompletedSql(_settings.SchemaName, _settings.TableName, chunk.Count);
                     command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
-                    _dialect.AddParameter(command, "@CompletedAtUtc", group.Key.When.UtcDateTime);
+                    _dialect.AddParameter(command, "@CompletedAtUtc", group.Key.CompletedAt.UtcDateTime);
                     _dialect.AddParameter(command, "@CompletionStatus", group.Key.Status.ToString());
 
                     for (var i = 0; i < chunk.Count; i++)
@@ -181,6 +209,7 @@ public sealed class SqlServerReminderStorage : IReminderStorage
                         _dialect.AddParameter(command, $"@sr{i}", chunk[i].Entity.ShardRegionName);
                         _dialect.AddParameter(command, $"@eid{i}", chunk[i].Entity.EntityId);
                         _dialect.AddParameter(command, $"@rk{i}", chunk[i].Key.Name);
+                        _dialect.AddParameter(command, $"@due{i}", chunk[i].DueTimeUtc.UtcDateTime);
                     }
 
                     await command.ExecuteNonQueryAsync(cancellationToken);
@@ -189,55 +218,58 @@ public sealed class SqlServerReminderStorage : IReminderStorage
 
             return true;
         }
-        catch (Exception)
+        catch
         {
             return false;
         }
     }
 
-    /// <inheritdoc />
-    public async Task<ReminderOverview> GetRemindersOverviewAsync(
-        DateTimeOffset now,
-        CancellationToken cancellationToken = default)
+    public async Task<int> ExpireRemindersAsync(DateTimeOffset now, CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
 
+        await using var command = connection.CreateCommand();
+        command.CommandText = _dialect.GetExpireRemindersSql(_settings.SchemaName, _settings.TableName);
+        command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+        _dialect.AddParameter(command, "@Now", now.UtcDateTime);
+        return await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    public async Task<ReminderOverview> GetRemindersOverviewAsync(DateTimeOffset now, CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
         await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
         await connection.OpenAsync(cancellationToken);
 
         await using var command = connection.CreateCommand();
         command.CommandText = _dialect.GetOverviewAggregateSql(_settings.SchemaName, _settings.TableName);
         command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+        _dialect.AddParameter(command, "@Now", now.UtcDateTime);
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
-
         if (await reader.ReadAsync(cancellationToken))
         {
             var totalCount = reader.GetInt32(reader.GetOrdinal("TotalCount"));
             var nextWhenUtcOrdinal = reader.GetOrdinal("NextWhenUtc");
-
             if (totalCount == 0 || reader.IsDBNull(nextWhenUtcOrdinal))
                 return ReminderOverview.Empty;
 
             var nextWhenUtc = reader.GetDateTime(nextWhenUtcOrdinal);
-            var timeUntilNext = new DateTimeOffset(DateTime.SpecifyKind(nextWhenUtc, DateTimeKind.Utc)) - now;
-
             return new ReminderOverview
             {
                 TotalPendingReminders = totalCount,
-                TimeUntilNext = timeUntilNext
+                TimeUntilNext = new DateTimeOffset(DateTime.SpecifyKind(nextWhenUtc, DateTimeKind.Utc)) - now
             };
         }
 
         return ReminderOverview.Empty;
     }
 
-    public async Task<bool> CleanUpCompletedRemindersAsync(
-        DateTimeOffset olderThan,
-        CancellationToken cancellationToken = default)
+    public async Task<bool> CleanUpCompletedRemindersAsync(DateTimeOffset olderThan, CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
-
         try
         {
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
@@ -246,25 +278,19 @@ public sealed class SqlServerReminderStorage : IReminderStorage
             await using var command = connection.CreateCommand();
             command.CommandText = _dialect.GetCleanupSql(_settings.SchemaName, _settings.TableName);
             command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
             _dialect.AddParameter(command, "@OlderThan", olderThan.UtcDateTime);
-
             await command.ExecuteNonQueryAsync(cancellationToken);
             return true;
         }
-        catch (Exception)
+        catch
         {
             return false;
         }
     }
 
-    public async Task<ReminderProtocol.RemindersCancelled> CancelReminderAsync(
-        ReminderEntity entity,
-        ReminderKey key,
-        CancellationToken cancellationToken = default)
+    public async Task<ReminderProtocol.RemindersCancelled> CancelReminderAsync(ReminderEntity entity, ReminderKey key, CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
-
         try
         {
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
@@ -273,142 +299,87 @@ public sealed class SqlServerReminderStorage : IReminderStorage
             await using var command = connection.CreateCommand();
             command.CommandText = _dialect.GetCancelReminderSql(_settings.SchemaName, _settings.TableName);
             command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
             _dialect.AddParameter(command, "@ShardRegionName", entity.ShardRegionName);
             _dialect.AddParameter(command, "@EntityId", entity.EntityId);
             _dialect.AddParameter(command, "@ReminderKey", key.Name);
             _dialect.AddParameter(command, "@CompletedAtUtc", DateTimeOffset.UtcNow.UtcDateTime);
-
             var count = await command.ExecuteNonQueryAsync(cancellationToken);
-
-            if (count > 0)
-            {
-                return new ReminderProtocol.RemindersCancelled(
-                    entity,
-                    ReminderCancelResponseCode.Success,
-                    new List<ReminderKey> { key },
-                    null);
-            }
-
-            return new ReminderProtocol.RemindersCancelled(
-                entity,
-                ReminderCancelResponseCode.NotFound,
-                new List<ReminderKey>(),
-                null);
+            return count > 0
+                ? new ReminderProtocol.RemindersCancelled(entity, ReminderCancelResponseCode.Success, [key])
+                : new ReminderProtocol.RemindersCancelled(entity, ReminderCancelResponseCode.NotFound, []);
         }
         catch (Exception ex)
         {
-            return new ReminderProtocol.RemindersCancelled(
-                entity,
-                ReminderCancelResponseCode.Error,
-                new List<ReminderKey>(),
-                ex.Message);
+            return new ReminderProtocol.RemindersCancelled(entity, ReminderCancelResponseCode.Error, [], ex.Message);
         }
     }
 
-    public async Task<ReminderProtocol.RemindersCancelled> CancelAllRemindersForEntityAsync(
-        ReminderEntity entity,
-        CancellationToken cancellationToken = default)
+    public async Task<ReminderProtocol.RemindersCancelled> CancelAllRemindersForEntityAsync(ReminderEntity entity, CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
-
         try
         {
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
 
-            var cancelledKeys = new List<ReminderKey>();
-
+            var cancelledKeys = new HashSet<ReminderKey>();
             await using (var selectCommand = connection.CreateCommand())
             {
                 selectCommand.CommandText = _dialect.GetFetchRemindersSql(_settings.SchemaName, _settings.TableName);
                 selectCommand.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
                 _dialect.AddParameter(selectCommand, "@ShardRegionName", entity.ShardRegionName);
                 _dialect.AddParameter(selectCommand, "@EntityId", entity.EntityId);
-
+                _dialect.AddParameter(selectCommand, "@Now", DateTimeOffset.UtcNow.UtcDateTime);
                 await using var reader = await selectCommand.ExecuteReaderAsync(cancellationToken);
                 while (await reader.ReadAsync(cancellationToken))
                 {
-                    var reminderKey = reader.GetString(reader.GetOrdinal("ReminderKey"));
-                    var isCompleted = reader.GetBoolean(reader.GetOrdinal("IsCompleted"));
-
-                    if (!isCompleted)
-                    {
-                        cancelledKeys.Add(new ReminderKey(reminderKey));
-                    }
+                    cancelledKeys.Add(new ReminderKey(reader.GetString(reader.GetOrdinal("ReminderKey"))));
                 }
             }
 
             if (cancelledKeys.Count == 0)
-            {
-                return new ReminderProtocol.RemindersCancelled(
-                    entity,
-                    ReminderCancelResponseCode.NotFound,
-                    new List<ReminderKey>(),
-                    null);
-            }
+                return new ReminderProtocol.RemindersCancelled(entity, ReminderCancelResponseCode.NotFound, []);
 
             await using var command = connection.CreateCommand();
             command.CommandText = _dialect.GetCancelAllRemindersSql(_settings.SchemaName, _settings.TableName);
             command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
             _dialect.AddParameter(command, "@ShardRegionName", entity.ShardRegionName);
             _dialect.AddParameter(command, "@EntityId", entity.EntityId);
             _dialect.AddParameter(command, "@CompletedAtUtc", DateTimeOffset.UtcNow.UtcDateTime);
-
             await command.ExecuteNonQueryAsync(cancellationToken);
 
-            return new ReminderProtocol.RemindersCancelled(
-                entity,
-                ReminderCancelResponseCode.Success,
-                cancelledKeys,
-                null);
+            return new ReminderProtocol.RemindersCancelled(entity, ReminderCancelResponseCode.Success, cancelledKeys.ToList());
         }
         catch (Exception ex)
         {
-            return new ReminderProtocol.RemindersCancelled(
-                entity,
-                ReminderCancelResponseCode.Error,
-                new List<ReminderKey>(),
-                ex.Message);
+            return new ReminderProtocol.RemindersCancelled(entity, ReminderCancelResponseCode.Error, [], ex.Message);
         }
     }
 
-    public async Task<IReadOnlyList<ScheduledReminder>> GetRemindersForEntityAsync(
-        ReminderEntity entity,
-        int take = 10,
-        int skip = 0,
-        CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<ScheduledReminder>> GetRemindersForEntityAsync(ReminderEntity entity, int take = 10, int skip = 0, CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
-
         var reminders = new List<ScheduledReminder>();
 
         await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
         await connection.OpenAsync(cancellationToken);
-
         await using var command = connection.CreateCommand();
         command.CommandText = _dialect.GetFetchRemindersSql(_settings.SchemaName, _settings.TableName);
         command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
         _dialect.AddParameter(command, "@ShardRegionName", entity.ShardRegionName);
         _dialect.AddParameter(command, "@EntityId", entity.EntityId);
+        _dialect.AddParameter(command, "@Now", DateTimeOffset.UtcNow.UtcDateTime);
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
-
         while (await reader.ReadAsync(cancellationToken))
         {
-            var reminder = ReadReminderFromReader(reader);
-            reminders.Add(reminder);
+            reminders.Add(ReadReminderFromReader(reader));
         }
 
         return reminders.Skip(skip).Take(take).ToList();
     }
 
-    public async Task<bool> MarkRemindersAsAwaitingAckAsync(
-        IEnumerable<AwaitingAckReminder> reminders,
-        CancellationToken cancellationToken = default)
+    public async Task<bool> MarkRemindersAsAwaitingAckAsync(IEnumerable<AwaitingAckReminder> reminders, CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
 
@@ -421,115 +392,77 @@ public sealed class SqlServerReminderStorage : IReminderStorage
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
 
-            foreach (var reminder in remindersList)
+            for (var offset = 0; offset < remindersList.Count; offset += MaxRemindersPerStatusUpdate)
             {
+                var chunk = remindersList.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
                 await using var command = connection.CreateCommand();
-                command.CommandText = _dialect.GetMarkAsAwaitingAckSql(_settings.SchemaName, _settings.TableName);
+                command.CommandText = _dialect.GetBatchMarkAsAwaitingAckSql(_settings.SchemaName, _settings.TableName, chunk.Count);
                 command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
 
-                _dialect.AddParameter(command, "@ShardRegionName", reminder.Entity.ShardRegionName);
-                _dialect.AddParameter(command, "@EntityId", reminder.Entity.EntityId);
-                _dialect.AddParameter(command, "@ReminderKey", reminder.Key.Name);
-                _dialect.AddParameter(command, "@DeliveredAtUtc", reminder.DeliveredAt.UtcDateTime);
-                _dialect.AddParameter(command, "@AckDeadlineUtc", reminder.AckDeadline.UtcDateTime);
+                for (var i = 0; i < chunk.Count; i++)
+                {
+                    _dialect.AddParameter(command, $"@sr{i}", chunk[i].Entity.ShardRegionName);
+                    _dialect.AddParameter(command, $"@eid{i}", chunk[i].Entity.EntityId);
+                    _dialect.AddParameter(command, $"@rk{i}", chunk[i].Key.Name);
+                    _dialect.AddParameter(command, $"@due{i}", chunk[i].DueTimeUtc.UtcDateTime);
+                    _dialect.AddParameter(command, $"@del{i}", chunk[i].DeliveredAt.UtcDateTime);
+                    _dialect.AddParameter(command, $"@ack{i}", chunk[i].AckDeadline.UtcDateTime);
+                }
 
                 await command.ExecuteNonQueryAsync(cancellationToken);
             }
 
             return true;
         }
-        catch (Exception)
+        catch
         {
             return false;
         }
     }
 
-    public async Task<IReadOnlyList<ScheduledReminder>> GetTimedOutAckRemindersAsync(
-        DateTimeOffset now,
-        ReminderBatchSize maxCount,
-        CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<ScheduledReminder>> GetTimedOutAckRemindersAsync(DateTimeOffset now, ReminderBatchSize maxCount, CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
-
         var reminders = new List<ScheduledReminder>();
 
         await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
         await connection.OpenAsync(cancellationToken);
-
         await using var command = connection.CreateCommand();
-        command.CommandText = _dialect.GetTimedOutAckRemindersSql(
-            _settings.SchemaName, _settings.TableName, maxCount.Value);
+        command.CommandText = _dialect.GetTimedOutAckRemindersSql(_settings.SchemaName, _settings.TableName, maxCount.Value);
         command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
         _dialect.AddParameter(command, "@Now", now.UtcDateTime);
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
-
         while (await reader.ReadAsync(cancellationToken))
         {
-            var reminder = ReadReminderFromReader(reader);
-            reminders.Add(reminder);
+            reminders.Add(ReadReminderFromReader(reader));
         }
 
         return reminders;
     }
 
-    public async Task<AckResult> AcknowledgeReminderAsync(
-        ReminderEntity entity,
-        ReminderKey key,
-        DateTimeOffset ackedAt,
-        CancellationToken cancellationToken = default)
+    public async Task<AckResult> AcknowledgeReminderAsync(ReminderEntity entity, ReminderKey key, DateTimeOffset dueTimeUtc, DateTimeOffset ackedAt, CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
-
         try
         {
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
-
             await using var command = connection.CreateCommand();
             command.CommandText = _dialect.GetAcknowledgeReminderSql(_settings.SchemaName, _settings.TableName);
             command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
             _dialect.AddParameter(command, "@ShardRegionName", entity.ShardRegionName);
             _dialect.AddParameter(command, "@EntityId", entity.EntityId);
             _dialect.AddParameter(command, "@ReminderKey", key.Name);
+            _dialect.AddParameter(command, "@DueTimeUtc", dueTimeUtc.UtcDateTime);
             _dialect.AddParameter(command, "@AckedAtUtc", ackedAt.UtcDateTime);
-
-            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
-
-            if (!await reader.ReadAsync(cancellationToken))
-            {
-                // No row updated — reminder was not in AwaitingAck state
-                return new AckResult(Success: false, IsRecurring: false, OriginalReminder: null);
-            }
-
-            var original = ReadReminderFromReader(reader);
-            var isRecurring = original.RepeatInterval.HasValue;
-
-            return new AckResult(
-                Success: true,
-                IsRecurring: isRecurring,
-                OriginalReminder: isRecurring ? original : null);
+            var count = await command.ExecuteNonQueryAsync(cancellationToken);
+            return new AckResult(count > 0);
         }
-        catch (Exception)
+        catch
         {
-            return new AckResult(Success: false, IsRecurring: false, OriginalReminder: null);
+            return new AckResult(false);
         }
-    }
-
-    public async Task<int> ResetAwaitingAckToPendingAsync(CancellationToken cancellationToken = default)
-    {
-        await EnsureInitializedAsync(cancellationToken);
-
-        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
-        await connection.OpenAsync(cancellationToken);
-
-        await using var command = connection.CreateCommand();
-        command.CommandText = _dialect.GetResetAwaitingAckSql(_settings.SchemaName, _settings.TableName);
-        command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
-        return await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
     private Task EnsureInitializedAsync(CancellationToken cancellationToken)
@@ -546,11 +479,9 @@ public sealed class SqlServerReminderStorage : IReminderStorage
             {
                 await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
                 await connection.OpenAsync(cancellationToken);
-
                 await using var command = connection.CreateCommand();
                 command.CommandText = _dialect.GetCreateTableSql(_settings.SchemaName, _settings.TableName);
                 command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
                 await command.ExecuteNonQueryAsync(cancellationToken);
             }, cancellationToken).Wait(cancellationToken);
 
@@ -560,12 +491,30 @@ public sealed class SqlServerReminderStorage : IReminderStorage
         return Task.CompletedTask;
     }
 
+    private void BindReminderParameters(System.Data.Common.DbCommand command, int index, ScheduledReminder reminder)
+    {
+        var (serializerId, manifest, payload) = SerializeMessage(reminder.Message);
+
+        _dialect.AddParameter(command, $"@ShardRegionName{index}", reminder.Entity.ShardRegionName);
+        _dialect.AddParameter(command, $"@EntityId{index}", reminder.Entity.EntityId);
+        _dialect.AddParameter(command, $"@ReminderKey{index}", reminder.Key.Name);
+        _dialect.AddParameter(command, $"@WhenUtc{index}", reminder.When.UtcDateTime);
+        _dialect.AddParameter(command, $"@DueTimeUtc{index}", reminder.DueTimeUtc.UtcDateTime);
+        _dialect.AddParameter(command, $"@RepeatIntervalTicks{index}", reminder.RepeatInterval?.Ticks ?? (object)DBNull.Value);
+        _dialect.AddParameter(command, $"@SerializerId{index}", serializerId);
+        _dialect.AddParameter(command, $"@Manifest{index}", manifest ?? (object)DBNull.Value);
+        _dialect.AddParameter(command, $"@Payload{index}", payload);
+        _dialect.AddParameter(command, $"@AttemptCount{index}", reminder.AttemptCount);
+        _dialect.AddParameter(command, $"@LastFailureReason{index}", reminder.LastFailureReason ?? (object)DBNull.Value);
+        _dialect.AddParameter(command, $"@MaxDeliveryWindowTicks{index}", reminder.MaxDeliveryWindow?.Ticks ?? (object)DBNull.Value);
+        _dialect.AddParameter(command, $"@DeliveryDeadlineUtc{index}", reminder.DeliveryDeadlineUtc?.UtcDateTime ?? (object)DBNull.Value);
+    }
+
     private (int serializerId, string? manifest, byte[] payload) SerializeMessage(object message)
     {
         var serializer = _serialization.FindSerializerFor(message);
         var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, message);
         var payload = serializer.ToBinary(message);
-
         return (serializer.Identifier, manifest, payload);
     }
 
@@ -580,6 +529,7 @@ public sealed class SqlServerReminderStorage : IReminderStorage
         var entityId = reader.GetString(reader.GetOrdinal("EntityId"));
         var reminderKey = reader.GetString(reader.GetOrdinal("ReminderKey"));
         var whenUtc = reader.GetDateTime(reader.GetOrdinal("WhenUtc"));
+        var dueTimeUtc = reader.GetDateTime(reader.GetOrdinal("DueTimeUtc"));
 
         var repeatIntervalTicksOrdinal = reader.GetOrdinal("RepeatIntervalTicks");
         var repeatInterval = reader.IsDBNull(repeatIntervalTicksOrdinal)
@@ -587,17 +537,23 @@ public sealed class SqlServerReminderStorage : IReminderStorage
             : TimeSpan.FromTicks(reader.GetInt64(repeatIntervalTicksOrdinal));
 
         var serializerId = reader.GetInt32(reader.GetOrdinal("SerializerId"));
-
         var manifestOrdinal = reader.GetOrdinal("Manifest");
         var manifest = reader.IsDBNull(manifestOrdinal) ? null : reader.GetString(manifestOrdinal);
-
         var payload = (byte[])reader.GetValue(reader.GetOrdinal("Payload"));
         var attemptCount = reader.GetInt32(reader.GetOrdinal("AttemptCount"));
 
         var lastFailureReasonOrdinal = reader.GetOrdinal("LastFailureReason");
-        var lastFailureReason = reader.IsDBNull(lastFailureReasonOrdinal)
-            ? null
-            : reader.GetString(lastFailureReasonOrdinal);
+        var lastFailureReason = reader.IsDBNull(lastFailureReasonOrdinal) ? null : reader.GetString(lastFailureReasonOrdinal);
+
+        var maxWindowOrdinal = reader.GetOrdinal("MaxDeliveryWindowTicks");
+        var maxDeliveryWindow = reader.IsDBNull(maxWindowOrdinal)
+            ? (TimeSpan?)null
+            : TimeSpan.FromTicks(reader.GetInt64(maxWindowOrdinal));
+
+        var deadlineOrdinal = reader.GetOrdinal("DeliveryDeadlineUtc");
+        var deliveryDeadlineUtc = reader.IsDBNull(deadlineOrdinal)
+            ? (DateTimeOffset?)null
+            : new DateTimeOffset(DateTime.SpecifyKind(reader.GetDateTime(deadlineOrdinal), DateTimeKind.Utc));
 
         var message = DeserializeMessage(serializerId, manifest, payload);
 
@@ -608,6 +564,9 @@ public sealed class SqlServerReminderStorage : IReminderStorage
             message,
             repeatInterval,
             attemptCount,
-            lastFailureReason);
+            lastFailureReason,
+            maxDeliveryWindow,
+            deliveryDeadlineUtc,
+            new DateTimeOffset(DateTime.SpecifyKind(dueTimeUtc, DateTimeKind.Utc)));
     }
 }

--- a/src/Akka.Reminders.SqlServer/SqlServerReminderStorage.cs
+++ b/src/Akka.Reminders.SqlServer/SqlServerReminderStorage.cs
@@ -39,8 +39,9 @@ public sealed class SqlServerReminderStorage : IReminderStorage
         {
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
+            await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
 
-            await using (var cancelCommand = connection.CreateCommand())
+            await using (var cancelCommand = CreateCommand(connection, transaction))
             {
                 cancelCommand.CommandText = _dialect.GetCancelReminderSql(_settings.SchemaName, _settings.TableName);
                 cancelCommand.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
@@ -51,13 +52,16 @@ public sealed class SqlServerReminderStorage : IReminderStorage
                 await cancelCommand.ExecuteNonQueryAsync(cancellationToken);
             }
 
-            if (!await UpsertReminderOccurrencesAsync(connection, [reminder], cancellationToken))
+            if (!await UpsertReminderOccurrencesAsync(connection, transaction, [reminder], cancellationToken))
             {
+                await transaction.RollbackAsync(cancellationToken);
                 return new ReminderProtocol.ReminderScheduled(
                     reminder.ToScheduleReminder(),
                     ReminderScheduleResponseCode.Error,
                     "Failed to persist reminder occurrence");
             }
+
+            await transaction.CommitAsync(cancellationToken);
 
             return new ReminderProtocol.ReminderScheduled(reminder.ToScheduleReminder(), ReminderScheduleResponseCode.Success);
         }
@@ -75,11 +79,52 @@ public sealed class SqlServerReminderStorage : IReminderStorage
 
         await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
         await connection.OpenAsync(cancellationToken);
-        return await UpsertReminderOccurrencesAsync(connection, reminders, cancellationToken);
+        return await UpsertReminderOccurrencesAsync(connection, null, reminders, cancellationToken);
+    }
+
+    public async Task<bool> CommitReminderMutationsAsync(ReminderMutationBatch mutationBatch, CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+        if (mutationBatch.IsEmpty)
+            return true;
+
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+        try
+        {
+            if (!await UpsertReminderOccurrencesAsync(connection, transaction, mutationBatch.PendingUpserts, cancellationToken))
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                return false;
+            }
+
+            if (!await MarkRemindersAsCompletedAsync(connection, transaction, mutationBatch.CompletedReminders, cancellationToken))
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                return false;
+            }
+
+            if (!await MarkRemindersAsAwaitingAckAsync(connection, transaction, mutationBatch.AwaitingAckReminders, cancellationToken))
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                return false;
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+            return true;
+        }
+        catch
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            return false;
+        }
     }
 
     private async Task<bool> UpsertReminderOccurrencesAsync(
         System.Data.Common.DbConnection connection,
+        System.Data.Common.DbTransaction? transaction,
         IEnumerable<ScheduledReminder> reminders,
         CancellationToken cancellationToken)
     {
@@ -92,7 +137,7 @@ public sealed class SqlServerReminderStorage : IReminderStorage
             for (var offset = 0; offset < remindersList.Count; offset += MaxUpsertedRemindersPerStatement)
             {
                 var chunk = remindersList.Skip(offset).Take(MaxUpsertedRemindersPerStatement).ToList();
-                await using var command = connection.CreateCommand();
+                await using var command = CreateCommand(connection, transaction);
                 command.CommandText = _dialect.GetBatchUpsertRemindersSql(_settings.SchemaName, _settings.TableName, chunk.Count);
                 command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
 
@@ -190,33 +235,7 @@ public sealed class SqlServerReminderStorage : IReminderStorage
         {
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
-
-            var groups = remindersList.GroupBy(r => (r.Status, r.CompletedAt));
-            foreach (var group in groups)
-            {
-                var items = group.ToList();
-                for (var offset = 0; offset < items.Count; offset += MaxRemindersPerStatusUpdate)
-                {
-                    var chunk = items.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
-                    await using var command = connection.CreateCommand();
-                    command.CommandText = _dialect.GetBatchMarkCompletedSql(_settings.SchemaName, _settings.TableName, chunk.Count);
-                    command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-                    _dialect.AddParameter(command, "@CompletedAtUtc", group.Key.CompletedAt.UtcDateTime);
-                    _dialect.AddParameter(command, "@CompletionStatus", group.Key.Status.ToString());
-
-                    for (var i = 0; i < chunk.Count; i++)
-                    {
-                        _dialect.AddParameter(command, $"@sr{i}", chunk[i].Entity.ShardRegionName);
-                        _dialect.AddParameter(command, $"@eid{i}", chunk[i].Entity.EntityId);
-                        _dialect.AddParameter(command, $"@rk{i}", chunk[i].Key.Name);
-                        _dialect.AddParameter(command, $"@due{i}", chunk[i].DueTimeUtc.UtcDateTime);
-                    }
-
-                    await command.ExecuteNonQueryAsync(cancellationToken);
-                }
-            }
-
-            return true;
+            return await MarkRemindersAsCompletedAsync(connection, null, completedReminders, cancellationToken);
         }
         catch
         {
@@ -391,28 +410,7 @@ public sealed class SqlServerReminderStorage : IReminderStorage
         {
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
-
-            for (var offset = 0; offset < remindersList.Count; offset += MaxRemindersPerStatusUpdate)
-            {
-                var chunk = remindersList.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
-                await using var command = connection.CreateCommand();
-                command.CommandText = _dialect.GetBatchMarkAsAwaitingAckSql(_settings.SchemaName, _settings.TableName, chunk.Count);
-                command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
-                for (var i = 0; i < chunk.Count; i++)
-                {
-                    _dialect.AddParameter(command, $"@sr{i}", chunk[i].Entity.ShardRegionName);
-                    _dialect.AddParameter(command, $"@eid{i}", chunk[i].Entity.EntityId);
-                    _dialect.AddParameter(command, $"@rk{i}", chunk[i].Key.Name);
-                    _dialect.AddParameter(command, $"@due{i}", chunk[i].DueTimeUtc.UtcDateTime);
-                    _dialect.AddParameter(command, $"@del{i}", chunk[i].DeliveredAt.UtcDateTime);
-                    _dialect.AddParameter(command, $"@ack{i}", chunk[i].AckDeadline.UtcDateTime);
-                }
-
-                await command.ExecuteNonQueryAsync(cancellationToken);
-            }
-
-            return true;
+            return await MarkRemindersAsAwaitingAckAsync(connection, null, reminders, cancellationToken);
         }
         catch
         {
@@ -442,27 +440,50 @@ public sealed class SqlServerReminderStorage : IReminderStorage
     }
 
     public async Task<AckResult> AcknowledgeReminderAsync(ReminderEntity entity, ReminderKey key, DateTimeOffset dueTimeUtc, DateTimeOffset ackedAt, CancellationToken cancellationToken = default)
+        => (await AcknowledgeRemindersAsync([new ReminderAcknowledgement(entity, key, dueTimeUtc, ackedAt)], cancellationToken))[0];
+
+    public async Task<IReadOnlyList<AckResult>> AcknowledgeRemindersAsync(
+        IEnumerable<ReminderAcknowledgement> acknowledgements,
+        CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
-        try
+        var results = new List<AckResult>();
+
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        foreach (var acknowledgement in acknowledgements)
         {
-            await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
-            await connection.OpenAsync(cancellationToken);
-            await using var command = connection.CreateCommand();
-            command.CommandText = _dialect.GetAcknowledgeReminderSql(_settings.SchemaName, _settings.TableName);
-            command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-            _dialect.AddParameter(command, "@ShardRegionName", entity.ShardRegionName);
-            _dialect.AddParameter(command, "@EntityId", entity.EntityId);
-            _dialect.AddParameter(command, "@ReminderKey", key.Name);
-            _dialect.AddParameter(command, "@DueTimeUtc", dueTimeUtc.UtcDateTime);
-            _dialect.AddParameter(command, "@AckedAtUtc", ackedAt.UtcDateTime);
-            var count = await command.ExecuteNonQueryAsync(cancellationToken);
-            return new AckResult(count > 0);
+            try
+            {
+                await using var command = CreateCommand(connection, null);
+                command.CommandText = _dialect.GetAcknowledgeReminderSql(_settings.SchemaName, _settings.TableName);
+                command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+                _dialect.AddParameter(command, "@ShardRegionName", acknowledgement.Entity.ShardRegionName);
+                _dialect.AddParameter(command, "@EntityId", acknowledgement.Entity.EntityId);
+                _dialect.AddParameter(command, "@ReminderKey", acknowledgement.Key.Name);
+                _dialect.AddParameter(command, "@DueTimeUtc", acknowledgement.DueTimeUtc.UtcDateTime);
+                _dialect.AddParameter(command, "@AckedAtUtc", acknowledgement.AckedAt.UtcDateTime);
+                var count = await command.ExecuteNonQueryAsync(cancellationToken);
+                results.Add(new AckResult(
+                    acknowledgement.Entity,
+                    acknowledgement.Key,
+                    acknowledgement.DueTimeUtc,
+                    count > 0 ? ReminderAckStorageStatus.Success : ReminderAckStorageStatus.NotFound,
+                    count > 0 ? null : "Reminder occurrence was not awaiting acknowledgement or was already stale."));
+            }
+            catch (Exception ex)
+            {
+                results.Add(new AckResult(
+                    acknowledgement.Entity,
+                    acknowledgement.Key,
+                    acknowledgement.DueTimeUtc,
+                    ReminderAckStorageStatus.Error,
+                    ex.Message));
+            }
         }
-        catch
-        {
-            return new AckResult(false);
-        }
+
+        return results;
     }
 
     private Task EnsureInitializedAsync(CancellationToken cancellationToken)
@@ -508,6 +529,91 @@ public sealed class SqlServerReminderStorage : IReminderStorage
         _dialect.AddParameter(command, $"@LastFailureReason{index}", reminder.LastFailureReason ?? (object)DBNull.Value);
         _dialect.AddParameter(command, $"@MaxDeliveryWindowTicks{index}", reminder.MaxDeliveryWindow?.Ticks ?? (object)DBNull.Value);
         _dialect.AddParameter(command, $"@DeliveryDeadlineUtc{index}", reminder.DeliveryDeadlineUtc?.UtcDateTime ?? (object)DBNull.Value);
+    }
+
+    private async Task<bool> MarkRemindersAsCompletedAsync(
+        System.Data.Common.DbConnection connection,
+        System.Data.Common.DbTransaction? transaction,
+        IEnumerable<CompletedReminder> completedReminders,
+        CancellationToken cancellationToken)
+    {
+        var remindersList = completedReminders.ToList();
+        if (remindersList.Count == 0)
+            return true;
+
+        var groups = remindersList.GroupBy(r => (r.Status, r.CompletedAt));
+        foreach (var group in groups)
+        {
+            var items = group.ToList();
+            for (var offset = 0; offset < items.Count; offset += MaxRemindersPerStatusUpdate)
+            {
+                var chunk = items.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
+                await using var command = CreateCommand(connection, transaction);
+                command.CommandText = _dialect.GetBatchMarkCompletedSql(_settings.SchemaName, _settings.TableName, chunk.Count);
+                command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+                _dialect.AddParameter(command, "@CompletedAtUtc", group.Key.CompletedAt.UtcDateTime);
+                _dialect.AddParameter(command, "@CompletionStatus", group.Key.Status.ToString());
+
+                for (var i = 0; i < chunk.Count; i++)
+                {
+                    _dialect.AddParameter(command, $"@sr{i}", chunk[i].Entity.ShardRegionName);
+                    _dialect.AddParameter(command, $"@eid{i}", chunk[i].Entity.EntityId);
+                    _dialect.AddParameter(command, $"@rk{i}", chunk[i].Key.Name);
+                    _dialect.AddParameter(command, $"@due{i}", chunk[i].DueTimeUtc.UtcDateTime);
+                }
+
+                var updated = await command.ExecuteNonQueryAsync(cancellationToken);
+                if (updated != chunk.Count)
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private async Task<bool> MarkRemindersAsAwaitingAckAsync(
+        System.Data.Common.DbConnection connection,
+        System.Data.Common.DbTransaction? transaction,
+        IEnumerable<AwaitingAckReminder> reminders,
+        CancellationToken cancellationToken)
+    {
+        var remindersList = reminders.ToList();
+        if (remindersList.Count == 0)
+            return true;
+
+        for (var offset = 0; offset < remindersList.Count; offset += MaxRemindersPerStatusUpdate)
+        {
+            var chunk = remindersList.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
+            await using var command = CreateCommand(connection, transaction);
+            command.CommandText = _dialect.GetBatchMarkAsAwaitingAckSql(_settings.SchemaName, _settings.TableName, chunk.Count);
+            command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+            for (var i = 0; i < chunk.Count; i++)
+            {
+                _dialect.AddParameter(command, $"@sr{i}", chunk[i].Entity.ShardRegionName);
+                _dialect.AddParameter(command, $"@eid{i}", chunk[i].Entity.EntityId);
+                _dialect.AddParameter(command, $"@rk{i}", chunk[i].Key.Name);
+                _dialect.AddParameter(command, $"@due{i}", chunk[i].DueTimeUtc.UtcDateTime);
+                _dialect.AddParameter(command, $"@del{i}", chunk[i].DeliveredAt.UtcDateTime);
+                _dialect.AddParameter(command, $"@ack{i}", chunk[i].AckDeadline.UtcDateTime);
+            }
+
+            var updated = await command.ExecuteNonQueryAsync(cancellationToken);
+            if (updated != chunk.Count)
+                return false;
+        }
+
+        return true;
+    }
+
+    private static System.Data.Common.DbCommand CreateCommand(
+        System.Data.Common.DbConnection connection,
+        System.Data.Common.DbTransaction? transaction)
+    {
+        var command = connection.CreateCommand();
+        if (transaction is not null)
+            command.Transaction = transaction;
+        return command;
     }
 
     private (int serializerId, string? manifest, byte[] payload) SerializeMessage(object message)

--- a/src/Akka.Reminders.Sqlite/Internal/ISqlDialect.cs
+++ b/src/Akka.Reminders.Sqlite/Internal/ISqlDialect.cs
@@ -15,6 +15,9 @@ internal interface ISqlDialect
     string GetCancelReminderSql(string tableName);
     string GetCancelAllRemindersSql(string tableName);
     string GetFetchRemindersSql(string tableName);
+    string GetMarkAsAwaitingAckSql(string tableName);
+    string GetTimedOutAckRemindersSql(string tableName, int maxCount);
+    string GetAcknowledgeReminderSql(string tableName);
     DbConnection CreateConnection(string connectionString);
     void AddParameter(DbCommand command, string name, object value);
 }

--- a/src/Akka.Reminders.Sqlite/Internal/ISqlDialect.cs
+++ b/src/Akka.Reminders.Sqlite/Internal/ISqlDialect.cs
@@ -18,6 +18,7 @@ internal interface ISqlDialect
     string GetMarkAsAwaitingAckSql(string tableName);
     string GetTimedOutAckRemindersSql(string tableName, int maxCount);
     string GetAcknowledgeReminderSql(string tableName);
+    string GetResetAwaitingAckSql(string tableName);
     DbConnection CreateConnection(string connectionString);
     void AddParameter(DbCommand command, string name, object value);
 }

--- a/src/Akka.Reminders.Sqlite/Internal/ISqlDialect.cs
+++ b/src/Akka.Reminders.Sqlite/Internal/ISqlDialect.cs
@@ -5,20 +5,19 @@ namespace Akka.Reminders.Sqlite.Internal;
 internal interface ISqlDialect
 {
     string GetCreateTableSql(string tableName);
-    string GetUpsertReminderSql(string tableName);
+    string GetBatchUpsertRemindersSql(string tableName, int count);
     string GetSelectDueRemindersSql(string tableName, int maxCount);
-    string GetMarkCompletedSql(string tableName);
     string GetBatchMarkCompletedSql(string tableName, int count);
+    string GetExpireRemindersSql(string tableName);
     string GetCleanupSql(string tableName);
     string GetOverviewAggregateSql(string tableName);
     string GetNextReminderTimeSql(string tableName);
     string GetCancelReminderSql(string tableName);
     string GetCancelAllRemindersSql(string tableName);
     string GetFetchRemindersSql(string tableName);
-    string GetMarkAsAwaitingAckSql(string tableName);
+    string GetBatchMarkAsAwaitingAckSql(string tableName, int count);
     string GetTimedOutAckRemindersSql(string tableName, int maxCount);
     string GetAcknowledgeReminderSql(string tableName);
-    string GetResetAwaitingAckSql(string tableName);
     DbConnection CreateConnection(string connectionString);
     void AddParameter(DbCommand command, string name, object value);
 }

--- a/src/Akka.Reminders.Sqlite/Internal/ISqlDialect.cs
+++ b/src/Akka.Reminders.Sqlite/Internal/ISqlDialect.cs
@@ -18,6 +18,7 @@ internal interface ISqlDialect
     string GetBatchMarkAsAwaitingAckSql(string tableName, int count);
     string GetTimedOutAckRemindersSql(string tableName, int maxCount);
     string GetAcknowledgeReminderSql(string tableName);
+    string GetBatchAcknowledgeRemindersSql(string tableName, int count);
     DbConnection CreateConnection(string connectionString);
     void AddParameter(DbCommand command, string name, object value);
 }

--- a/src/Akka.Reminders.Sqlite/Internal/SqliteDialect.cs
+++ b/src/Akka.Reminders.Sqlite/Internal/SqliteDialect.cs
@@ -20,24 +20,27 @@ internal sealed class SqliteDialect : ISqlDialect
                 entity_id TEXT NOT NULL,
                 reminder_key TEXT NOT NULL,
                 when_utc TEXT NOT NULL,
+                due_time_utc TEXT NOT NULL,
                 repeat_interval_ticks INTEGER NULL,
                 serializer_id INTEGER NOT NULL,
                 manifest TEXT NULL,
                 payload BLOB NOT NULL,
                 attempt_count INTEGER NOT NULL DEFAULT 0,
                 last_failure_reason TEXT NULL,
+                max_delivery_window_ticks INTEGER NULL,
+                delivery_deadline_utc TEXT NULL,
                 is_completed INTEGER NOT NULL DEFAULT 0,
                 completed_at_utc TEXT NULL,
                 completion_status TEXT NOT NULL DEFAULT 'Pending',
                 delivered_at_utc TEXT NULL,
                 ack_deadline_utc TEXT NULL,
 
-                PRIMARY KEY (shard_region_name, entity_id, reminder_key)
+                PRIMARY KEY (shard_region_name, entity_id, reminder_key, due_time_utc)
             );
 
             CREATE INDEX IF NOT EXISTS ix_{tableName}_due_reminders
             ON {fullTableName} (when_utc, shard_region_name, entity_id)
-            WHERE is_completed = 0;
+            WHERE is_completed = 0 AND completion_status = 'Pending';
 
             CREATE INDEX IF NOT EXISTS ix_{tableName}_cleanup
             ON {fullTableName} (completed_at_utc)
@@ -45,24 +48,26 @@ internal sealed class SqliteDialect : ISqlDialect
 
             CREATE INDEX IF NOT EXISTS ix_{tableName}_awaiting_ack
             ON {fullTableName} (ack_deadline_utc)
-            WHERE completion_status = 'AwaitingAck';
+            WHERE completion_status = 'AwaitingAck' AND is_completed = 0;
             """;
     }
 
-    public string GetUpsertReminderSql(string tableName)
+    public string GetBatchUpsertRemindersSql(string tableName, int count)
     {
         var fullTableName = $"\"{tableName}\"";
+        var values = string.Join(",\n                ",
+            Enumerable.Range(0, count).Select(i =>
+                $"(@ShardRegionName{i}, @EntityId{i}, @ReminderKey{i}, @WhenUtc{i}, @DueTimeUtc{i}, @RepeatIntervalTicks{i}, @SerializerId{i}, @Manifest{i}, @Payload{i}, @AttemptCount{i}, @LastFailureReason{i}, @MaxDeliveryWindowTicks{i}, @DeliveryDeadlineUtc{i}, 0, NULL, 'Pending', NULL, NULL)"));
 
         return $"""
             INSERT INTO {fullTableName}
-                (shard_region_name, entity_id, reminder_key, when_utc, repeat_interval_ticks,
+                (shard_region_name, entity_id, reminder_key, when_utc, due_time_utc, repeat_interval_ticks,
                  serializer_id, manifest, payload, attempt_count, last_failure_reason,
-                 is_completed, completed_at_utc, completion_status)
+                 max_delivery_window_ticks, delivery_deadline_utc,
+                 is_completed, completed_at_utc, completion_status, delivered_at_utc, ack_deadline_utc)
             VALUES
-                (@ShardRegionName, @EntityId, @ReminderKey, @WhenUtc, @RepeatIntervalTicks,
-                 @SerializerId, @Manifest, @Payload, @AttemptCount, @LastFailureReason,
-                 0, NULL, 'Pending')
-            ON CONFLICT (shard_region_name, entity_id, reminder_key)
+                {values}
+            ON CONFLICT (shard_region_name, entity_id, reminder_key, due_time_utc)
             DO UPDATE SET
                 when_utc = excluded.when_utc,
                 repeat_interval_ticks = excluded.repeat_interval_ticks,
@@ -71,9 +76,13 @@ internal sealed class SqliteDialect : ISqlDialect
                 payload = excluded.payload,
                 attempt_count = excluded.attempt_count,
                 last_failure_reason = excluded.last_failure_reason,
+                max_delivery_window_ticks = excluded.max_delivery_window_ticks,
+                delivery_deadline_utc = excluded.delivery_deadline_utc,
                 is_completed = 0,
                 completed_at_utc = NULL,
-                completion_status = 'Pending';
+                completion_status = 'Pending',
+                delivered_at_utc = NULL,
+                ack_deadline_utc = NULL;
             """;
     }
 
@@ -85,29 +94,16 @@ internal sealed class SqliteDialect : ISqlDialect
         var fullTableName = $"\"{tableName}\"";
 
         return $"""
-            SELECT shard_region_name, entity_id, reminder_key, when_utc, repeat_interval_ticks,
-                   serializer_id, manifest, payload, attempt_count, last_failure_reason
+            SELECT shard_region_name, entity_id, reminder_key, when_utc, due_time_utc, repeat_interval_ticks,
+                   serializer_id, manifest, payload, attempt_count, last_failure_reason,
+                   max_delivery_window_ticks, delivery_deadline_utc
             FROM {fullTableName}
             WHERE is_completed = 0
               AND completion_status = 'Pending'
               AND when_utc <= @UntilDeadline
+              AND (delivery_deadline_utc IS NULL OR delivery_deadline_utc > @Now)
             ORDER BY when_utc ASC
             LIMIT {maxCount};
-            """;
-    }
-
-    public string GetMarkCompletedSql(string tableName)
-    {
-        var fullTableName = $"\"{tableName}\"";
-
-        return $"""
-            UPDATE {fullTableName}
-            SET is_completed = 1,
-                completed_at_utc = @CompletedAtUtc,
-                completion_status = @CompletionStatus
-            WHERE shard_region_name = @ShardRegionName
-              AND entity_id = @EntityId
-              AND reminder_key = @ReminderKey;
             """;
     }
 
@@ -117,14 +113,33 @@ internal sealed class SqliteDialect : ISqlDialect
 
         var predicates = string.Join(" OR ",
             Enumerable.Range(0, count).Select(i =>
-                $"(shard_region_name = @sr{i} AND entity_id = @eid{i} AND reminder_key = @rk{i})"));
+                $"(shard_region_name = @sr{i} AND entity_id = @eid{i} AND reminder_key = @rk{i} AND due_time_utc = @due{i})"));
 
         return $"""
             UPDATE {fullTableName}
             SET is_completed = 1,
                 completed_at_utc = @CompletedAtUtc,
-                completion_status = @CompletionStatus
+                completion_status = @CompletionStatus,
+                delivered_at_utc = NULL,
+                ack_deadline_utc = NULL
             WHERE {predicates};
+            """;
+    }
+
+    public string GetExpireRemindersSql(string tableName)
+    {
+        var fullTableName = $"\"{tableName}\"";
+
+        return $"""
+            UPDATE {fullTableName}
+            SET is_completed = 1,
+                completed_at_utc = @Now,
+                completion_status = 'Expired',
+                delivered_at_utc = NULL,
+                ack_deadline_utc = NULL
+            WHERE is_completed = 0
+              AND delivery_deadline_utc IS NOT NULL
+              AND delivery_deadline_utc <= @Now;
             """;
     }
 
@@ -146,7 +161,9 @@ internal sealed class SqliteDialect : ISqlDialect
         return $"""
             SELECT COUNT(*) AS total_count, MIN(when_utc) AS next_when_utc
             FROM {fullTableName}
-            WHERE is_completed = 0;
+            WHERE is_completed = 0
+              AND completion_status = 'Pending'
+              AND (delivery_deadline_utc IS NULL OR delivery_deadline_utc > @Now);
             """;
     }
 
@@ -158,6 +175,8 @@ internal sealed class SqliteDialect : ISqlDialect
             SELECT when_utc
             FROM {fullTableName}
             WHERE is_completed = 0
+              AND completion_status = 'Pending'
+              AND (delivery_deadline_utc IS NULL OR delivery_deadline_utc > @Now)
             ORDER BY when_utc ASC
             LIMIT 1 OFFSET @Skip;
             """;
@@ -171,7 +190,9 @@ internal sealed class SqliteDialect : ISqlDialect
             UPDATE {fullTableName}
             SET is_completed = 1,
                 completed_at_utc = @CompletedAtUtc,
-                completion_status = 'Cancelled'
+                completion_status = 'Cancelled',
+                delivered_at_utc = NULL,
+                ack_deadline_utc = NULL
             WHERE shard_region_name = @ShardRegionName
               AND entity_id = @EntityId
               AND reminder_key = @ReminderKey
@@ -187,7 +208,9 @@ internal sealed class SqliteDialect : ISqlDialect
             UPDATE {fullTableName}
             SET is_completed = 1,
                 completed_at_utc = @CompletedAtUtc,
-                completion_status = 'Cancelled'
+                completion_status = 'Cancelled',
+                delivered_at_utc = NULL,
+                ack_deadline_utc = NULL
             WHERE shard_region_name = @ShardRegionName
               AND entity_id = @EntityId
               AND is_completed = 0;
@@ -199,29 +222,45 @@ internal sealed class SqliteDialect : ISqlDialect
         var fullTableName = $"\"{tableName}\"";
 
         return $"""
-            SELECT shard_region_name, entity_id, reminder_key, when_utc, repeat_interval_ticks,
-                   serializer_id, manifest, payload, attempt_count, last_failure_reason, is_completed
+            SELECT shard_region_name, entity_id, reminder_key, when_utc, due_time_utc, repeat_interval_ticks,
+                   serializer_id, manifest, payload, attempt_count, last_failure_reason,
+                   max_delivery_window_ticks, delivery_deadline_utc
             FROM {fullTableName}
             WHERE shard_region_name = @ShardRegionName
               AND entity_id = @EntityId
               AND is_completed = 0
+              AND (delivery_deadline_utc IS NULL OR delivery_deadline_utc > @Now)
             ORDER BY when_utc ASC;
             """;
     }
 
-    public string GetMarkAsAwaitingAckSql(string tableName)
+    public string GetBatchMarkAsAwaitingAckSql(string tableName, int count)
     {
         var fullTableName = $"\"{tableName}\"";
+        var predicates = string.Join(" OR ",
+            Enumerable.Range(0, count).Select(i =>
+                $"(shard_region_name = @sr{i} AND entity_id = @eid{i} AND reminder_key = @rk{i} AND due_time_utc = @due{i})"));
+        var deliveredCases = string.Join("\n                ",
+            Enumerable.Range(0, count).Select(i =>
+                $"WHEN shard_region_name = @sr{i} AND entity_id = @eid{i} AND reminder_key = @rk{i} AND due_time_utc = @due{i} THEN @del{i}"));
+        var ackCases = string.Join("\n                ",
+            Enumerable.Range(0, count).Select(i =>
+                $"WHEN shard_region_name = @sr{i} AND entity_id = @eid{i} AND reminder_key = @rk{i} AND due_time_utc = @due{i} THEN @ack{i}"));
 
         return $"""
             UPDATE {fullTableName}
             SET completion_status = 'AwaitingAck',
-                delivered_at_utc = @DeliveredAtUtc,
-                ack_deadline_utc = @AckDeadlineUtc
-            WHERE shard_region_name = @ShardRegionName
-              AND entity_id = @EntityId
-              AND reminder_key = @ReminderKey
-              AND is_completed = 0;
+                delivered_at_utc = CASE
+                    {deliveredCases}
+                    ELSE delivered_at_utc
+                END,
+                ack_deadline_utc = CASE
+                    {ackCases}
+                    ELSE ack_deadline_utc
+                END
+            WHERE is_completed = 0
+              AND completion_status = 'Pending'
+              AND ({predicates});
             """;
     }
 
@@ -233,8 +272,9 @@ internal sealed class SqliteDialect : ISqlDialect
         var fullTableName = $"\"{tableName}\"";
 
         return $"""
-            SELECT shard_region_name, entity_id, reminder_key, when_utc, repeat_interval_ticks,
-                   serializer_id, manifest, payload, attempt_count, last_failure_reason
+            SELECT shard_region_name, entity_id, reminder_key, when_utc, due_time_utc, repeat_interval_ticks,
+                   serializer_id, manifest, payload, attempt_count, last_failure_reason,
+                   max_delivery_window_ticks, delivery_deadline_utc
             FROM {fullTableName}
             WHERE completion_status = 'AwaitingAck'
               AND is_completed = 0
@@ -248,34 +288,20 @@ internal sealed class SqliteDialect : ISqlDialect
     {
         var fullTableName = $"\"{tableName}\"";
 
-        // Returns the full reminder row so the caller can read repeat_interval_ticks and
-        // reconstruct the ScheduledReminder for rescheduling recurring reminders.
         return $"""
             UPDATE {fullTableName}
             SET is_completed = 1,
                 completed_at_utc = @AckedAtUtc,
-                completion_status = 'Delivered'
+                completion_status = 'Delivered',
+                delivered_at_utc = NULL,
+                ack_deadline_utc = NULL
             WHERE shard_region_name = @ShardRegionName
               AND entity_id = @EntityId
               AND reminder_key = @ReminderKey
+              AND due_time_utc = @DueTimeUtc
               AND completion_status = 'AwaitingAck'
               AND is_completed = 0
-            RETURNING shard_region_name, entity_id, reminder_key, when_utc, repeat_interval_ticks,
-                      serializer_id, manifest, payload, attempt_count, last_failure_reason;
-            """;
-    }
-
-    public string GetResetAwaitingAckSql(string tableName)
-    {
-        var fullTableName = $"\"{tableName}\"";
-
-        return $"""
-            UPDATE {fullTableName}
-            SET completion_status = 'Pending',
-                delivered_at_utc = NULL,
-                ack_deadline_utc = NULL
-            WHERE completion_status = 'AwaitingAck'
-              AND is_completed = 0;
+              AND (delivery_deadline_utc IS NULL OR delivery_deadline_utc > @AckedAtUtc);
             """;
     }
 

--- a/src/Akka.Reminders.Sqlite/Internal/SqliteDialect.cs
+++ b/src/Akka.Reminders.Sqlite/Internal/SqliteDialect.cs
@@ -265,6 +265,20 @@ internal sealed class SqliteDialect : ISqlDialect
             """;
     }
 
+    public string GetResetAwaitingAckSql(string tableName)
+    {
+        var fullTableName = $"\"{tableName}\"";
+
+        return $"""
+            UPDATE {fullTableName}
+            SET completion_status = 'Pending',
+                delivered_at_utc = NULL,
+                ack_deadline_utc = NULL
+            WHERE completion_status = 'AwaitingAck'
+              AND is_completed = 0;
+            """;
+    }
+
     public DbConnection CreateConnection(string connectionString)
     {
         return new SqliteConnection(connectionString);

--- a/src/Akka.Reminders.Sqlite/Internal/SqliteDialect.cs
+++ b/src/Akka.Reminders.Sqlite/Internal/SqliteDialect.cs
@@ -29,6 +29,8 @@ internal sealed class SqliteDialect : ISqlDialect
                 is_completed INTEGER NOT NULL DEFAULT 0,
                 completed_at_utc TEXT NULL,
                 completion_status TEXT NOT NULL DEFAULT 'Pending',
+                delivered_at_utc TEXT NULL,
+                ack_deadline_utc TEXT NULL,
 
                 PRIMARY KEY (shard_region_name, entity_id, reminder_key)
             );
@@ -40,6 +42,10 @@ internal sealed class SqliteDialect : ISqlDialect
             CREATE INDEX IF NOT EXISTS ix_{tableName}_cleanup
             ON {fullTableName} (completed_at_utc)
             WHERE is_completed = 1;
+
+            CREATE INDEX IF NOT EXISTS ix_{tableName}_awaiting_ack
+            ON {fullTableName} (ack_deadline_utc)
+            WHERE completion_status = 'AwaitingAck';
             """;
     }
 
@@ -83,6 +89,7 @@ internal sealed class SqliteDialect : ISqlDialect
                    serializer_id, manifest, payload, attempt_count, last_failure_reason
             FROM {fullTableName}
             WHERE is_completed = 0
+              AND completion_status = 'Pending'
               AND when_utc <= @UntilDeadline
             ORDER BY when_utc ASC
             LIMIT {maxCount};
@@ -199,6 +206,62 @@ internal sealed class SqliteDialect : ISqlDialect
               AND entity_id = @EntityId
               AND is_completed = 0
             ORDER BY when_utc ASC;
+            """;
+    }
+
+    public string GetMarkAsAwaitingAckSql(string tableName)
+    {
+        var fullTableName = $"\"{tableName}\"";
+
+        return $"""
+            UPDATE {fullTableName}
+            SET completion_status = 'AwaitingAck',
+                delivered_at_utc = @DeliveredAtUtc,
+                ack_deadline_utc = @AckDeadlineUtc
+            WHERE shard_region_name = @ShardRegionName
+              AND entity_id = @EntityId
+              AND reminder_key = @ReminderKey
+              AND is_completed = 0;
+            """;
+    }
+
+    public string GetTimedOutAckRemindersSql(string tableName, int maxCount)
+    {
+        if (maxCount < 1)
+            throw new ArgumentOutOfRangeException(nameof(maxCount), "maxCount must be greater than or equal to 1.");
+
+        var fullTableName = $"\"{tableName}\"";
+
+        return $"""
+            SELECT shard_region_name, entity_id, reminder_key, when_utc, repeat_interval_ticks,
+                   serializer_id, manifest, payload, attempt_count, last_failure_reason
+            FROM {fullTableName}
+            WHERE completion_status = 'AwaitingAck'
+              AND is_completed = 0
+              AND ack_deadline_utc <= @Now
+            ORDER BY ack_deadline_utc ASC
+            LIMIT {maxCount};
+            """;
+    }
+
+    public string GetAcknowledgeReminderSql(string tableName)
+    {
+        var fullTableName = $"\"{tableName}\"";
+
+        // Returns the full reminder row so the caller can read repeat_interval_ticks and
+        // reconstruct the ScheduledReminder for rescheduling recurring reminders.
+        return $"""
+            UPDATE {fullTableName}
+            SET is_completed = 1,
+                completed_at_utc = @AckedAtUtc,
+                completion_status = 'Delivered'
+            WHERE shard_region_name = @ShardRegionName
+              AND entity_id = @EntityId
+              AND reminder_key = @ReminderKey
+              AND completion_status = 'AwaitingAck'
+              AND is_completed = 0
+            RETURNING shard_region_name, entity_id, reminder_key, when_utc, repeat_interval_ticks,
+                      serializer_id, manifest, payload, attempt_count, last_failure_reason;
             """;
     }
 

--- a/src/Akka.Reminders.Sqlite/Internal/SqliteDialect.cs
+++ b/src/Akka.Reminders.Sqlite/Internal/SqliteDialect.cs
@@ -305,6 +305,36 @@ internal sealed class SqliteDialect : ISqlDialect
             """;
     }
 
+    public string GetBatchAcknowledgeRemindersSql(string tableName, int count)
+    {
+        var fullTableName = $"\"{tableName}\"";
+        var predicates = string.Join(" OR ",
+            Enumerable.Range(0, count).Select(i =>
+                $"(shard_region_name = @sr{i} AND entity_id = @eid{i} AND reminder_key = @rk{i} AND due_time_utc = @due{i})"));
+        var ackedCases = string.Join("\n                ",
+            Enumerable.Range(0, count).Select(i =>
+                $"WHEN shard_region_name = @sr{i} AND entity_id = @eid{i} AND reminder_key = @rk{i} AND due_time_utc = @due{i} THEN @acked{i}"));
+
+        return $"""
+            UPDATE {fullTableName}
+            SET is_completed = 1,
+                completed_at_utc = CASE
+                    {ackedCases}
+                    ELSE completed_at_utc
+                END,
+                completion_status = 'Delivered',
+                delivered_at_utc = NULL,
+                ack_deadline_utc = NULL
+            WHERE completion_status = 'AwaitingAck'
+              AND is_completed = 0
+              AND ({predicates})
+              AND (delivery_deadline_utc IS NULL OR delivery_deadline_utc > CASE
+                    {ackedCases}
+                    ELSE completed_at_utc
+                END);
+            """;
+    }
+
     public DbConnection CreateConnection(string connectionString)
     {
         return new SqliteConnection(connectionString);

--- a/src/Akka.Reminders.Sqlite/Scripts/Migrations/V0_6_0__add_ack_columns.sql
+++ b/src/Akka.Reminders.Sqlite/Scripts/Migrations/V0_6_0__add_ack_columns.sql
@@ -1,16 +1,69 @@
--- Migration for Akka.Reminders 0.6.0: Add acknowledgement columns
--- Adds delivered_at_utc and ack_deadline_utc to support reliable at-least-once delivery.
+-- Migration for Akka.Reminders 0.6.0: Full schema upgrade from 0.5.x
+-- SQLite cannot ALTER PRIMARY KEY, so we rename-and-recreate the table.
 --
--- This script is idempotent: SQLite's ADD COLUMN is safe to re-run if the column already exists
--- in SQLite 3.37.0+ (using IF NOT EXISTS on ALTER TABLE is not supported in older versions,
--- so wrap in a guard if needed for older environments).
+-- Steps:
+--   1. Rename existing table to scheduled_reminders_v05x
+--   2. Create new table with full 0.6.0 schema (includes due_time_utc in PK)
+--   3. Copy data from old table, mapping when_utc -> due_time_utc
+--   4. Drop old table
+--   5. Create all indexes
 --
 -- Note: This script uses the default table name 'scheduled_reminders'.
 --       If you use a custom table name, replace the table name accordingly.
 
-ALTER TABLE scheduled_reminders ADD COLUMN delivered_at_utc TEXT NULL;
-ALTER TABLE scheduled_reminders ADD COLUMN ack_deadline_utc TEXT NULL;
+ALTER TABLE scheduled_reminders RENAME TO scheduled_reminders_v05x;
+
+CREATE TABLE IF NOT EXISTS scheduled_reminders (
+    shard_region_name TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    reminder_key TEXT NOT NULL,
+    when_utc TEXT NOT NULL,
+    due_time_utc TEXT NOT NULL,
+    repeat_interval_ticks INTEGER NULL,
+    serializer_id INTEGER NOT NULL,
+    manifest TEXT NULL,
+    payload BLOB NOT NULL,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_failure_reason TEXT NULL,
+    max_delivery_window_ticks INTEGER NULL,
+    delivery_deadline_utc TEXT NULL,
+    is_completed INTEGER NOT NULL DEFAULT 0,
+    completed_at_utc TEXT NULL,
+    completion_status TEXT NOT NULL DEFAULT 'Pending',
+    delivered_at_utc TEXT NULL,
+    ack_deadline_utc TEXT NULL,
+    PRIMARY KEY (shard_region_name, entity_id, reminder_key, due_time_utc)
+);
+
+INSERT INTO scheduled_reminders (
+    shard_region_name, entity_id, reminder_key,
+    when_utc, due_time_utc, repeat_interval_ticks,
+    serializer_id, manifest, payload,
+    attempt_count, last_failure_reason,
+    max_delivery_window_ticks, delivery_deadline_utc,
+    is_completed, completed_at_utc, completion_status,
+    delivered_at_utc, ack_deadline_utc
+)
+SELECT
+    shard_region_name, entity_id, reminder_key,
+    when_utc, when_utc AS due_time_utc, repeat_interval_ticks,
+    serializer_id, manifest, payload,
+    attempt_count, last_failure_reason,
+    NULL, NULL,
+    is_completed, completed_at_utc, completion_status,
+    NULL, NULL
+FROM scheduled_reminders_v05x;
+
+DROP TABLE scheduled_reminders_v05x;
+
+CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_due_reminders
+ON scheduled_reminders (when_utc, shard_region_name, entity_id)
+WHERE is_completed = 0 AND completion_status = 'Pending';
+
+CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_cleanup
+ON scheduled_reminders (completed_at_utc)
+WHERE is_completed = 1;
 
 CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_awaiting_ack
 ON scheduled_reminders (ack_deadline_utc)
-WHERE completion_status = 'AwaitingAck';
+WHERE completion_status = 'AwaitingAck' AND is_completed = 0;

--- a/src/Akka.Reminders.Sqlite/Scripts/Migrations/V0_6_0__add_ack_columns.sql
+++ b/src/Akka.Reminders.Sqlite/Scripts/Migrations/V0_6_0__add_ack_columns.sql
@@ -1,0 +1,16 @@
+-- Migration for Akka.Reminders 0.6.0: Add acknowledgement columns
+-- Adds delivered_at_utc and ack_deadline_utc to support reliable at-least-once delivery.
+--
+-- This script is idempotent: SQLite's ADD COLUMN is safe to re-run if the column already exists
+-- in SQLite 3.37.0+ (using IF NOT EXISTS on ALTER TABLE is not supported in older versions,
+-- so wrap in a guard if needed for older environments).
+--
+-- Note: This script uses the default table name 'scheduled_reminders'.
+--       If you use a custom table name, replace the table name accordingly.
+
+ALTER TABLE scheduled_reminders ADD COLUMN delivered_at_utc TEXT NULL;
+ALTER TABLE scheduled_reminders ADD COLUMN ack_deadline_utc TEXT NULL;
+
+CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_awaiting_ack
+ON scheduled_reminders (ack_deadline_utc)
+WHERE completion_status = 'AwaitingAck';

--- a/src/Akka.Reminders.Sqlite/Scripts/Sqlite-Create.sql
+++ b/src/Akka.Reminders.Sqlite/Scripts/Sqlite-Create.sql
@@ -12,24 +12,27 @@ CREATE TABLE IF NOT EXISTS scheduled_reminders (
     entity_id TEXT NOT NULL,
     reminder_key TEXT NOT NULL,
     when_utc TEXT NOT NULL,
+    due_time_utc TEXT NOT NULL,
     repeat_interval_ticks INTEGER NULL,
     serializer_id INTEGER NOT NULL,
     manifest TEXT NULL,
     payload BLOB NOT NULL,
     attempt_count INTEGER NOT NULL DEFAULT 0,
     last_failure_reason TEXT NULL,
+    max_delivery_window_ticks INTEGER NULL,
+    delivery_deadline_utc TEXT NULL,
     is_completed INTEGER NOT NULL DEFAULT 0,
     completed_at_utc TEXT NULL,
     completion_status TEXT NOT NULL DEFAULT 'Pending',
     delivered_at_utc TEXT NULL,
     ack_deadline_utc TEXT NULL,
 
-    PRIMARY KEY (shard_region_name, entity_id, reminder_key)
+    PRIMARY KEY (shard_region_name, entity_id, reminder_key, due_time_utc)
 );
 
 CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_due_reminders
 ON scheduled_reminders (when_utc, shard_region_name, entity_id)
-WHERE is_completed = 0;
+WHERE is_completed = 0 AND completion_status = 'Pending';
 
 CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_cleanup
 ON scheduled_reminders (completed_at_utc)
@@ -37,4 +40,4 @@ WHERE is_completed = 1;
 
 CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_awaiting_ack
 ON scheduled_reminders (ack_deadline_utc)
-WHERE completion_status = 'AwaitingAck';
+WHERE completion_status = 'AwaitingAck' AND is_completed = 0;

--- a/src/Akka.Reminders.Sqlite/Scripts/Sqlite-Create.sql
+++ b/src/Akka.Reminders.Sqlite/Scripts/Sqlite-Create.sql
@@ -21,6 +21,8 @@ CREATE TABLE IF NOT EXISTS scheduled_reminders (
     is_completed INTEGER NOT NULL DEFAULT 0,
     completed_at_utc TEXT NULL,
     completion_status TEXT NOT NULL DEFAULT 'Pending',
+    delivered_at_utc TEXT NULL,
+    ack_deadline_utc TEXT NULL,
 
     PRIMARY KEY (shard_region_name, entity_id, reminder_key)
 );
@@ -32,3 +34,7 @@ WHERE is_completed = 0;
 CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_cleanup
 ON scheduled_reminders (completed_at_utc)
 WHERE is_completed = 1;
+
+CREATE INDEX IF NOT EXISTS ix_scheduled_reminders_awaiting_ack
+ON scheduled_reminders (ack_deadline_utc)
+WHERE completion_status = 'AwaitingAck';

--- a/src/Akka.Reminders.Sqlite/SqliteReminderStorage.cs
+++ b/src/Akka.Reminders.Sqlite/SqliteReminderStorage.cs
@@ -484,6 +484,21 @@ public sealed class SqliteReminderStorage : IReminderStorage
         return reminders;
     }
 
+    public async Task<DateTimeOffset?> GetNextAwaitingAckDeadlineAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"SELECT MIN(ack_deadline_utc) FROM \"{_settings.TableName}\" WHERE completion_status = 'AwaitingAck' AND is_completed = 0;";
+        command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+        return result is null || result == DBNull.Value ? null : ParseDateTimeOffset(result);
+    }
+
     public async Task<AckResult> AcknowledgeReminderAsync(
         ReminderEntity entity,
         ReminderKey key,
@@ -497,10 +512,74 @@ public sealed class SqliteReminderStorage : IReminderStorage
         CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
-        var results = new List<AckResult>();
+        var acknowledgementList = acknowledgements.ToList();
+        var results = new List<AckResult>(acknowledgementList.Count);
+
+        if (acknowledgementList.Count == 0)
+            return results;
 
         await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
         await connection.OpenAsync(cancellationToken);
+
+        for (var offset = 0; offset < acknowledgementList.Count; offset += MaxRemindersPerStatusUpdate)
+        {
+            var chunk = acknowledgementList.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
+            results.AddRange(await AcknowledgeReminderChunkAsync(connection, chunk, cancellationToken));
+        }
+
+        return results;
+    }
+
+    private async Task<IReadOnlyList<AckResult>> AcknowledgeReminderChunkAsync(
+        System.Data.Common.DbConnection connection,
+        IReadOnlyList<ReminderAcknowledgement> acknowledgements,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+            await using var command = CreateCommand(connection, transaction);
+            command.CommandText = _dialect.GetBatchAcknowledgeRemindersSql(_settings.TableName, acknowledgements.Count);
+            command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+            for (var i = 0; i < acknowledgements.Count; i++)
+            {
+                var acknowledgement = acknowledgements[i];
+                _dialect.AddParameter(command, $"@sr{i}", acknowledgement.Entity.ShardRegionName);
+                _dialect.AddParameter(command, $"@eid{i}", acknowledgement.Entity.EntityId);
+                _dialect.AddParameter(command, $"@rk{i}", acknowledgement.Key.Name);
+                _dialect.AddParameter(command, $"@due{i}", acknowledgement.DueTimeUtc.UtcDateTime);
+                _dialect.AddParameter(command, $"@acked{i}", acknowledgement.AckedAt.UtcDateTime);
+            }
+
+            var updated = await command.ExecuteNonQueryAsync(cancellationToken);
+            if (updated == acknowledgements.Count)
+            {
+                await transaction.CommitAsync(cancellationToken);
+                return acknowledgements.Select(ToSuccessfulAckResult).ToList();
+            }
+
+            await transaction.RollbackAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            return acknowledgements.Select(a => new AckResult(
+                a.Entity,
+                a.Key,
+                a.DueTimeUtc,
+                ReminderAckStorageStatus.Error,
+                ex.Message)).ToList();
+        }
+
+        return await AcknowledgeRemindersIndividuallyAsync(connection, acknowledgements, cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<AckResult>> AcknowledgeRemindersIndividuallyAsync(
+        System.Data.Common.DbConnection connection,
+        IReadOnlyList<ReminderAcknowledgement> acknowledgements,
+        CancellationToken cancellationToken)
+    {
+        var results = new List<AckResult>(acknowledgements.Count);
 
         foreach (var acknowledgement in acknowledgements)
         {
@@ -517,12 +596,9 @@ public sealed class SqliteReminderStorage : IReminderStorage
                 _dialect.AddParameter(command, "@AckedAtUtc", acknowledgement.AckedAt.UtcDateTime);
 
                 var count = await command.ExecuteNonQueryAsync(cancellationToken);
-                results.Add(new AckResult(
-                    acknowledgement.Entity,
-                    acknowledgement.Key,
-                    acknowledgement.DueTimeUtc,
-                    count > 0 ? ReminderAckStorageStatus.Success : ReminderAckStorageStatus.NotFound,
-                    count > 0 ? null : "Reminder occurrence was not awaiting acknowledgement or was already stale."));
+                results.Add(count > 0
+                    ? ToSuccessfulAckResult(acknowledgement)
+                    : ToMissingAckResult(acknowledgement));
             }
             catch (Exception ex)
             {
@@ -537,6 +613,21 @@ public sealed class SqliteReminderStorage : IReminderStorage
 
         return results;
     }
+
+    private static AckResult ToSuccessfulAckResult(ReminderAcknowledgement acknowledgement)
+        => new(
+            acknowledgement.Entity,
+            acknowledgement.Key,
+            acknowledgement.DueTimeUtc,
+            ReminderAckStorageStatus.Success);
+
+    private static AckResult ToMissingAckResult(ReminderAcknowledgement acknowledgement)
+        => new(
+            acknowledgement.Entity,
+            acknowledgement.Key,
+            acknowledgement.DueTimeUtc,
+            ReminderAckStorageStatus.NotFound,
+            "Reminder occurrence was not awaiting acknowledgement or was already stale.");
 
     private Task EnsureInitializedAsync(CancellationToken cancellationToken)
     {

--- a/src/Akka.Reminders.Sqlite/SqliteReminderStorage.cs
+++ b/src/Akka.Reminders.Sqlite/SqliteReminderStorage.cs
@@ -407,6 +407,117 @@ public sealed class SqliteReminderStorage : IReminderStorage
         return reminders.Skip(skip).Take(take).ToList();
     }
 
+    public async Task<bool> MarkRemindersAsAwaitingAckAsync(
+        IEnumerable<AwaitingAckReminder> reminders,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+
+        var remindersList = reminders.ToList();
+        if (remindersList.Count == 0)
+            return true;
+
+        try
+        {
+            await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            foreach (var reminder in remindersList)
+            {
+                await using var command = connection.CreateCommand();
+                command.CommandText = _dialect.GetMarkAsAwaitingAckSql(_settings.TableName);
+                command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+                _dialect.AddParameter(command, "@ShardRegionName", reminder.Entity.ShardRegionName);
+                _dialect.AddParameter(command, "@EntityId", reminder.Entity.EntityId);
+                _dialect.AddParameter(command, "@ReminderKey", reminder.Key.Name);
+                _dialect.AddParameter(command, "@DeliveredAtUtc", reminder.DeliveredAt.UtcDateTime);
+                _dialect.AddParameter(command, "@AckDeadlineUtc", reminder.AckDeadline.UtcDateTime);
+
+                await command.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    public async Task<IReadOnlyList<ScheduledReminder>> GetTimedOutAckRemindersAsync(
+        DateTimeOffset now,
+        ReminderBatchSize maxCount,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+
+        var reminders = new List<ScheduledReminder>();
+
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = _dialect.GetTimedOutAckRemindersSql(_settings.TableName, maxCount.Value);
+        command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+        _dialect.AddParameter(command, "@Now", now.UtcDateTime);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            var reminder = ReadReminderFromReader(reader);
+            reminders.Add(reminder);
+        }
+
+        return reminders;
+    }
+
+    public async Task<AckResult> AcknowledgeReminderAsync(
+        ReminderEntity entity,
+        ReminderKey key,
+        DateTimeOffset ackedAt,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+
+        try
+        {
+            await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = _dialect.GetAcknowledgeReminderSql(_settings.TableName);
+            command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+            _dialect.AddParameter(command, "@ShardRegionName", entity.ShardRegionName);
+            _dialect.AddParameter(command, "@EntityId", entity.EntityId);
+            _dialect.AddParameter(command, "@ReminderKey", key.Name);
+            _dialect.AddParameter(command, "@AckedAtUtc", ackedAt.UtcDateTime);
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+            if (!await reader.ReadAsync(cancellationToken))
+            {
+                // No row updated — reminder was not in AwaitingAck state
+                return new AckResult(Success: false, IsRecurring: false, OriginalReminder: null);
+            }
+
+            var original = ReadReminderFromReader(reader);
+            var isRecurring = original.RepeatInterval.HasValue;
+
+            return new AckResult(
+                Success: true,
+                IsRecurring: isRecurring,
+                OriginalReminder: isRecurring ? original : null);
+        }
+        catch (Exception)
+        {
+            return new AckResult(Success: false, IsRecurring: false, OriginalReminder: null);
+        }
+    }
+
     private Task EnsureInitializedAsync(CancellationToken cancellationToken)
     {
         if (_initialized || !_settings.AutoInitialize)

--- a/src/Akka.Reminders.Sqlite/SqliteReminderStorage.cs
+++ b/src/Akka.Reminders.Sqlite/SqliteReminderStorage.cs
@@ -40,8 +40,9 @@ public sealed class SqliteReminderStorage : IReminderStorage
         {
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
+            await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
 
-            await using (var cancelCommand = connection.CreateCommand())
+            await using (var cancelCommand = CreateCommand(connection, transaction))
             {
                 cancelCommand.CommandText = _dialect.GetCancelReminderSql(_settings.TableName);
                 cancelCommand.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
@@ -52,13 +53,16 @@ public sealed class SqliteReminderStorage : IReminderStorage
                 await cancelCommand.ExecuteNonQueryAsync(cancellationToken);
             }
 
-            if (!await UpsertReminderOccurrencesAsync(connection, [reminder], cancellationToken))
+            if (!await UpsertReminderOccurrencesAsync(connection, transaction, [reminder], cancellationToken))
             {
+                await transaction.RollbackAsync(cancellationToken);
                 return new ReminderProtocol.ReminderScheduled(
                     reminder.ToScheduleReminder(),
                     ReminderScheduleResponseCode.Error,
                     "Failed to persist reminder occurrence");
             }
+
+            await transaction.CommitAsync(cancellationToken);
 
             return new ReminderProtocol.ReminderScheduled(
                 reminder.ToScheduleReminder(),
@@ -81,11 +85,52 @@ public sealed class SqliteReminderStorage : IReminderStorage
 
         await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
         await connection.OpenAsync(cancellationToken);
-        return await UpsertReminderOccurrencesAsync(connection, reminders, cancellationToken);
+        return await UpsertReminderOccurrencesAsync(connection, null, reminders, cancellationToken);
+    }
+
+    public async Task<bool> CommitReminderMutationsAsync(ReminderMutationBatch mutationBatch, CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+        if (mutationBatch.IsEmpty)
+            return true;
+
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+        try
+        {
+            if (!await UpsertReminderOccurrencesAsync(connection, transaction, mutationBatch.PendingUpserts, cancellationToken))
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                return false;
+            }
+
+            if (!await MarkRemindersAsCompletedAsync(connection, transaction, mutationBatch.CompletedReminders, cancellationToken))
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                return false;
+            }
+
+            if (!await MarkRemindersAsAwaitingAckAsync(connection, transaction, mutationBatch.AwaitingAckReminders, cancellationToken))
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                return false;
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+            return true;
+        }
+        catch
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            return false;
+        }
     }
 
     private async Task<bool> UpsertReminderOccurrencesAsync(
-        IDbConnection connection,
+        System.Data.Common.DbConnection connection,
+        System.Data.Common.DbTransaction? transaction,
         IEnumerable<ScheduledReminder> reminders,
         CancellationToken cancellationToken)
     {
@@ -98,7 +143,7 @@ public sealed class SqliteReminderStorage : IReminderStorage
             for (var offset = 0; offset < remindersList.Count; offset += MaxUpsertedRemindersPerStatement)
             {
                 var chunk = remindersList.Skip(offset).Take(MaxUpsertedRemindersPerStatement).ToList();
-                await using var command = ((System.Data.Common.DbConnection)connection).CreateCommand();
+                await using var command = CreateCommand(connection, transaction);
                 command.CommandText = _dialect.GetBatchUpsertRemindersSql(_settings.TableName, chunk.Count);
                 command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
 
@@ -201,34 +246,7 @@ public sealed class SqliteReminderStorage : IReminderStorage
         {
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
-
-            var groups = remindersList.GroupBy(r => (r.Status, r.CompletedAt));
-            foreach (var group in groups)
-            {
-                var items = group.ToList();
-                for (var offset = 0; offset < items.Count; offset += MaxRemindersPerStatusUpdate)
-                {
-                    var chunk = items.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
-                    await using var command = connection.CreateCommand();
-                    command.CommandText = _dialect.GetBatchMarkCompletedSql(_settings.TableName, chunk.Count);
-                    command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
-                    _dialect.AddParameter(command, "@CompletedAtUtc", group.Key.CompletedAt.UtcDateTime);
-                    _dialect.AddParameter(command, "@CompletionStatus", group.Key.Status.ToString());
-
-                    for (var i = 0; i < chunk.Count; i++)
-                    {
-                        _dialect.AddParameter(command, $"@sr{i}", chunk[i].Entity.ShardRegionName);
-                        _dialect.AddParameter(command, $"@eid{i}", chunk[i].Entity.EntityId);
-                        _dialect.AddParameter(command, $"@rk{i}", chunk[i].Key.Name);
-                        _dialect.AddParameter(command, $"@due{i}", chunk[i].DueTimeUtc.UtcDateTime);
-                    }
-
-                    await command.ExecuteNonQueryAsync(cancellationToken);
-                }
-            }
-
-            return true;
+            return await MarkRemindersAsCompletedAsync(connection, null, completedReminders, cancellationToken);
         }
         catch
         {
@@ -432,28 +450,7 @@ public sealed class SqliteReminderStorage : IReminderStorage
         {
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
-
-            for (var offset = 0; offset < remindersList.Count; offset += MaxRemindersPerStatusUpdate)
-            {
-                var chunk = remindersList.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
-                await using var command = connection.CreateCommand();
-                command.CommandText = _dialect.GetBatchMarkAsAwaitingAckSql(_settings.TableName, chunk.Count);
-                command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
-                for (var i = 0; i < chunk.Count; i++)
-                {
-                    _dialect.AddParameter(command, $"@sr{i}", chunk[i].Entity.ShardRegionName);
-                    _dialect.AddParameter(command, $"@eid{i}", chunk[i].Entity.EntityId);
-                    _dialect.AddParameter(command, $"@rk{i}", chunk[i].Key.Name);
-                    _dialect.AddParameter(command, $"@due{i}", chunk[i].DueTimeUtc.UtcDateTime);
-                    _dialect.AddParameter(command, $"@del{i}", chunk[i].DeliveredAt.UtcDateTime);
-                    _dialect.AddParameter(command, $"@ack{i}", chunk[i].AckDeadline.UtcDateTime);
-                }
-
-                await command.ExecuteNonQueryAsync(cancellationToken);
-            }
-
-            return true;
+            return await MarkRemindersAsAwaitingAckAsync(connection, null, reminders, cancellationToken);
         }
         catch
         {
@@ -493,31 +490,52 @@ public sealed class SqliteReminderStorage : IReminderStorage
         DateTimeOffset dueTimeUtc,
         DateTimeOffset ackedAt,
         CancellationToken cancellationToken = default)
+        => (await AcknowledgeRemindersAsync([new ReminderAcknowledgement(entity, key, dueTimeUtc, ackedAt)], cancellationToken))[0];
+
+    public async Task<IReadOnlyList<AckResult>> AcknowledgeRemindersAsync(
+        IEnumerable<ReminderAcknowledgement> acknowledgements,
+        CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);
+        var results = new List<AckResult>();
 
-        try
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        foreach (var acknowledgement in acknowledgements)
         {
-            await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
-            await connection.OpenAsync(cancellationToken);
+            try
+            {
+                await using var command = CreateCommand(connection, null);
+                command.CommandText = _dialect.GetAcknowledgeReminderSql(_settings.TableName);
+                command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
 
-            await using var command = connection.CreateCommand();
-            command.CommandText = _dialect.GetAcknowledgeReminderSql(_settings.TableName);
-            command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+                _dialect.AddParameter(command, "@ShardRegionName", acknowledgement.Entity.ShardRegionName);
+                _dialect.AddParameter(command, "@EntityId", acknowledgement.Entity.EntityId);
+                _dialect.AddParameter(command, "@ReminderKey", acknowledgement.Key.Name);
+                _dialect.AddParameter(command, "@DueTimeUtc", acknowledgement.DueTimeUtc.UtcDateTime);
+                _dialect.AddParameter(command, "@AckedAtUtc", acknowledgement.AckedAt.UtcDateTime);
 
-            _dialect.AddParameter(command, "@ShardRegionName", entity.ShardRegionName);
-            _dialect.AddParameter(command, "@EntityId", entity.EntityId);
-            _dialect.AddParameter(command, "@ReminderKey", key.Name);
-            _dialect.AddParameter(command, "@DueTimeUtc", dueTimeUtc.UtcDateTime);
-            _dialect.AddParameter(command, "@AckedAtUtc", ackedAt.UtcDateTime);
-
-            var count = await command.ExecuteNonQueryAsync(cancellationToken);
-            return new AckResult(count > 0);
+                var count = await command.ExecuteNonQueryAsync(cancellationToken);
+                results.Add(new AckResult(
+                    acknowledgement.Entity,
+                    acknowledgement.Key,
+                    acknowledgement.DueTimeUtc,
+                    count > 0 ? ReminderAckStorageStatus.Success : ReminderAckStorageStatus.NotFound,
+                    count > 0 ? null : "Reminder occurrence was not awaiting acknowledgement or was already stale."));
+            }
+            catch (Exception ex)
+            {
+                results.Add(new AckResult(
+                    acknowledgement.Entity,
+                    acknowledgement.Key,
+                    acknowledgement.DueTimeUtc,
+                    ReminderAckStorageStatus.Error,
+                    ex.Message));
+            }
         }
-        catch
-        {
-            return new AckResult(false);
-        }
+
+        return results;
     }
 
     private Task EnsureInitializedAsync(CancellationToken cancellationToken)
@@ -564,6 +582,91 @@ public sealed class SqliteReminderStorage : IReminderStorage
         _dialect.AddParameter(command, $"@LastFailureReason{index}", reminder.LastFailureReason ?? (object)DBNull.Value);
         _dialect.AddParameter(command, $"@MaxDeliveryWindowTicks{index}", reminder.MaxDeliveryWindow?.Ticks ?? (object)DBNull.Value);
         _dialect.AddParameter(command, $"@DeliveryDeadlineUtc{index}", reminder.DeliveryDeadlineUtc?.UtcDateTime ?? (object)DBNull.Value);
+    }
+
+    private async Task<bool> MarkRemindersAsCompletedAsync(
+        System.Data.Common.DbConnection connection,
+        System.Data.Common.DbTransaction? transaction,
+        IEnumerable<CompletedReminder> completedReminders,
+        CancellationToken cancellationToken)
+    {
+        var remindersList = completedReminders.ToList();
+        if (remindersList.Count == 0)
+            return true;
+
+        var groups = remindersList.GroupBy(r => (r.Status, r.CompletedAt));
+        foreach (var group in groups)
+        {
+            var items = group.ToList();
+            for (var offset = 0; offset < items.Count; offset += MaxRemindersPerStatusUpdate)
+            {
+                var chunk = items.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
+                await using var command = CreateCommand(connection, transaction);
+                command.CommandText = _dialect.GetBatchMarkCompletedSql(_settings.TableName, chunk.Count);
+                command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+                _dialect.AddParameter(command, "@CompletedAtUtc", group.Key.CompletedAt.UtcDateTime);
+                _dialect.AddParameter(command, "@CompletionStatus", group.Key.Status.ToString());
+
+                for (var i = 0; i < chunk.Count; i++)
+                {
+                    _dialect.AddParameter(command, $"@sr{i}", chunk[i].Entity.ShardRegionName);
+                    _dialect.AddParameter(command, $"@eid{i}", chunk[i].Entity.EntityId);
+                    _dialect.AddParameter(command, $"@rk{i}", chunk[i].Key.Name);
+                    _dialect.AddParameter(command, $"@due{i}", chunk[i].DueTimeUtc.UtcDateTime);
+                }
+
+                var updated = await command.ExecuteNonQueryAsync(cancellationToken);
+                if (updated != chunk.Count)
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private async Task<bool> MarkRemindersAsAwaitingAckAsync(
+        System.Data.Common.DbConnection connection,
+        System.Data.Common.DbTransaction? transaction,
+        IEnumerable<AwaitingAckReminder> reminders,
+        CancellationToken cancellationToken)
+    {
+        var remindersList = reminders.ToList();
+        if (remindersList.Count == 0)
+            return true;
+
+        for (var offset = 0; offset < remindersList.Count; offset += MaxRemindersPerStatusUpdate)
+        {
+            var chunk = remindersList.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
+            await using var command = CreateCommand(connection, transaction);
+            command.CommandText = _dialect.GetBatchMarkAsAwaitingAckSql(_settings.TableName, chunk.Count);
+            command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+            for (var i = 0; i < chunk.Count; i++)
+            {
+                _dialect.AddParameter(command, $"@sr{i}", chunk[i].Entity.ShardRegionName);
+                _dialect.AddParameter(command, $"@eid{i}", chunk[i].Entity.EntityId);
+                _dialect.AddParameter(command, $"@rk{i}", chunk[i].Key.Name);
+                _dialect.AddParameter(command, $"@due{i}", chunk[i].DueTimeUtc.UtcDateTime);
+                _dialect.AddParameter(command, $"@del{i}", chunk[i].DeliveredAt.UtcDateTime);
+                _dialect.AddParameter(command, $"@ack{i}", chunk[i].AckDeadline.UtcDateTime);
+            }
+
+            var updated = await command.ExecuteNonQueryAsync(cancellationToken);
+            if (updated != chunk.Count)
+                return false;
+        }
+
+        return true;
+    }
+
+    private static System.Data.Common.DbCommand CreateCommand(
+        System.Data.Common.DbConnection connection,
+        System.Data.Common.DbTransaction? transaction)
+    {
+        var command = connection.CreateCommand();
+        if (transaction is not null)
+            command.Transaction = transaction;
+        return command;
     }
 
     private (int serializerId, string? manifest, byte[] payload) SerializeMessage(object message)

--- a/src/Akka.Reminders.Sqlite/SqliteReminderStorage.cs
+++ b/src/Akka.Reminders.Sqlite/SqliteReminderStorage.cs
@@ -518,6 +518,20 @@ public sealed class SqliteReminderStorage : IReminderStorage
         }
     }
 
+    public async Task<int> ResetAwaitingAckToPendingAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = _dialect.GetResetAwaitingAckSql(_settings.TableName);
+        command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+        return await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
     private Task EnsureInitializedAsync(CancellationToken cancellationToken)
     {
         if (_initialized || !_settings.AutoInitialize)

--- a/src/Akka.Reminders.Sqlite/SqliteReminderStorage.cs
+++ b/src/Akka.Reminders.Sqlite/SqliteReminderStorage.cs
@@ -18,6 +18,9 @@ public sealed class SqliteReminderStorage : IReminderStorage
     private readonly object _initLock = new();
     private volatile bool _initialized;
 
+    private const int MaxUpsertedRemindersPerStatement = 60;
+    private const int MaxRemindersPerStatusUpdate = 200;
+
     public SqliteReminderStorage(SqliteReminderStorageSettings settings, ActorSystem system)
     {
         _settings = settings ?? throw new ArgumentNullException(nameof(settings));
@@ -35,27 +38,27 @@ public sealed class SqliteReminderStorage : IReminderStorage
 
         try
         {
-            var (serializerId, manifest, payload) = SerializeMessage(reminder.Message);
-
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
 
-            await using var command = connection.CreateCommand();
-            command.CommandText = _dialect.GetUpsertReminderSql(_settings.TableName);
-            command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+            await using (var cancelCommand = connection.CreateCommand())
+            {
+                cancelCommand.CommandText = _dialect.GetCancelReminderSql(_settings.TableName);
+                cancelCommand.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+                _dialect.AddParameter(cancelCommand, "@ShardRegionName", reminder.Entity.ShardRegionName);
+                _dialect.AddParameter(cancelCommand, "@EntityId", reminder.Entity.EntityId);
+                _dialect.AddParameter(cancelCommand, "@ReminderKey", reminder.Key.Name);
+                _dialect.AddParameter(cancelCommand, "@CompletedAtUtc", DateTimeOffset.UtcNow.UtcDateTime);
+                await cancelCommand.ExecuteNonQueryAsync(cancellationToken);
+            }
 
-            _dialect.AddParameter(command, "@ShardRegionName", reminder.Entity.ShardRegionName);
-            _dialect.AddParameter(command, "@EntityId", reminder.Entity.EntityId);
-            _dialect.AddParameter(command, "@ReminderKey", reminder.Key.Name);
-            _dialect.AddParameter(command, "@WhenUtc", reminder.When);
-            _dialect.AddParameter(command, "@RepeatIntervalTicks", reminder.RepeatInterval?.Ticks ?? (object)DBNull.Value);
-            _dialect.AddParameter(command, "@SerializerId", serializerId);
-            _dialect.AddParameter(command, "@Manifest", manifest ?? (object)DBNull.Value);
-            _dialect.AddParameter(command, "@Payload", payload);
-            _dialect.AddParameter(command, "@AttemptCount", reminder.AttemptCount);
-            _dialect.AddParameter(command, "@LastFailureReason", reminder.LastFailureReason ?? (object)DBNull.Value);
-
-            await command.ExecuteNonQueryAsync(cancellationToken);
+            if (!await UpsertReminderOccurrencesAsync(connection, [reminder], cancellationToken))
+            {
+                return new ReminderProtocol.ReminderScheduled(
+                    reminder.ToScheduleReminder(),
+                    ReminderScheduleResponseCode.Error,
+                    "Failed to persist reminder occurrence");
+            }
 
             return new ReminderProtocol.ReminderScheduled(
                 reminder.ToScheduleReminder(),
@@ -67,6 +70,51 @@ public sealed class SqliteReminderStorage : IReminderStorage
                 reminder.ToScheduleReminder(),
                 ReminderScheduleResponseCode.Error,
                 ex.Message);
+        }
+    }
+
+    public async Task<bool> UpsertReminderOccurrencesAsync(
+        IEnumerable<ScheduledReminder> reminders,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+        return await UpsertReminderOccurrencesAsync(connection, reminders, cancellationToken);
+    }
+
+    private async Task<bool> UpsertReminderOccurrencesAsync(
+        IDbConnection connection,
+        IEnumerable<ScheduledReminder> reminders,
+        CancellationToken cancellationToken)
+    {
+        var remindersList = reminders.ToList();
+        if (remindersList.Count == 0)
+            return true;
+
+        try
+        {
+            for (var offset = 0; offset < remindersList.Count; offset += MaxUpsertedRemindersPerStatement)
+            {
+                var chunk = remindersList.Skip(offset).Take(MaxUpsertedRemindersPerStatement).ToList();
+                await using var command = ((System.Data.Common.DbConnection)connection).CreateCommand();
+                command.CommandText = _dialect.GetBatchUpsertRemindersSql(_settings.TableName, chunk.Count);
+                command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+
+                for (var i = 0; i < chunk.Count; i++)
+                {
+                    BindReminderParameters(command, i, chunk[i]);
+                }
+
+                await command.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            return true;
+        }
+        catch
+        {
+            return false;
         }
     }
 
@@ -88,16 +136,15 @@ public sealed class SqliteReminderStorage : IReminderStorage
         command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
 
         _dialect.AddParameter(command, "@UntilDeadline", untilDeadline.UtcDateTime);
+        _dialect.AddParameter(command, "@Now", now.UtcDateTime);
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
 
         while (await reader.ReadAsync(cancellationToken))
         {
-            var reminder = ReadReminderFromReader(reader);
-            reminders.Add(reminder);
+            reminders.Add(ReadReminderFromReader(reader));
         }
 
-        // Get overview of remaining reminders using aggregate queries
         await using var conn2 = _dialect.CreateConnection(_settings.ConnectionString);
         await conn2.OpenAsync(cancellationToken);
 
@@ -106,11 +153,11 @@ public sealed class SqliteReminderStorage : IReminderStorage
         {
             cmd2.CommandText = _dialect.GetOverviewAggregateSql(_settings.TableName);
             cmd2.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+            _dialect.AddParameter(cmd2, "@Now", now.UtcDateTime);
             await using var reader2 = await cmd2.ExecuteReaderAsync(cancellationToken);
             if (await reader2.ReadAsync(cancellationToken))
             {
-                totalPending = Convert.ToInt64(reader2.GetValue(reader2.GetOrdinal("total_count")),
-                    CultureInfo.InvariantCulture);
+                totalPending = Convert.ToInt64(reader2.GetValue(reader2.GetOrdinal("total_count")), CultureInfo.InvariantCulture);
             }
         }
 
@@ -123,6 +170,7 @@ public sealed class SqliteReminderStorage : IReminderStorage
             cmd3.CommandText = _dialect.GetNextReminderTimeSql(_settings.TableName);
             cmd3.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
             _dialect.AddParameter(cmd3, "@Skip", reminders.Count);
+            _dialect.AddParameter(cmd3, "@Now", now.UtcDateTime);
 
             var result = await cmd3.ExecuteScalarAsync(cancellationToken);
             if (result != null && result != DBNull.Value)
@@ -132,18 +180,12 @@ public sealed class SqliteReminderStorage : IReminderStorage
             }
         }
 
-        var adjustedOverview = new ReminderOverview
+        return new PendingRemindersWithSummary(reminders, new ReminderOverview
         {
             TimeUntilNext = timeUntilNext,
             TotalPendingReminders = remainingCount
-        };
-
-        return new PendingRemindersWithSummary(reminders, adjustedOverview);
+        });
     }
-
-    // SQLite default parameter limit is lower than SQL Server/PostgreSQL.
-    // 250 reminders => 752 parameters (250 * 3 + 2 shared), leaving room under 999.
-    private const int MaxRemindersPerStatement = 250;
 
     public async Task<bool> MarkRemindersAsCompletedAsync(
         IEnumerable<CompletedReminder> completedReminders,
@@ -160,21 +202,18 @@ public sealed class SqliteReminderStorage : IReminderStorage
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
 
-            var groups = remindersList.GroupBy(r => (r.Status, r.When));
-
+            var groups = remindersList.GroupBy(r => (r.Status, r.CompletedAt));
             foreach (var group in groups)
             {
                 var items = group.ToList();
-
-                for (var offset = 0; offset < items.Count; offset += MaxRemindersPerStatement)
+                for (var offset = 0; offset < items.Count; offset += MaxRemindersPerStatusUpdate)
                 {
-                    var chunk = items.Skip(offset).Take(MaxRemindersPerStatement).ToList();
-
+                    var chunk = items.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
                     await using var command = connection.CreateCommand();
                     command.CommandText = _dialect.GetBatchMarkCompletedSql(_settings.TableName, chunk.Count);
                     command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
 
-                    _dialect.AddParameter(command, "@CompletedAtUtc", group.Key.When.UtcDateTime);
+                    _dialect.AddParameter(command, "@CompletedAtUtc", group.Key.CompletedAt.UtcDateTime);
                     _dialect.AddParameter(command, "@CompletionStatus", group.Key.Status.ToString());
 
                     for (var i = 0; i < chunk.Count; i++)
@@ -182,6 +221,7 @@ public sealed class SqliteReminderStorage : IReminderStorage
                         _dialect.AddParameter(command, $"@sr{i}", chunk[i].Entity.ShardRegionName);
                         _dialect.AddParameter(command, $"@eid{i}", chunk[i].Entity.EntityId);
                         _dialect.AddParameter(command, $"@rk{i}", chunk[i].Key.Name);
+                        _dialect.AddParameter(command, $"@due{i}", chunk[i].DueTimeUtc.UtcDateTime);
                     }
 
                     await command.ExecuteNonQueryAsync(cancellationToken);
@@ -190,10 +230,24 @@ public sealed class SqliteReminderStorage : IReminderStorage
 
             return true;
         }
-        catch (Exception)
+        catch
         {
             return false;
         }
+    }
+
+    public async Task<int> ExpireRemindersAsync(DateTimeOffset now, CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken);
+
+        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = _dialect.GetExpireRemindersSql(_settings.TableName);
+        command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+        _dialect.AddParameter(command, "@Now", now.UtcDateTime);
+        return await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
     public async Task<ReminderOverview> GetRemindersOverviewAsync(
@@ -208,25 +262,23 @@ public sealed class SqliteReminderStorage : IReminderStorage
         await using var command = connection.CreateCommand();
         command.CommandText = _dialect.GetOverviewAggregateSql(_settings.TableName);
         command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
+        _dialect.AddParameter(command, "@Now", now.UtcDateTime);
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
 
         if (await reader.ReadAsync(cancellationToken))
         {
-            var totalCount = Convert.ToInt64(reader.GetValue(reader.GetOrdinal("total_count")),
-                CultureInfo.InvariantCulture);
+            var totalCount = Convert.ToInt64(reader.GetValue(reader.GetOrdinal("total_count")), CultureInfo.InvariantCulture);
             var nextWhenUtcOrdinal = reader.GetOrdinal("next_when_utc");
 
             if (totalCount == 0 || reader.IsDBNull(nextWhenUtcOrdinal))
                 return ReminderOverview.Empty;
 
             var nextWhenUtc = ParseDateTimeOffset(reader.GetValue(nextWhenUtcOrdinal));
-            var timeUntilNext = nextWhenUtc - now;
-
             return new ReminderOverview
             {
                 TotalPendingReminders = totalCount,
-                TimeUntilNext = timeUntilNext
+                TimeUntilNext = nextWhenUtc - now
             };
         }
 
@@ -247,13 +299,11 @@ public sealed class SqliteReminderStorage : IReminderStorage
             await using var command = connection.CreateCommand();
             command.CommandText = _dialect.GetCleanupSql(_settings.TableName);
             command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
             _dialect.AddParameter(command, "@OlderThan", olderThan.UtcDateTime);
-
             await command.ExecuteNonQueryAsync(cancellationToken);
             return true;
         }
-        catch (Exception)
+        catch
         {
             return false;
         }
@@ -274,36 +324,19 @@ public sealed class SqliteReminderStorage : IReminderStorage
             await using var command = connection.CreateCommand();
             command.CommandText = _dialect.GetCancelReminderSql(_settings.TableName);
             command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
             _dialect.AddParameter(command, "@ShardRegionName", entity.ShardRegionName);
             _dialect.AddParameter(command, "@EntityId", entity.EntityId);
             _dialect.AddParameter(command, "@ReminderKey", key.Name);
             _dialect.AddParameter(command, "@CompletedAtUtc", DateTimeOffset.UtcNow.UtcDateTime);
 
             var count = await command.ExecuteNonQueryAsync(cancellationToken);
-
-            if (count > 0)
-            {
-                return new ReminderProtocol.RemindersCancelled(
-                    entity,
-                    ReminderCancelResponseCode.Success,
-                    new List<ReminderKey> { key },
-                    null);
-            }
-
-            return new ReminderProtocol.RemindersCancelled(
-                entity,
-                ReminderCancelResponseCode.NotFound,
-                new List<ReminderKey>(),
-                null);
+            return count > 0
+                ? new ReminderProtocol.RemindersCancelled(entity, ReminderCancelResponseCode.Success, [key])
+                : new ReminderProtocol.RemindersCancelled(entity, ReminderCancelResponseCode.NotFound, []);
         }
         catch (Exception ex)
         {
-            return new ReminderProtocol.RemindersCancelled(
-                entity,
-                ReminderCancelResponseCode.Error,
-                new List<ReminderKey>(),
-                ex.Message);
+            return new ReminderProtocol.RemindersCancelled(entity, ReminderCancelResponseCode.Error, [], ex.Message);
         }
     }
 
@@ -318,61 +351,41 @@ public sealed class SqliteReminderStorage : IReminderStorage
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
 
-            var cancelledKeys = new List<ReminderKey>();
+            var cancelledKeys = new HashSet<ReminderKey>();
 
             await using (var selectCommand = connection.CreateCommand())
             {
                 selectCommand.CommandText = _dialect.GetFetchRemindersSql(_settings.TableName);
                 selectCommand.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
                 _dialect.AddParameter(selectCommand, "@ShardRegionName", entity.ShardRegionName);
                 _dialect.AddParameter(selectCommand, "@EntityId", entity.EntityId);
+                _dialect.AddParameter(selectCommand, "@Now", DateTimeOffset.UtcNow.UtcDateTime);
 
                 await using var reader = await selectCommand.ExecuteReaderAsync(cancellationToken);
                 while (await reader.ReadAsync(cancellationToken))
                 {
-                    var reminderKey = reader.GetString(reader.GetOrdinal("reminder_key"));
-                    var isCompleted = ReadBoolean(reader, "is_completed");
-
-                    if (!isCompleted)
-                    {
-                        cancelledKeys.Add(new ReminderKey(reminderKey));
-                    }
+                    cancelledKeys.Add(new ReminderKey(reader.GetString(reader.GetOrdinal("reminder_key"))));
                 }
             }
 
             if (cancelledKeys.Count == 0)
             {
-                return new ReminderProtocol.RemindersCancelled(
-                    entity,
-                    ReminderCancelResponseCode.NotFound,
-                    new List<ReminderKey>(),
-                    null);
+                return new ReminderProtocol.RemindersCancelled(entity, ReminderCancelResponseCode.NotFound, []);
             }
 
             await using var command = connection.CreateCommand();
             command.CommandText = _dialect.GetCancelAllRemindersSql(_settings.TableName);
             command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
             _dialect.AddParameter(command, "@ShardRegionName", entity.ShardRegionName);
             _dialect.AddParameter(command, "@EntityId", entity.EntityId);
             _dialect.AddParameter(command, "@CompletedAtUtc", DateTimeOffset.UtcNow.UtcDateTime);
-
             await command.ExecuteNonQueryAsync(cancellationToken);
 
-            return new ReminderProtocol.RemindersCancelled(
-                entity,
-                ReminderCancelResponseCode.Success,
-                cancelledKeys,
-                null);
+            return new ReminderProtocol.RemindersCancelled(entity, ReminderCancelResponseCode.Success, cancelledKeys.ToList());
         }
         catch (Exception ex)
         {
-            return new ReminderProtocol.RemindersCancelled(
-                entity,
-                ReminderCancelResponseCode.Error,
-                new List<ReminderKey>(),
-                ex.Message);
+            return new ReminderProtocol.RemindersCancelled(entity, ReminderCancelResponseCode.Error, [], ex.Message);
         }
     }
 
@@ -392,16 +405,14 @@ public sealed class SqliteReminderStorage : IReminderStorage
         await using var command = connection.CreateCommand();
         command.CommandText = _dialect.GetFetchRemindersSql(_settings.TableName);
         command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
         _dialect.AddParameter(command, "@ShardRegionName", entity.ShardRegionName);
         _dialect.AddParameter(command, "@EntityId", entity.EntityId);
+        _dialect.AddParameter(command, "@Now", DateTimeOffset.UtcNow.UtcDateTime);
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
-
         while (await reader.ReadAsync(cancellationToken))
         {
-            var reminder = ReadReminderFromReader(reader);
-            reminders.Add(reminder);
+            reminders.Add(ReadReminderFromReader(reader));
         }
 
         return reminders.Skip(skip).Take(take).ToList();
@@ -422,24 +433,29 @@ public sealed class SqliteReminderStorage : IReminderStorage
             await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken);
 
-            foreach (var reminder in remindersList)
+            for (var offset = 0; offset < remindersList.Count; offset += MaxRemindersPerStatusUpdate)
             {
+                var chunk = remindersList.Skip(offset).Take(MaxRemindersPerStatusUpdate).ToList();
                 await using var command = connection.CreateCommand();
-                command.CommandText = _dialect.GetMarkAsAwaitingAckSql(_settings.TableName);
+                command.CommandText = _dialect.GetBatchMarkAsAwaitingAckSql(_settings.TableName, chunk.Count);
                 command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
 
-                _dialect.AddParameter(command, "@ShardRegionName", reminder.Entity.ShardRegionName);
-                _dialect.AddParameter(command, "@EntityId", reminder.Entity.EntityId);
-                _dialect.AddParameter(command, "@ReminderKey", reminder.Key.Name);
-                _dialect.AddParameter(command, "@DeliveredAtUtc", reminder.DeliveredAt.UtcDateTime);
-                _dialect.AddParameter(command, "@AckDeadlineUtc", reminder.AckDeadline.UtcDateTime);
+                for (var i = 0; i < chunk.Count; i++)
+                {
+                    _dialect.AddParameter(command, $"@sr{i}", chunk[i].Entity.ShardRegionName);
+                    _dialect.AddParameter(command, $"@eid{i}", chunk[i].Entity.EntityId);
+                    _dialect.AddParameter(command, $"@rk{i}", chunk[i].Key.Name);
+                    _dialect.AddParameter(command, $"@due{i}", chunk[i].DueTimeUtc.UtcDateTime);
+                    _dialect.AddParameter(command, $"@del{i}", chunk[i].DeliveredAt.UtcDateTime);
+                    _dialect.AddParameter(command, $"@ack{i}", chunk[i].AckDeadline.UtcDateTime);
+                }
 
                 await command.ExecuteNonQueryAsync(cancellationToken);
             }
 
             return true;
         }
-        catch (Exception)
+        catch
         {
             return false;
         }
@@ -460,15 +476,12 @@ public sealed class SqliteReminderStorage : IReminderStorage
         await using var command = connection.CreateCommand();
         command.CommandText = _dialect.GetTimedOutAckRemindersSql(_settings.TableName, maxCount.Value);
         command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
         _dialect.AddParameter(command, "@Now", now.UtcDateTime);
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
-
         while (await reader.ReadAsync(cancellationToken))
         {
-            var reminder = ReadReminderFromReader(reader);
-            reminders.Add(reminder);
+            reminders.Add(ReadReminderFromReader(reader));
         }
 
         return reminders;
@@ -477,6 +490,7 @@ public sealed class SqliteReminderStorage : IReminderStorage
     public async Task<AckResult> AcknowledgeReminderAsync(
         ReminderEntity entity,
         ReminderKey key,
+        DateTimeOffset dueTimeUtc,
         DateTimeOffset ackedAt,
         CancellationToken cancellationToken = default)
     {
@@ -494,42 +508,16 @@ public sealed class SqliteReminderStorage : IReminderStorage
             _dialect.AddParameter(command, "@ShardRegionName", entity.ShardRegionName);
             _dialect.AddParameter(command, "@EntityId", entity.EntityId);
             _dialect.AddParameter(command, "@ReminderKey", key.Name);
+            _dialect.AddParameter(command, "@DueTimeUtc", dueTimeUtc.UtcDateTime);
             _dialect.AddParameter(command, "@AckedAtUtc", ackedAt.UtcDateTime);
 
-            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
-
-            if (!await reader.ReadAsync(cancellationToken))
-            {
-                // No row updated — reminder was not in AwaitingAck state
-                return new AckResult(Success: false, IsRecurring: false, OriginalReminder: null);
-            }
-
-            var original = ReadReminderFromReader(reader);
-            var isRecurring = original.RepeatInterval.HasValue;
-
-            return new AckResult(
-                Success: true,
-                IsRecurring: isRecurring,
-                OriginalReminder: isRecurring ? original : null);
+            var count = await command.ExecuteNonQueryAsync(cancellationToken);
+            return new AckResult(count > 0);
         }
-        catch (Exception)
+        catch
         {
-            return new AckResult(Success: false, IsRecurring: false, OriginalReminder: null);
+            return new AckResult(false);
         }
-    }
-
-    public async Task<int> ResetAwaitingAckToPendingAsync(CancellationToken cancellationToken = default)
-    {
-        await EnsureInitializedAsync(cancellationToken);
-
-        await using var connection = _dialect.CreateConnection(_settings.ConnectionString);
-        await connection.OpenAsync(cancellationToken);
-
-        await using var command = connection.CreateCommand();
-        command.CommandText = _dialect.GetResetAwaitingAckSql(_settings.TableName);
-        command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
-        return await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
     private Task EnsureInitializedAsync(CancellationToken cancellationToken)
@@ -550,7 +538,6 @@ public sealed class SqliteReminderStorage : IReminderStorage
                 await using var command = connection.CreateCommand();
                 command.CommandText = _dialect.GetCreateTableSql(_settings.TableName);
                 command.CommandTimeout = (int)_settings.CommandTimeout.TotalSeconds;
-
                 await command.ExecuteNonQueryAsync(cancellationToken);
             }, cancellationToken).Wait(cancellationToken);
 
@@ -560,31 +547,36 @@ public sealed class SqliteReminderStorage : IReminderStorage
         return Task.CompletedTask;
     }
 
+    private void BindReminderParameters(System.Data.Common.DbCommand command, int index, ScheduledReminder reminder)
+    {
+        var (serializerId, manifest, payload) = SerializeMessage(reminder.Message);
+
+        _dialect.AddParameter(command, $"@ShardRegionName{index}", reminder.Entity.ShardRegionName);
+        _dialect.AddParameter(command, $"@EntityId{index}", reminder.Entity.EntityId);
+        _dialect.AddParameter(command, $"@ReminderKey{index}", reminder.Key.Name);
+        _dialect.AddParameter(command, $"@WhenUtc{index}", reminder.When.UtcDateTime);
+        _dialect.AddParameter(command, $"@DueTimeUtc{index}", reminder.DueTimeUtc.UtcDateTime);
+        _dialect.AddParameter(command, $"@RepeatIntervalTicks{index}", reminder.RepeatInterval?.Ticks ?? (object)DBNull.Value);
+        _dialect.AddParameter(command, $"@SerializerId{index}", serializerId);
+        _dialect.AddParameter(command, $"@Manifest{index}", manifest ?? (object)DBNull.Value);
+        _dialect.AddParameter(command, $"@Payload{index}", payload);
+        _dialect.AddParameter(command, $"@AttemptCount{index}", reminder.AttemptCount);
+        _dialect.AddParameter(command, $"@LastFailureReason{index}", reminder.LastFailureReason ?? (object)DBNull.Value);
+        _dialect.AddParameter(command, $"@MaxDeliveryWindowTicks{index}", reminder.MaxDeliveryWindow?.Ticks ?? (object)DBNull.Value);
+        _dialect.AddParameter(command, $"@DeliveryDeadlineUtc{index}", reminder.DeliveryDeadlineUtc?.UtcDateTime ?? (object)DBNull.Value);
+    }
+
     private (int serializerId, string? manifest, byte[] payload) SerializeMessage(object message)
     {
         var serializer = _serialization.FindSerializerFor(message);
         var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, message);
         var payload = serializer.ToBinary(message);
-
         return (serializer.Identifier, manifest, payload);
     }
 
     private object DeserializeMessage(int serializerId, string? manifest, byte[] payload)
     {
         return _serialization.Deserialize(payload, serializerId, manifest ?? string.Empty);
-    }
-
-    private static bool ReadBoolean(IDataReader reader, string columnName)
-    {
-        var ordinal = reader.GetOrdinal(columnName);
-        return Convert.ToInt32(reader.GetValue(ordinal), CultureInfo.InvariantCulture) != 0;
-    }
-
-    private static DateTimeOffset ReadDateTimeOffset(IDataReader reader, string columnName)
-    {
-        var ordinal = reader.GetOrdinal(columnName);
-        var value = reader.GetValue(ordinal);
-        return ParseDateTimeOffset(value);
     }
 
     private static DateTimeOffset ParseDateTimeOffset(object value)
@@ -603,7 +595,8 @@ public sealed class SqliteReminderStorage : IReminderStorage
         var shardRegionName = reader.GetString(reader.GetOrdinal("shard_region_name"));
         var entityId = reader.GetString(reader.GetOrdinal("entity_id"));
         var reminderKey = reader.GetString(reader.GetOrdinal("reminder_key"));
-        var whenUtc = ReadDateTimeOffset(reader, "when_utc");
+        var whenUtc = ParseDateTimeOffset(reader.GetValue(reader.GetOrdinal("when_utc")));
+        var dueTimeUtc = ParseDateTimeOffset(reader.GetValue(reader.GetOrdinal("due_time_utc")));
 
         var repeatIntervalTicksOrdinal = reader.GetOrdinal("repeat_interval_ticks");
         var repeatInterval = reader.IsDBNull(repeatIntervalTicksOrdinal)
@@ -611,17 +604,23 @@ public sealed class SqliteReminderStorage : IReminderStorage
             : TimeSpan.FromTicks(Convert.ToInt64(reader.GetValue(repeatIntervalTicksOrdinal), CultureInfo.InvariantCulture));
 
         var serializerId = Convert.ToInt32(reader.GetValue(reader.GetOrdinal("serializer_id")), CultureInfo.InvariantCulture);
-
         var manifestOrdinal = reader.GetOrdinal("manifest");
         var manifest = reader.IsDBNull(manifestOrdinal) ? null : reader.GetString(manifestOrdinal);
-
         var payload = (byte[])reader.GetValue(reader.GetOrdinal("payload"));
         var attemptCount = Convert.ToInt32(reader.GetValue(reader.GetOrdinal("attempt_count")), CultureInfo.InvariantCulture);
 
         var lastFailureReasonOrdinal = reader.GetOrdinal("last_failure_reason");
-        var lastFailureReason = reader.IsDBNull(lastFailureReasonOrdinal)
-            ? null
-            : reader.GetString(lastFailureReasonOrdinal);
+        var lastFailureReason = reader.IsDBNull(lastFailureReasonOrdinal) ? null : reader.GetString(lastFailureReasonOrdinal);
+
+        var maxWindowOrdinal = reader.GetOrdinal("max_delivery_window_ticks");
+        var maxDeliveryWindow = reader.IsDBNull(maxWindowOrdinal)
+            ? (TimeSpan?)null
+            : TimeSpan.FromTicks(Convert.ToInt64(reader.GetValue(maxWindowOrdinal), CultureInfo.InvariantCulture));
+
+        var deadlineOrdinal = reader.GetOrdinal("delivery_deadline_utc");
+        var deliveryDeadlineUtc = reader.IsDBNull(deadlineOrdinal)
+            ? (DateTimeOffset?)null
+            : ParseDateTimeOffset(reader.GetValue(deadlineOrdinal));
 
         var message = DeserializeMessage(serializerId, manifest, payload);
 
@@ -632,6 +631,9 @@ public sealed class SqliteReminderStorage : IReminderStorage
             message,
             repeatInterval,
             attemptCount,
-            lastFailureReason);
+            lastFailureReason,
+            maxDeliveryWindow,
+            deliveryDeadlineUtc,
+            dueTimeUtc);
     }
 }

--- a/src/Akka.Reminders.Tests/FailableReminderStorage.cs
+++ b/src/Akka.Reminders.Tests/FailableReminderStorage.cs
@@ -112,4 +112,11 @@ internal sealed class FailableReminderStorage : IReminderStorage
             throw new TimeoutException("Simulated database write timeout");
         return _inner.AcknowledgeReminderAsync(entity, key, ackedAt, ct);
     }
+
+    public Task<int> ResetAwaitingAckToPendingAsync(CancellationToken ct = default)
+    {
+        if (FailWrites)
+            throw new TimeoutException("Simulated database write timeout");
+        return _inner.ResetAwaitingAckToPendingAsync(ct);
+    }
 }

--- a/src/Akka.Reminders.Tests/FailableReminderStorage.cs
+++ b/src/Akka.Reminders.Tests/FailableReminderStorage.cs
@@ -53,6 +53,13 @@ internal sealed class FailableReminderStorage : IReminderStorage
         return _inner.ScheduleReminderAsync(reminder, ct);
     }
 
+    public Task<bool> UpsertReminderOccurrencesAsync(IEnumerable<ScheduledReminder> reminders, CancellationToken ct = default)
+    {
+        if (FailWrites || FailScheduleWrites)
+            throw new TimeoutException("Simulated database write timeout");
+        return _inner.UpsertReminderOccurrencesAsync(reminders, ct);
+    }
+
     public Task<ReminderProtocol.RemindersCancelled> CancelReminderAsync(ReminderEntity entity, ReminderKey key, CancellationToken ct = default)
     {
         if (FailWrites)
@@ -72,6 +79,13 @@ internal sealed class FailableReminderStorage : IReminderStorage
         if (FailWrites)
             throw new TimeoutException("Simulated database write timeout");
         return _inner.CleanUpCompletedRemindersAsync(olderThan, ct);
+    }
+
+    public Task<int> ExpireRemindersAsync(DateTimeOffset now, CancellationToken ct = default)
+    {
+        if (FailWrites)
+            throw new TimeoutException("Simulated database write timeout");
+        return _inner.ExpireRemindersAsync(now, ct);
     }
 
     // --- Read operations: always work ---
@@ -106,17 +120,10 @@ internal sealed class FailableReminderStorage : IReminderStorage
         return _inner.GetTimedOutAckRemindersAsync(now, maxCount, ct);
     }
 
-    public Task<AckResult> AcknowledgeReminderAsync(ReminderEntity entity, ReminderKey key, DateTimeOffset ackedAt, CancellationToken ct = default)
+    public Task<AckResult> AcknowledgeReminderAsync(ReminderEntity entity, ReminderKey key, DateTimeOffset dueTimeUtc, DateTimeOffset ackedAt, CancellationToken ct = default)
     {
         if (FailWrites)
             throw new TimeoutException("Simulated database write timeout");
-        return _inner.AcknowledgeReminderAsync(entity, key, ackedAt, ct);
-    }
-
-    public Task<int> ResetAwaitingAckToPendingAsync(CancellationToken ct = default)
-    {
-        if (FailWrites)
-            throw new TimeoutException("Simulated database write timeout");
-        return _inner.ResetAwaitingAckToPendingAsync(ct);
+        return _inner.AcknowledgeReminderAsync(entity, key, dueTimeUtc, ackedAt, ct);
     }
 }

--- a/src/Akka.Reminders.Tests/FailableReminderStorage.cs
+++ b/src/Akka.Reminders.Tests/FailableReminderStorage.cs
@@ -60,6 +60,13 @@ internal sealed class FailableReminderStorage : IReminderStorage
         return _inner.UpsertReminderOccurrencesAsync(reminders, ct);
     }
 
+    public Task<bool> CommitReminderMutationsAsync(ReminderMutationBatch mutationBatch, CancellationToken ct = default)
+    {
+        if (FailWrites || FailScheduleWrites || FailMarkCompletedWrites)
+            throw new TimeoutException("Simulated database write timeout");
+        return _inner.CommitReminderMutationsAsync(mutationBatch, ct);
+    }
+
     public Task<ReminderProtocol.RemindersCancelled> CancelReminderAsync(ReminderEntity entity, ReminderKey key, CancellationToken ct = default)
     {
         if (FailWrites)
@@ -125,5 +132,12 @@ internal sealed class FailableReminderStorage : IReminderStorage
         if (FailWrites)
             throw new TimeoutException("Simulated database write timeout");
         return _inner.AcknowledgeReminderAsync(entity, key, dueTimeUtc, ackedAt, ct);
+    }
+
+    public Task<IReadOnlyList<AckResult>> AcknowledgeRemindersAsync(IEnumerable<ReminderAcknowledgement> acknowledgements, CancellationToken ct = default)
+    {
+        if (FailWrites)
+            throw new TimeoutException("Simulated database write timeout");
+        return _inner.AcknowledgeRemindersAsync(acknowledgements, ct);
     }
 }

--- a/src/Akka.Reminders.Tests/FailableReminderStorage.cs
+++ b/src/Akka.Reminders.Tests/FailableReminderStorage.cs
@@ -18,6 +18,11 @@ internal sealed class FailableReminderStorage : IReminderStorage
     public bool FailWrites { get; set; }
 
     /// <summary>
+    /// When true, all read operations throw.
+    /// </summary>
+    public bool FailReads { get; set; }
+
+    /// <summary>
     /// When true, MarkRemindersAsCompletedAsync throws.
     /// </summary>
     public bool FailMarkCompletedWrites { get; set; }
@@ -85,5 +90,26 @@ internal sealed class FailableReminderStorage : IReminderStorage
     public Task<IReadOnlyList<ScheduledReminder>> GetRemindersForEntityAsync(ReminderEntity entity, int take = 10, int skip = 0, CancellationToken ct = default)
     {
         return _inner.GetRemindersForEntityAsync(entity, take, skip, ct);
+    }
+
+    public Task<bool> MarkRemindersAsAwaitingAckAsync(IEnumerable<AwaitingAckReminder> reminders, CancellationToken ct = default)
+    {
+        if (FailWrites)
+            throw new TimeoutException("Simulated database write timeout");
+        return _inner.MarkRemindersAsAwaitingAckAsync(reminders, ct);
+    }
+
+    public Task<IReadOnlyList<ScheduledReminder>> GetTimedOutAckRemindersAsync(DateTimeOffset now, ReminderBatchSize maxCount, CancellationToken ct = default)
+    {
+        if (FailReads)
+            throw new TimeoutException("Simulated database read timeout");
+        return _inner.GetTimedOutAckRemindersAsync(now, maxCount, ct);
+    }
+
+    public Task<AckResult> AcknowledgeReminderAsync(ReminderEntity entity, ReminderKey key, DateTimeOffset ackedAt, CancellationToken ct = default)
+    {
+        if (FailWrites)
+            throw new TimeoutException("Simulated database write timeout");
+        return _inner.AcknowledgeReminderAsync(entity, key, ackedAt, ct);
     }
 }

--- a/src/Akka.Reminders.Tests/FailableReminderStorage.cs
+++ b/src/Akka.Reminders.Tests/FailableReminderStorage.cs
@@ -127,6 +127,13 @@ internal sealed class FailableReminderStorage : IReminderStorage
         return _inner.GetTimedOutAckRemindersAsync(now, maxCount, ct);
     }
 
+    public Task<DateTimeOffset?> GetNextAwaitingAckDeadlineAsync(CancellationToken ct = default)
+    {
+        if (FailReads)
+            throw new TimeoutException("Simulated database read timeout");
+        return _inner.GetNextAwaitingAckDeadlineAsync(ct);
+    }
+
     public Task<AckResult> AcknowledgeReminderAsync(ReminderEntity entity, ReminderKey key, DateTimeOffset dueTimeUtc, DateTimeOffset ackedAt, CancellationToken ct = default)
     {
         if (FailWrites)

--- a/src/Akka.Reminders.Tests/LocalReminderSpecs.cs
+++ b/src/Akka.Reminders.Tests/LocalReminderSpecs.cs
@@ -66,8 +66,8 @@ public class LocalReminderSpecs : Akka.Hosting.TestKit.TestKit
         scheduleResult.ResponseCode.Should().Be(ReminderScheduleResponseCode.Success);
 
         // Assert - the reminder should be delivered as a ReminderEnvelope
-        var envelope = await targetActor.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(2));
-        ((TestMessage)envelope.Message).Content.Should().Be("Payment Retry");
+        var envelope = await targetActor.ExpectMsgAsync<ReminderEnvelope<TestMessage>>(TimeSpan.FromSeconds(2));
+        envelope.Message.Content.Should().Be("Payment Retry");
 
         Output?.WriteLine($"Reminder delivered successfully to {targetActor.Ref.Path}");
     }
@@ -98,11 +98,11 @@ public class LocalReminderSpecs : Akka.Hosting.TestKit.TestKit
             new TestMessage("Send Notification"));
 
         // Assert - each reminder should be delivered as a ReminderEnvelope to its respective shard region
-        var billingEnvelope = await billingActor.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(2));
-        ((TestMessage)billingEnvelope.Message).Content.Should().Be("Bill Customer");
+        var billingEnvelope = await billingActor.ExpectMsgAsync<ReminderEnvelope<TestMessage>>(TimeSpan.FromSeconds(2));
+        billingEnvelope.Message.Content.Should().Be("Bill Customer");
 
-        var notificationEnvelope = await notificationActor.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(2));
-        ((TestMessage)notificationEnvelope.Message).Content.Should().Be("Send Notification");
+        var notificationEnvelope = await notificationActor.ExpectMsgAsync<ReminderEnvelope<TestMessage>>(TimeSpan.FromSeconds(2));
+        notificationEnvelope.Message.Content.Should().Be("Send Notification");
     }
 
     private record TestMessage(string Content);

--- a/src/Akka.Reminders.Tests/LocalReminderSpecs.cs
+++ b/src/Akka.Reminders.Tests/LocalReminderSpecs.cs
@@ -1,9 +1,7 @@
 using Akka.Actor;
-using Akka.Cluster.Sharding;
 using Akka.Hosting;
 using Akka.Reminders.Sharding;
 using FluentAssertions;
-using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -67,9 +65,9 @@ public class LocalReminderSpecs : Akka.Hosting.TestKit.TestKit
         var scheduleResult = await client.ScheduleSingleReminderAsync(key, when, message);
         scheduleResult.ResponseCode.Should().Be(ReminderScheduleResponseCode.Success);
 
-        // Assert - the reminder should be delivered directly (no ShardingEnvelope wrapping in tests)
-        var receivedMessage = await targetActor.ExpectMsgAsync<TestMessage>(TimeSpan.FromSeconds(2));
-        receivedMessage.Content.Should().Be("Payment Retry");
+        // Assert - the reminder should be delivered as a ReminderEnvelope
+        var envelope = await targetActor.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(2));
+        ((TestMessage)envelope.Message).Content.Should().Be("Payment Retry");
 
         Output?.WriteLine($"Reminder delivered successfully to {targetActor.Ref.Path}");
     }
@@ -99,12 +97,12 @@ public class LocalReminderSpecs : Akka.Hosting.TestKit.TestKit
             DateTimeOffset.UtcNow.AddMilliseconds(100),
             new TestMessage("Send Notification"));
 
-        // Assert - each reminder should be delivered directly to its respective shard region (no ShardingEnvelope wrapping in tests)
-        var billingMessage = await billingActor.ExpectMsgAsync<TestMessage>(TimeSpan.FromSeconds(2));
-        billingMessage.Content.Should().Be("Bill Customer");
+        // Assert - each reminder should be delivered as a ReminderEnvelope to its respective shard region
+        var billingEnvelope = await billingActor.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(2));
+        ((TestMessage)billingEnvelope.Message).Content.Should().Be("Bill Customer");
 
-        var notificationMessage = await notificationActor.ExpectMsgAsync<TestMessage>(TimeSpan.FromSeconds(2));
-        notificationMessage.Content.Should().Be("Send Notification");
+        var notificationEnvelope = await notificationActor.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(2));
+        ((TestMessage)notificationEnvelope.Message).Content.Should().Be("Send Notification");
     }
 
     private record TestMessage(string Content);

--- a/src/Akka.Reminders.Tests/ReminderClientSpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderClientSpecs.cs
@@ -27,7 +27,7 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
         {
             var response = await client.ListRemindersAsync();
             Assert.Equal(FetchRemindersResponseCode.Success, response.ResponseCode);
-        }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100));
+        }, TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(100));
     }
 
     protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)

--- a/src/Akka.Reminders.Tests/ReminderClientSpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderClientSpecs.cs
@@ -21,6 +21,15 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
         _resolver = new TestShardRegionResolver();
     }
 
+    private async Task EnsureReminderSchedulerReady(IReminderClient client)
+    {
+        await AwaitAssertAsync(async () =>
+        {
+            var response = await client.ListRemindersAsync();
+            Assert.Equal(FetchRemindersResponseCode.Success, response.ResponseCode);
+        }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100));
+    }
+
     protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
         // For testing, we create the reminder scheduler directly without clustering
@@ -121,6 +130,7 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
 
         var extension = Sys.ReminderClient();
         var client = extension.CreateClient("test-region", "entity-1");
+        await EnsureReminderSchedulerReady(client);
 
         // Act
         var result = await client.ScheduleSingleReminderAsync(
@@ -138,6 +148,7 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
         // Arrange
         var extension = Sys.ReminderClient();
         var client = extension.CreateClient("missing-region", "entity-1");
+        await EnsureReminderSchedulerReady(client);
 
         // Act
         var result = await client.ScheduleSingleReminderAsync(
@@ -159,6 +170,7 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
         var extension = Sys.ReminderClient();
         var client = extension.CreateClient("test-region", "entity-1");
         var key = new ReminderKey("test-reminder");
+        await EnsureReminderSchedulerReady(client);
 
         // Act - Schedule first reminder
         var result1 = await client.ScheduleSingleReminderAsync(
@@ -195,6 +207,7 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
 
         var extension = Sys.ReminderClient();
         var client = extension.CreateClient("test-region", "entity-1");
+        await EnsureReminderSchedulerReady(client);
 
         // Act
         var result = await client.ScheduleRecurringReminderAsync(
@@ -222,6 +235,7 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
         var client = extension.CreateClient("test-region", "entity-1");
         var when = DateTimeOffset.UtcNow.AddMinutes(5);
         var window = TimeSpan.FromMinutes(2);
+        await EnsureReminderSchedulerReady(client);
 
         var result = await client.ScheduleSingleReminderAsync(
             new ReminderKey("deadline-reminder"),
@@ -251,6 +265,7 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
         var extension = Sys.ReminderClient();
         var client = extension.CreateClient("test-region", "entity-1");
         var key = new ReminderKey("test-reminder");
+        await EnsureReminderSchedulerReady(client);
 
         await client.ScheduleSingleReminderAsync(key, DateTimeOffset.UtcNow.AddHours(1), "test message");
 
@@ -272,6 +287,7 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
         // Arrange
         var extension = Sys.ReminderClient();
         var client = extension.CreateClient("test-region", "entity-1");
+        await EnsureReminderSchedulerReady(client);
 
         // Act
         var result = await client.CancelReminderAsync(new ReminderKey("nonexistent"));
@@ -289,6 +305,7 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
 
         var extension = Sys.ReminderClient();
         var client = extension.CreateClient("test-region", "entity-1");
+        await EnsureReminderSchedulerReady(client);
 
         await client.ScheduleSingleReminderAsync(new ReminderKey("r1"), DateTimeOffset.UtcNow.AddHours(1), "m1");
         await client.ScheduleSingleReminderAsync(new ReminderKey("r2"), DateTimeOffset.UtcNow.AddHours(2), "m2");
@@ -315,6 +332,7 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
         // Arrange
         var extension = Sys.ReminderClient();
         var client = extension.CreateClient("test-region", "entity-1");
+        await EnsureReminderSchedulerReady(client);
 
         // Act
         var result = await client.ListRemindersAsync();
@@ -333,6 +351,7 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
 
         var extension = Sys.ReminderClient();
         var client = extension.CreateClient("test-region", "entity-1");
+        await EnsureReminderSchedulerReady(client);
 
         await client.ScheduleSingleReminderAsync(new ReminderKey("r1"), DateTimeOffset.UtcNow.AddHours(1), "m1");
         await client.ScheduleSingleReminderAsync(new ReminderKey("r2"), DateTimeOffset.UtcNow.AddHours(2), "m2");
@@ -355,6 +374,7 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
         var extension = Sys.ReminderClient();
         var client1 = extension.CreateClient("test-region", "entity-1");
         var client2 = extension.CreateClient("test-region", "entity-2");
+        await EnsureReminderSchedulerReady(client1);
 
         await client1.ScheduleSingleReminderAsync(new ReminderKey("r1"), DateTimeOffset.UtcNow.AddHours(1), "m1");
         await client2.ScheduleSingleReminderAsync(new ReminderKey("r2"), DateTimeOffset.UtcNow.AddHours(2), "m2");

--- a/src/Akka.Reminders.Tests/ReminderClientSpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderClientSpecs.cs
@@ -212,6 +212,31 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
         Assert.Equal(TimeSpan.FromMinutes(5), list.Reminders[0].RepeatInterval);
     }
 
+    [Fact]
+    public async Task ScheduleSingleReminder_ShouldPersistMaxDeliveryWindow()
+    {
+        var testProbe = CreateTestProbe();
+        _resolver.RegisterShardRegion("test-region", testProbe);
+
+        var extension = Sys.ReminderClient();
+        var client = extension.CreateClient("test-region", "entity-1");
+        var when = DateTimeOffset.UtcNow.AddMinutes(5);
+        var window = TimeSpan.FromMinutes(2);
+
+        var result = await client.ScheduleSingleReminderAsync(
+            new ReminderKey("deadline-reminder"),
+            when,
+            "deadline message",
+            maxDeliveryWindow: window);
+
+        Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
+
+        var list = await client.ListRemindersAsync();
+        Assert.Single(list.Reminders);
+        Assert.Equal(window, list.Reminders[0].MaxDeliveryWindow);
+        Assert.True(list.Reminders[0].DeliveryDeadlineUtc.HasValue);
+    }
+
     #endregion
 
     #region Cancellation Tests
@@ -347,4 +372,3 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
 
     #endregion
 }
-

--- a/src/Akka.Reminders.Tests/ReminderClusterIntegrationSpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderClusterIntegrationSpecs.cs
@@ -215,17 +215,11 @@ internal sealed class TestEntity : ReceiveActor
     {
         _entityId = entityId;
 
-        ReceiveAsync<ReminderEnvelope>(async envelope =>
+        ReceiveAsync<ReminderEnvelope<EntityMessage>>(async envelope =>
         {
             // Extract the EntityMessage payload from the reminder envelope
-            if (envelope.Message is EntityMessage msg)
-            {
-                Context.System.EventStream.Publish(new ReminderReceived(_entityId, msg.Payload));
-            }
-            else
-            {
-                Context.System.EventStream.Publish(new ReminderReceived(_entityId, envelope.Message.ToString() ?? ""));
-            }
+            var msg = envelope.Message;
+            Context.System.EventStream.Publish(new ReminderReceived(_entityId, msg.Payload));
 
             // Ack the reminder so recurring reminders schedule their next occurrence
             var ext = Context.System.ReminderClient();

--- a/src/Akka.Reminders.Tests/ReminderClusterIntegrationSpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderClusterIntegrationSpecs.cs
@@ -129,16 +129,18 @@ public class ReminderClusterIntegrationSpecs : Akka.Hosting.TestKit.TestKit
         // Assert
         Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
 
-        // Wait for multiple occurrences
-        var msg1 = probe.ExpectMsg<TestEntity.ReminderReceived>(TimeSpan.FromSeconds(5));
+        // Wait for multiple occurrences — first delivery traverses the full
+        // cluster singleton → shard region → entity actor chain which has
+        // higher latency on constrained CI runners.
+        var msg1 = probe.ExpectMsg<TestEntity.ReminderReceived>(TimeSpan.FromSeconds(10));
         Assert.Equal("entity-2", msg1.EntityId);
         Assert.Equal("recurring message", msg1.Message);
 
-        var msg2 = probe.ExpectMsg<TestEntity.ReminderReceived>(TimeSpan.FromSeconds(2));
+        var msg2 = probe.ExpectMsg<TestEntity.ReminderReceived>(TimeSpan.FromSeconds(5));
         Assert.Equal("entity-2", msg2.EntityId);
         Assert.Equal("recurring message", msg2.Message);
 
-        var msg3 = probe.ExpectMsg<TestEntity.ReminderReceived>(TimeSpan.FromSeconds(2));
+        var msg3 = probe.ExpectMsg<TestEntity.ReminderReceived>(TimeSpan.FromSeconds(5));
         Assert.Equal("entity-2", msg3.EntityId);
         Assert.Equal("recurring message", msg3.Message);
 

--- a/src/Akka.Reminders.Tests/ReminderClusterIntegrationSpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderClusterIntegrationSpecs.cs
@@ -215,16 +215,23 @@ internal sealed class TestEntity : ReceiveActor
     {
         _entityId = entityId;
 
-        Receive<EntityMessage>(msg =>
+        Receive<ReminderEnvelope>(envelope =>
         {
-            // Publish reminder receipt to event stream for test verification
-            Context.System.EventStream.Publish(new ReminderReceived(_entityId, msg.Payload));
+            // Extract the EntityMessage payload from the reminder envelope
+            if (envelope.Message is EntityMessage msg)
+            {
+                Context.System.EventStream.Publish(new ReminderReceived(_entityId, msg.Payload));
+            }
+            else
+            {
+                Context.System.EventStream.Publish(new ReminderReceived(_entityId, envelope.Message.ToString() ?? ""));
+            }
         });
 
-        ReceiveAny(msg =>
+        Receive<EntityMessage>(msg =>
         {
-            // Fallback for any other messages
-            Context.System.EventStream.Publish(new ReminderReceived(_entityId, msg.ToString() ?? ""));
+            // Handle direct EntityMessage delivery (non-reminder path)
+            Context.System.EventStream.Publish(new ReminderReceived(_entityId, msg.Payload));
         });
     }
 }

--- a/src/Akka.Reminders.Tests/ReminderClusterIntegrationSpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderClusterIntegrationSpecs.cs
@@ -39,6 +39,15 @@ public class ReminderClusterIntegrationSpecs : Akka.Hosting.TestKit.TestKit
         _clusterFormed = true;
     }
 
+    private async Task EnsureReminderSchedulerReady(IReminderClient client)
+    {
+        await AwaitAssertAsync(async () =>
+        {
+            var response = await client.ListRemindersAsync();
+            Assert.Equal(FetchRemindersResponseCode.Success, response.ResponseCode);
+        }, TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(100));
+    }
+
     protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
         // Configure a single-node cluster
@@ -73,6 +82,7 @@ public class ReminderClusterIntegrationSpecs : Akka.Hosting.TestKit.TestKit
         EnsureClusterFormed();
         var extension = Sys.ReminderClient();
         var client = extension.CreateClient(ShardRegionName, "entity-1");
+        await EnsureReminderSchedulerReady(client);
 
         // Get the shard region to observe messages
         var shardRegion = await Sys.ActorSelection($"/system/sharding/{ShardRegionName}").ResolveOne(TimeSpan.FromSeconds(5));
@@ -104,6 +114,7 @@ public class ReminderClusterIntegrationSpecs : Akka.Hosting.TestKit.TestKit
         EnsureClusterFormed();
         var extension = Sys.ReminderClient();
         var client = extension.CreateClient(ShardRegionName, "entity-2");
+        await EnsureReminderSchedulerReady(client);
 
         var probe = CreateTestProbe();
         Sys.EventStream.Subscribe(probe.Ref, typeof(TestEntity.ReminderReceived));
@@ -143,6 +154,7 @@ public class ReminderClusterIntegrationSpecs : Akka.Hosting.TestKit.TestKit
         var extension = Sys.ReminderClient();
         var client1 = extension.CreateClient(ShardRegionName, "entity-3");
         var client2 = extension.CreateClient(ShardRegionName, "entity-4");
+        await EnsureReminderSchedulerReady(client1);
 
         var probe = CreateTestProbe();
         Sys.EventStream.Subscribe(probe.Ref, typeof(TestEntity.ReminderReceived));
@@ -175,6 +187,7 @@ public class ReminderClusterIntegrationSpecs : Akka.Hosting.TestKit.TestKit
         EnsureClusterFormed();
         var extension = Sys.ReminderClient();
         var client = extension.CreateClient(ShardRegionName, "entity-5");
+        await EnsureReminderSchedulerReady(client);
 
         var probe = CreateTestProbe();
         Sys.EventStream.Subscribe(probe.Ref, typeof(TestEntity.ReminderReceived));

--- a/src/Akka.Reminders.Tests/ReminderClusterIntegrationSpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderClusterIntegrationSpecs.cs
@@ -215,7 +215,7 @@ internal sealed class TestEntity : ReceiveActor
     {
         _entityId = entityId;
 
-        Receive<ReminderEnvelope>(envelope =>
+        ReceiveAsync<ReminderEnvelope>(async envelope =>
         {
             // Extract the EntityMessage payload from the reminder envelope
             if (envelope.Message is EntityMessage msg)
@@ -226,6 +226,10 @@ internal sealed class TestEntity : ReceiveActor
             {
                 Context.System.EventStream.Publish(new ReminderReceived(_entityId, envelope.Message.ToString() ?? ""));
             }
+
+            // Ack the reminder so recurring reminders schedule their next occurrence
+            var ext = Context.System.ReminderClient();
+            await ext.AckAsync(envelope);
         });
 
         Receive<EntityMessage>(msg =>

--- a/src/Akka.Reminders.Tests/ReminderSchedulerRecoverySpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderSchedulerRecoverySpecs.cs
@@ -204,6 +204,48 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
     }
 
     [Fact]
+    public async Task Scheduler_ShouldResumeAckTimeouts_AfterRestart()
+    {
+        var testProbe = CreateTestProbe();
+        _resolver.RegisterShardRegion("test-region", testProbe);
+
+        var testScheduler = (TestScheduler)Sys.Scheduler;
+        var now = testScheduler.Now;
+
+        var reminder = new ScheduledReminder(
+            new ReminderEntity("test-region", "entity-ack-timeout"),
+            new ReminderKey("ack-timeout"),
+            now.AddSeconds(-1),
+            "timeout message",
+            RepeatInterval: null,
+            AttemptCount: 0,
+            LastFailureReason: null);
+
+        await _storage.ScheduleReminderAsync(reminder, CancellationToken.None);
+
+        var firstScheduler = CreateScheduler();
+        await Task.Delay(100);
+        testScheduler.Advance(TimeSpan.FromMilliseconds(100));
+
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        Assert.Equal("timeout message", envelope.Message);
+
+        await firstScheduler.GracefulStop(TimeSpan.FromSeconds(5));
+
+        var recoveredScheduler = CreateScheduler();
+        await Task.Delay(100);
+
+        testScheduler.Advance(TimeSpan.FromSeconds(31));
+        testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+
+        var reminders = await _storage.GetRemindersForEntityAsync(reminder.Entity, take: 10, skip: 0, CancellationToken.None);
+        var retried = Assert.Single(reminders, r => r.AttemptCount == 1);
+        Assert.Equal(envelope.DueTimeUtc, retried.DueTimeUtc);
+        Assert.Equal(1, retried.AttemptCount);
+        Assert.Equal("Ack timeout", retried.LastFailureReason);
+    }
+
+    [Fact]
     public async Task Scheduler_ShouldRestart_AndRecover_AfterFailure()
     {
         // Arrange - Schedule a reminder through a live scheduler

--- a/src/Akka.Reminders.Tests/ReminderSchedulerRecoverySpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderSchedulerRecoverySpecs.cs
@@ -84,7 +84,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 
         // Assert - Verify reminders are loaded by checking they fire at the right times
         testScheduler.Advance(TimeSpan.FromSeconds(11));
-        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("message 1", envelope1.Message);
 
         // Ack "message 1" so it is removed from storage and won't be re-delivered on the next fetch
@@ -94,7 +94,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
         testScheduler.Advance(TimeSpan.FromSeconds(10));
-        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("message 2", envelope2.Message);
     }
 
@@ -144,10 +144,10 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
 
         // Assert - Both overdue reminders should be delivered immediately
-        var messages = new List<object?>();
-        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var messages = new List<string>();
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         messages.Add(envelope1.Message);
-        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         messages.Add(envelope2.Message);
 
         Assert.Contains("overdue message 1", messages);
@@ -181,7 +181,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 
         // Assert - First occurrence
         testScheduler.Advance(TimeSpan.FromSeconds(6));
-        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("recurring message", envelope1.Message);
 
         // Ack the first delivery so the scheduler reschedulesthe next occurrence
@@ -190,7 +190,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 
         // Second occurrence
         testScheduler.Advance(TimeSpan.FromSeconds(5));
-        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("recurring message", envelope2.Message);
 
         // Ack the second delivery
@@ -199,7 +199,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 
         // Third occurrence
         testScheduler.Advance(TimeSpan.FromSeconds(5));
-        var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("recurring message", envelope3.Message);
     }
 
@@ -251,7 +251,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         testScheduler.Advance(TimeSpan.FromSeconds(16)); // Total 31 seconds from start
         Output?.WriteLine($"Current time after second advance: {testScheduler.Now}");
 
-        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("future message", envelope.Message);
     }
 
@@ -307,12 +307,12 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
 
         // Assert - All overdue reminders should be processed
-        var messages = new List<object?>();
-        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var messages = new List<string>();
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         messages.Add(envelope1.Message);
-        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         messages.Add(envelope2.Message);
-        var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         messages.Add(envelope3.Message);
 
         // Verify all messages were delivered (order may vary due to async processing)
@@ -358,7 +358,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 
         // Assert - Overdue reminder fires immediately
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
-        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("overdue message", envelope1.Message);
 
         // Ack the overdue reminder so it is removed from storage and won't be re-delivered
@@ -370,7 +370,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 
         // Advance to future reminder time
         testScheduler.Advance(TimeSpan.FromSeconds(10));
-        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("future message", envelope2.Message);
     }
 
@@ -398,7 +398,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         Assert.Equal(ReminderScheduleResponseCode.Success, response.ResponseCode);
 
         testScheduler.Advance(TimeSpan.FromSeconds(6));
-        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("test message", envelope.Message);
     }
 }

--- a/src/Akka.Reminders.Tests/ReminderSchedulerRecoverySpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderSchedulerRecoverySpecs.cs
@@ -84,14 +84,18 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 
         // Assert - Verify reminders are loaded by checking they fire at the right times
         testScheduler.Advance(TimeSpan.FromSeconds(11));
-        var message1 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        Assert.Equal("message 1", message1);
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        Assert.Equal("message 1", envelope1.Message);
+
+        // Ack "message 1" so it is removed from storage and won't be re-delivered on the next fetch
+        scheduler.Tell(new ReminderProtocol.ReminderAck(envelope1.Entity, envelope1.Key));
+        await Task.Delay(50); // Allow ack to be processed
 
         testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
         testScheduler.Advance(TimeSpan.FromSeconds(10));
-        var message2 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        Assert.Equal("message 2", message2);
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        Assert.Equal("message 2", envelope2.Message);
     }
 
     [Fact]
@@ -140,11 +144,11 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
 
         // Assert - Both overdue reminders should be delivered immediately
-        var messages = new List<string>();
-        var message1 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        messages.Add(message1);
-        var message2 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        messages.Add(message2);
+        var messages = new List<object?>();
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        messages.Add(envelope1.Message);
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        messages.Add(envelope2.Message);
 
         Assert.Contains("overdue message 1", messages);
         Assert.Contains("overdue message 2", messages);
@@ -177,24 +181,26 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 
         // Assert - First occurrence
         testScheduler.Advance(TimeSpan.FromSeconds(6));
-        var message1 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        Assert.Equal("recurring message", message1);
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        Assert.Equal("recurring message", envelope1.Message);
 
-        // Wait for next occurrence to be scheduled
-        testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        // Ack the first delivery so the scheduler reschedulesthe next occurrence
+        scheduler.Tell(new ReminderProtocol.ReminderAck(envelope1.Entity, envelope1.Key));
+        await Task.Delay(100); // Allow ack to be processed and next occurrence to be scheduled
 
         // Second occurrence
         testScheduler.Advance(TimeSpan.FromSeconds(5));
-        var message2 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        Assert.Equal("recurring message", message2);
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        Assert.Equal("recurring message", envelope2.Message);
 
-        // Wait for next occurrence to be scheduled
-        testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        // Ack the second delivery
+        scheduler.Tell(new ReminderProtocol.ReminderAck(envelope2.Entity, envelope2.Key));
+        await Task.Delay(100); // Allow ack to be processed and next occurrence to be scheduled
 
         // Third occurrence
         testScheduler.Advance(TimeSpan.FromSeconds(5));
-        var message3 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        Assert.Equal("recurring message", message3);
+        var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        Assert.Equal("recurring message", envelope3.Message);
     }
 
     [Fact]
@@ -245,8 +251,8 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         testScheduler.Advance(TimeSpan.FromSeconds(16)); // Total 31 seconds from start
         Output?.WriteLine($"Current time after second advance: {testScheduler.Now}");
 
-        var message = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        Assert.Equal("future message", message);
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        Assert.Equal("future message", envelope.Message);
     }
 
     [Fact]
@@ -301,13 +307,13 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
 
         // Assert - All overdue reminders should be processed
-        var messages = new List<string>();
-        var message1 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        messages.Add(message1);
-        var message2 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        messages.Add(message2);
-        var message3 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        messages.Add(message3);
+        var messages = new List<object?>();
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        messages.Add(envelope1.Message);
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        messages.Add(envelope2.Message);
+        var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        messages.Add(envelope3.Message);
 
         // Verify all messages were delivered (order may vary due to async processing)
         Assert.Contains("oldest message", messages);
@@ -352,16 +358,20 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 
         // Assert - Overdue reminder fires immediately
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
-        var message1 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        Assert.Equal("overdue message", message1);
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        Assert.Equal("overdue message", envelope1.Message);
+
+        // Ack the overdue reminder so it is removed from storage and won't be re-delivered
+        scheduler.Tell(new ReminderProtocol.ReminderAck(envelope1.Entity, envelope1.Key));
+        await Task.Delay(50); // Allow ack to be processed
 
         // Future reminder hasn't fired yet
         testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
         // Advance to future reminder time
         testScheduler.Advance(TimeSpan.FromSeconds(10));
-        var message2 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        Assert.Equal("future message", message2);
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        Assert.Equal("future message", envelope2.Message);
     }
 
     [Fact]
@@ -388,7 +398,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         Assert.Equal(ReminderScheduleResponseCode.Success, response.ResponseCode);
 
         testScheduler.Advance(TimeSpan.FromSeconds(6));
-        var message = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        Assert.Equal("test message", message);
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        Assert.Equal("test message", envelope.Message);
     }
 }

--- a/src/Akka.Reminders.Tests/ReminderSchedulerRecoverySpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderSchedulerRecoverySpecs.cs
@@ -88,7 +88,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         Assert.Equal("message 1", envelope1.Message);
 
         // Ack "message 1" so it is removed from storage and won't be re-delivered on the next fetch
-        scheduler.Tell(new ReminderProtocol.ReminderAck(envelope1.Entity, envelope1.Key));
+        scheduler.Tell(new ReminderProtocol.ReminderAck(envelope1.Entity, envelope1.Key, envelope1.DueTimeUtc));
         await Task.Delay(50); // Allow ack to be processed
 
         testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
@@ -185,7 +185,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         Assert.Equal("recurring message", envelope1.Message);
 
         // Ack the first delivery so the scheduler reschedulesthe next occurrence
-        scheduler.Tell(new ReminderProtocol.ReminderAck(envelope1.Entity, envelope1.Key));
+        scheduler.Tell(new ReminderProtocol.ReminderAck(envelope1.Entity, envelope1.Key, envelope1.DueTimeUtc));
         await Task.Delay(100); // Allow ack to be processed and next occurrence to be scheduled
 
         // Second occurrence
@@ -194,7 +194,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         Assert.Equal("recurring message", envelope2.Message);
 
         // Ack the second delivery
-        scheduler.Tell(new ReminderProtocol.ReminderAck(envelope2.Entity, envelope2.Key));
+        scheduler.Tell(new ReminderProtocol.ReminderAck(envelope2.Entity, envelope2.Key, envelope2.DueTimeUtc));
         await Task.Delay(100); // Allow ack to be processed and next occurrence to be scheduled
 
         // Third occurrence
@@ -362,7 +362,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         Assert.Equal("overdue message", envelope1.Message);
 
         // Ack the overdue reminder so it is removed from storage and won't be re-delivered
-        scheduler.Tell(new ReminderProtocol.ReminderAck(envelope1.Entity, envelope1.Key));
+        scheduler.Tell(new ReminderProtocol.ReminderAck(envelope1.Entity, envelope1.Key, envelope1.DueTimeUtc));
         await Task.Delay(50); // Allow ack to be processed
 
         // Future reminder hasn't fired yet

--- a/src/Akka.Reminders.Tests/ReminderSchedulerRecoverySpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderSchedulerRecoverySpecs.cs
@@ -304,11 +304,17 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         testScheduler.Advance(TimeSpan.FromSeconds(31));
 
         // The retry isn't delivered yet — it has a backoff delay. But we can verify
-        // the storage state to confirm the timeout was processed.
-        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+        // the storage state to confirm the timeout was processed. Use AwaitAssertAsync
+        // to wait for the RunTask to complete rather than a fixed delay.
+        await AwaitAssertAsync(async () =>
+        {
+            var reminders = await _storage.GetRemindersForEntityAsync(
+                reminder.Entity, take: 10, skip: 0, CancellationToken.None);
+            Assert.Single(reminders, r => r.AttemptCount == 1);
+        }, TimeSpan.FromSeconds(5));
 
-        var reminders = await _storage.GetRemindersForEntityAsync(reminder.Entity, take: 10, skip: 0, CancellationToken.None);
-        var retried = Assert.Single(reminders, r => r.AttemptCount == 1);
+        var finalReminders = await _storage.GetRemindersForEntityAsync(reminder.Entity, take: 10, skip: 0, CancellationToken.None);
+        var retried = Assert.Single(finalReminders, r => r.AttemptCount == 1);
         // DueTimeUtc stays the same (occurrence identity), but when_utc moved forward.
         Assert.Equal(envelope.DueTimeUtc, retried.DueTimeUtc);
         Assert.Equal(1, retried.AttemptCount);

--- a/src/Akka.Reminders.Tests/ReminderSchedulerRecoverySpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderSchedulerRecoverySpecs.cs
@@ -10,8 +10,14 @@ namespace Akka.Reminders.Tests;
 
 /// <summary>
 /// Tests for ReminderScheduler recovery behavior.
-/// Validates that the scheduler correctly loads and processes reminders from storage on startup,
-/// including overdue reminders that should have fired while the scheduler was down.
+///
+/// These tests simulate scheduler restarts by pre-populating InMemoryReminderStorage
+/// before creating the scheduler actor. Because storage is shared across scheduler
+/// instances, creating a new scheduler is equivalent to a singleton handoff or
+/// process restart — the new instance loads its state from the same storage.
+///
+/// All tests use TestScheduler for deterministic time control. Virtual time advances
+/// only via explicit Advance() calls, so timer-driven delivery is fully reproducible.
 /// </summary>
 public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 {
@@ -26,7 +32,6 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 
     protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
-        // Use TestScheduler for deterministic time control
         builder.AddHocon("akka.scheduler.implementation = \"Akka.TestKit.TestScheduler, Akka.TestKit\"", HoconAddMode.Prepend);
     }
 
@@ -45,16 +50,52 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
             $"reminder-scheduler-{Guid.NewGuid():N}");
     }
 
+    /// <summary>
+    /// Waits for the scheduler to finish initialization (PreStart → LoadReminderOverview
+    /// → PipeTo → Become(Scheduling) → UnstashAll). Sends a GetReminders query which
+    /// gets stashed during init and replayed after — the response proves the scheduler
+    /// is in the Scheduling behavior and ready to process commands.
+    /// </summary>
+    private async Task WaitForSchedulerReady(IActorRef scheduler)
+    {
+        var probe = new ReminderEntity("__probe__", "__probe__");
+        var response = await scheduler.Ask<ReminderProtocol.RemindersForEntity>(
+            new ReminderProtocol.GetReminders(probe),
+            TimeSpan.FromSeconds(10));
+        Assert.Equal(FetchRemindersResponseCode.Success, response.ResponseCode);
+    }
+
+    /// <summary>
+    /// Sends an ack to the scheduler and waits for the response. This guarantees the
+    /// ack has been buffered and flushed before the test continues — no arbitrary delay.
+    /// </summary>
+    private async Task AckAndWait(IActorRef scheduler, ReminderEnvelope envelope)
+    {
+        var response = await scheduler.Ask<ReminderProtocol.ReminderAckResponse>(
+            new ReminderProtocol.ReminderAck(envelope.Entity, envelope.Key, envelope.DueTimeUtc),
+            TimeSpan.FromSeconds(10));
+        Assert.Equal(ReminderAckResponseCode.Success, response.ResponseCode);
+    }
+
+    /// <summary>
+    /// Verifies that a new scheduler loads existing reminders from storage on startup.
+    /// Pre-populates storage with two future reminders, then creates the scheduler and
+    /// advances virtual time past each due time to confirm delivery.
+    ///
+    /// This simulates the normal startup path where the scheduler discovers pending work
+    /// from a previous instance or from application-level pre-seeding.
+    /// </summary>
     [Fact]
     public async Task Scheduler_ShouldLoadRemindersFromStorage_OnStartup()
     {
-        // Arrange - Pre-populate storage with reminders before scheduler starts
         var testProbe = CreateTestProbe();
         _resolver.RegisterShardRegion("test-region", testProbe);
 
         var testScheduler = (TestScheduler)Sys.Scheduler;
         var now = testScheduler.Now;
 
+        // Pre-populate storage before the scheduler exists — simulates reminders
+        // persisted by a previous scheduler instance or by application startup logic.
         var reminder1 = new ScheduledReminder(
             new ReminderEntity("test-region", "entity-1"),
             new ReminderKey("reminder-1"),
@@ -76,43 +117,52 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         await _storage.ScheduleReminderAsync(reminder1, CancellationToken.None);
         await _storage.ScheduleReminderAsync(reminder2, CancellationToken.None);
 
-        // Act - Create scheduler (triggers PreStart -> LoadReminderOverview)
+        // Create scheduler — triggers PreStart → LoadReminderOverview → TryScheduleFetchReminders.
         var scheduler = CreateScheduler();
+        await WaitForSchedulerReady(scheduler);
 
-        // Give scheduler time to initialize and load from storage
-        await Task.Delay(100);
-
-        // Assert - Verify reminders are loaded by checking they fire at the right times
+        // Advance past reminder-1's due time. The scheduler's fetch timer fires and
+        // delivers reminder-1 to the test probe via the shard region resolver.
         testScheduler.Advance(TimeSpan.FromSeconds(11));
         var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("message 1", envelope1.Message);
 
-        // Ack "message 1" so it is removed from storage and won't be re-delivered on the next fetch
-        scheduler.Tell(new ReminderProtocol.ReminderAck(envelope1.Entity, envelope1.Key, envelope1.DueTimeUtc));
-        await Task.Delay(50); // Allow ack to be processed
+        // Ack reminder-1 so it's marked Delivered and won't be re-fetched on the next tick.
+        await AckAndWait(scheduler, envelope1);
 
-        testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        // Reminder-2 hasn't fired yet — its due time is T+20s, we're only at T+11s.
+        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
 
+        // Advance to reminder-2's due time.
         testScheduler.Advance(TimeSpan.FromSeconds(10));
         var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("message 2", envelope2.Message);
     }
 
+    /// <summary>
+    /// Verifies that overdue reminders (due time in the past) are processed immediately
+    /// on startup. When a scheduler starts and finds reminders whose when_utc is already
+    /// past, TryScheduleFetchReminders computes a zero or negative delay (clamped to zero),
+    /// so the fetch timer fires on the next tick.
+    ///
+    /// This simulates a scheduler that was down for a period and needs to catch up on
+    /// missed deliveries.
+    /// </summary>
     [Fact]
     public async Task Scheduler_ShouldProcessOverdueReminders_Immediately()
     {
-        // Arrange - Create reminders that are already overdue
         var testProbe = CreateTestProbe();
         _resolver.RegisterShardRegion("test-region", testProbe);
 
         var testScheduler = (TestScheduler)Sys.Scheduler;
         var now = testScheduler.Now;
 
-        // These reminders are already past due
+        // These reminders are already past due — simulates the scheduler being down
+        // when they were supposed to fire.
         var overdueReminder1 = new ScheduledReminder(
             new ReminderEntity("test-region", "entity-1"),
             new ReminderKey("overdue-1"),
-            now.AddSeconds(-5), // 5 seconds ago
+            now.AddSeconds(-5),
             "overdue message 1",
             RepeatInterval: null,
             AttemptCount: 0,
@@ -121,7 +171,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         var overdueReminder2 = new ScheduledReminder(
             new ReminderEntity("test-region", "entity-2"),
             new ReminderKey("overdue-2"),
-            now.AddSeconds(-10), // 10 seconds ago
+            now.AddSeconds(-10),
             "overdue message 2",
             RepeatInterval: null,
             AttemptCount: 0,
@@ -130,34 +180,33 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         await _storage.ScheduleReminderAsync(overdueReminder1, CancellationToken.None);
         await _storage.ScheduleReminderAsync(overdueReminder2, CancellationToken.None);
 
-        Output?.WriteLine($"TestScheduler.Now before scheduler start: {testScheduler.Now}");
-        Output?.WriteLine($"Overdue reminder 1 was due at: {overdueReminder1.When}");
-        Output?.WriteLine($"Overdue reminder 2 was due at: {overdueReminder2.When}");
-
-        // Act - Create scheduler - it should process overdue reminders immediately
         var scheduler = CreateScheduler();
+        await WaitForSchedulerReady(scheduler);
 
-        // Give scheduler time to initialize
-        await Task.Delay(100);
-
-        // Small advance to trigger processing
+        // A small advance triggers the zero-delay fetch timer, which finds both
+        // overdue reminders and delivers them in a single batch.
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
 
-        // Assert - Both overdue reminders should be delivered immediately
         var messages = new List<string>();
         var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         messages.Add(envelope1.Message);
         var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         messages.Add(envelope2.Message);
 
+        // Both overdue reminders should be delivered (order within a batch may vary).
         Assert.Contains("overdue message 1", messages);
         Assert.Contains("overdue message 2", messages);
     }
 
+    /// <summary>
+    /// Verifies that a recurring reminder loaded from storage continues to produce
+    /// occurrences across multiple cycles. Each delivery requires an ack before the
+    /// next occurrence can be processed — the ack triggers the scheduler to reload
+    /// its pending overview and schedule the next fetch timer.
+    /// </summary>
     [Fact]
     public async Task Scheduler_ShouldRecover_RecurringReminders()
     {
-        // Arrange - Create a recurring reminder before scheduler starts
         var testProbe = CreateTestProbe();
         _resolver.RegisterShardRegion("test-region", testProbe);
 
@@ -175,34 +224,44 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 
         await _storage.ScheduleReminderAsync(recurringReminder, CancellationToken.None);
 
-        // Act - Create scheduler
         var scheduler = CreateScheduler();
-        await Task.Delay(100);
+        await WaitForSchedulerReady(scheduler);
 
-        // Assert - First occurrence
+        // First occurrence: advance past T+5s, receive delivery.
         testScheduler.Advance(TimeSpan.FromSeconds(6));
         var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("recurring message", envelope1.Message);
 
-        // Ack the first delivery so the scheduler reschedulesthe next occurrence
-        scheduler.Tell(new ReminderProtocol.ReminderAck(envelope1.Entity, envelope1.Key, envelope1.DueTimeUtc));
-        await Task.Delay(100); // Allow ack to be processed and next occurrence to be scheduled
+        // Ack the first delivery. The next occurrence (T+10s) was already persisted
+        // during the commit phase, but the ack confirms the current one is done.
+        await AckAndWait(scheduler, envelope1);
 
-        // Second occurrence
+        // Second occurrence: advance by another interval.
         testScheduler.Advance(TimeSpan.FromSeconds(5));
         var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("recurring message", envelope2.Message);
 
-        // Ack the second delivery
-        scheduler.Tell(new ReminderProtocol.ReminderAck(envelope2.Entity, envelope2.Key, envelope2.DueTimeUtc));
-        await Task.Delay(100); // Allow ack to be processed and next occurrence to be scheduled
+        await AckAndWait(scheduler, envelope2);
 
-        // Third occurrence
+        // Third occurrence: confirms the cycle continues indefinitely.
         testScheduler.Advance(TimeSpan.FromSeconds(5));
         var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("recurring message", envelope3.Message);
     }
 
+    /// <summary>
+    /// Verifies that ack-timeout state survives a scheduler restart.
+    ///
+    /// Scenario:
+    /// 1. First scheduler delivers a reminder (moves it to AwaitingAck in storage)
+    /// 2. No ack arrives — the first scheduler is stopped
+    /// 3. Second scheduler starts, loads the ack deadline from InitResult
+    /// 4. When the ack deadline passes, the second scheduler detects the timeout
+    ///    and retries the reminder (incrementing AttemptCount, setting failure reason)
+    ///
+    /// This is the key singleton-handoff test: AwaitingAck state is in the database,
+    /// not in-memory, so the new scheduler picks up where the old one left off.
+    /// </summary>
     [Fact]
     public async Task Scheduler_ShouldResumeAckTimeouts_AfterRestart()
     {
@@ -212,6 +271,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         var testScheduler = (TestScheduler)Sys.Scheduler;
         var now = testScheduler.Now;
 
+        // Schedule an overdue reminder so it's delivered immediately.
         var reminder = new ScheduledReminder(
             new ReminderEntity("test-region", "entity-ack-timeout"),
             new ReminderKey("ack-timeout"),
@@ -223,44 +283,59 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 
         await _storage.ScheduleReminderAsync(reminder, CancellationToken.None);
 
+        // First scheduler: delivers the reminder but we intentionally don't ack it.
         var firstScheduler = CreateScheduler();
-        await Task.Delay(100);
+        await WaitForSchedulerReady(firstScheduler);
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
 
         var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("timeout message", envelope.Message);
 
+        // Stop the first scheduler without acking — the occurrence stays AwaitingAck in storage.
         await firstScheduler.GracefulStop(TimeSpan.FromSeconds(5));
 
+        // Second scheduler: loads InitResult with the ack deadline from storage.
         var recoveredScheduler = CreateScheduler();
-        await Task.Delay(100);
+        await WaitForSchedulerReady(recoveredScheduler);
 
+        // Advance past the AckTimeout (30s default). The ack-timeout checker fires,
+        // finds the timed-out occurrence, and creates a retry (back to Pending with
+        // incremented AttemptCount and backoff when_utc).
         testScheduler.Advance(TimeSpan.FromSeconds(31));
-        testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+
+        // The retry isn't delivered yet — it has a backoff delay. But we can verify
+        // the storage state to confirm the timeout was processed.
+        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
 
         var reminders = await _storage.GetRemindersForEntityAsync(reminder.Entity, take: 10, skip: 0, CancellationToken.None);
         var retried = Assert.Single(reminders, r => r.AttemptCount == 1);
+        // DueTimeUtc stays the same (occurrence identity), but when_utc moved forward.
         Assert.Equal(envelope.DueTimeUtc, retried.DueTimeUtc);
         Assert.Equal(1, retried.AttemptCount);
         Assert.Equal("Ack timeout", retried.LastFailureReason);
     }
 
+    /// <summary>
+    /// Verifies that a reminder scheduled through one scheduler instance is correctly
+    /// delivered by a different instance after a simulated crash and restart.
+    ///
+    /// The key insight: the reminder is persisted in storage, not in the scheduler's
+    /// memory. The second scheduler loads the pending overview on startup and discovers
+    /// the reminder, then delivers it when its due time arrives.
+    /// </summary>
     [Fact]
     public async Task Scheduler_ShouldRestart_AndRecover_AfterFailure()
     {
-        // Arrange - Schedule a reminder through a live scheduler
         var testProbe = CreateTestProbe();
         _resolver.RegisterShardRegion("test-region", testProbe);
 
         var testScheduler = (TestScheduler)Sys.Scheduler;
         var now = testScheduler.Now;
 
+        // First scheduler: schedule a reminder for T+30s.
         var firstScheduler = CreateScheduler();
+        await WaitForSchedulerReady(firstScheduler);
 
-        // Wait for initialization
-        await Task.Delay(100);
-
-        // Schedule a reminder for the future - send directly to scheduler, not through client
         var reminderTime = now.AddSeconds(30);
         firstScheduler.Tell(new ReminderProtocol.ScheduleReminder(
             new ReminderEntity("test-region", "entity-1"),
@@ -271,49 +346,45 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         var scheduleResponse = await testProbe.ExpectMsgAsync<ReminderProtocol.ReminderScheduled>(TimeSpan.FromSeconds(5));
         Assert.Equal(ReminderScheduleResponseCode.Success, scheduleResponse.ResponseCode);
 
-        Output?.WriteLine($"Scheduled reminder for: {reminderTime}");
-        Output?.WriteLine($"Current time: {testScheduler.Now}");
-
-        // Act - Kill the scheduler (simulating crash/restart)
-        Output?.WriteLine("Stopping first scheduler...");
+        // Crash: stop the scheduler while the reminder is still in the future.
         await firstScheduler.GracefulStop(TimeSpan.FromSeconds(5));
 
-        // Advance time while scheduler is "down"
-        Output?.WriteLine("Advancing time by 15 seconds while scheduler is down...");
+        // Time passes while the scheduler is "down."
         testScheduler.Advance(TimeSpan.FromSeconds(15));
-        Output?.WriteLine($"Current time after advance: {testScheduler.Now}");
 
-        // Create new scheduler instance - simulates recovery
-        Output?.WriteLine("Creating new scheduler (recovery)...");
+        // Recovery: new scheduler loads the reminder from storage.
         var recoveredScheduler = CreateScheduler();
-        await Task.Delay(100);
+        await WaitForSchedulerReady(recoveredScheduler);
 
-        // Assert - The reminder should still fire at its scheduled time
-        Output?.WriteLine($"Advancing to reminder time (15 more seconds)...");
-        testScheduler.Advance(TimeSpan.FromSeconds(16)); // Total 31 seconds from start
-        Output?.WriteLine($"Current time after second advance: {testScheduler.Now}");
+        // Advance past the reminder's due time. The recovered scheduler delivers it.
+        testScheduler.Advance(TimeSpan.FromSeconds(16));
 
         var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("future message", envelope.Message);
     }
 
+    /// <summary>
+    /// Verifies that when multiple overdue reminders exist at startup, all of them
+    /// are delivered. GetNextRemindersAsync fetches them as a batch ordered by when_utc,
+    /// and ProcessReminders delivers all of them in a single tick.
+    /// </summary>
     [Fact]
     public async Task Scheduler_ShouldProcessMultipleOverdueReminders_InOrder()
     {
-        // Arrange - Create multiple overdue reminders with different due times
         var testProbe = CreateTestProbe();
         _resolver.RegisterShardRegion("test-region", testProbe);
 
         var testScheduler = (TestScheduler)Sys.Scheduler;
         var now = testScheduler.Now;
 
-        // Create reminders that are overdue by varying amounts
+        // Three reminders overdue by varying amounts — simulates the scheduler being
+        // down for 30 seconds while reminders piled up.
         var reminders = new[]
         {
             new ScheduledReminder(
                 new ReminderEntity("test-region", "entity-1"),
                 new ReminderKey("oldest"),
-                now.AddSeconds(-30), // Oldest
+                now.AddSeconds(-30),
                 "oldest message",
                 RepeatInterval: null,
                 AttemptCount: 0,
@@ -331,7 +402,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
             new ScheduledReminder(
                 new ReminderEntity("test-region", "entity-3"),
                 new ReminderKey("newest"),
-                now.AddSeconds(-5), // Most recent
+                now.AddSeconds(-5),
                 "newest message",
                 RepeatInterval: null,
                 AttemptCount: 0,
@@ -343,12 +414,11 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
             await _storage.ScheduleReminderAsync(reminder, CancellationToken.None);
         }
 
-        // Act - Create scheduler
         var scheduler = CreateScheduler();
-        await Task.Delay(100);
+        await WaitForSchedulerReady(scheduler);
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
 
-        // Assert - All overdue reminders should be processed
+        // All three are overdue and fetched in a single batch.
         var messages = new List<string>();
         var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         messages.Add(envelope1.Message);
@@ -357,16 +427,23 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         messages.Add(envelope3.Message);
 
-        // Verify all messages were delivered (order may vary due to async processing)
+        // All delivered — order within a batch may vary due to async processing.
         Assert.Contains("oldest message", messages);
         Assert.Contains("middle message", messages);
         Assert.Contains("newest message", messages);
     }
 
+    /// <summary>
+    /// Verifies that the scheduler correctly handles a mix of overdue and future
+    /// reminders on startup. Overdue reminders fire on the first tick; future
+    /// reminders wait for their scheduled time.
+    ///
+    /// This is the most realistic recovery scenario: some reminders were missed
+    /// while the scheduler was down, and others haven't come due yet.
+    /// </summary>
     [Fact]
     public async Task Scheduler_ShouldRecover_AndProcessMixOfOverdueAndFutureReminders()
     {
-        // Arrange - Mix of overdue and future reminders
         var testProbe = CreateTestProbe();
         _resolver.RegisterShardRegion("test-region", testProbe);
 
@@ -394,41 +471,42 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         await _storage.ScheduleReminderAsync(overdueReminder, CancellationToken.None);
         await _storage.ScheduleReminderAsync(futureReminder, CancellationToken.None);
 
-        // Act - Create scheduler
         var scheduler = CreateScheduler();
-        await Task.Delay(100);
+        await WaitForSchedulerReady(scheduler);
 
-        // Assert - Overdue reminder fires immediately
+        // Overdue reminder fires immediately on the first tick.
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
         var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("overdue message", envelope1.Message);
 
-        // Ack the overdue reminder so it is removed from storage and won't be re-delivered
-        scheduler.Tell(new ReminderProtocol.ReminderAck(envelope1.Entity, envelope1.Key, envelope1.DueTimeUtc));
-        await Task.Delay(50); // Allow ack to be processed
+        // Ack the overdue reminder so it doesn't interfere with the future one.
+        await AckAndWait(scheduler, envelope1);
 
-        // Future reminder hasn't fired yet
-        testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        // Future reminder hasn't fired yet — its due time is T+10s.
+        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
 
-        // Advance to future reminder time
+        // Advance to the future reminder's due time.
         testScheduler.Advance(TimeSpan.FromSeconds(10));
         var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("future message", envelope2.Message);
     }
 
+    /// <summary>
+    /// Verifies that the scheduler initializes correctly with empty storage.
+    /// This is the fresh-start scenario: no pre-existing reminders, the scheduler
+    /// just needs to be ready to accept new commands.
+    /// </summary>
     [Fact]
     public async Task Scheduler_ShouldHandleEmptyStorage_OnStartup()
     {
-        // Arrange - Empty storage
         var testProbe = CreateTestProbe();
         _resolver.RegisterShardRegion("test-region", testProbe);
 
-        // Act - Create scheduler with empty storage
+        // Create scheduler with empty storage — no reminders to load.
         var scheduler = CreateScheduler();
-        await Task.Delay(100);
+        await WaitForSchedulerReady(scheduler);
 
-        // Assert - Scheduler should initialize successfully
-        // Schedule a new reminder to verify scheduler is working - send directly to scheduler
+        // Verify the scheduler is operational by scheduling and delivering a reminder.
         var testScheduler = (TestScheduler)Sys.Scheduler;
         scheduler.Tell(new ReminderProtocol.ScheduleReminder(
             new ReminderEntity("test-region", "entity-1"),

--- a/src/Akka.Reminders.Tests/ReminderSchedulerTimingSpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderSchedulerTimingSpecs.cs
@@ -92,8 +92,8 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         Output?.WriteLine($"TestScheduler.Now after second advance: {testScheduler.Now}");
 
         // Assert - Verify the reminder message was received
-        var message = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        Assert.Equal("test message", message);
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        Assert.Equal("test message", envelope.Message);
     }
 
     [Fact]
@@ -133,23 +133,29 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         Output?.WriteLine($"Advancing by 11 seconds...");
         testScheduler.Advance(TimeSpan.FromSeconds(11));
         Output?.WriteLine($"TestScheduler.Now after first advance: {testScheduler.Now}");
-        var message1 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        Assert.Equal("first", message1);
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        Assert.Equal("first", envelope1.Message);
         Output?.WriteLine($"Received first message");
 
-        // Wait for processing to complete and next timer to be scheduled
-        await AwaitConditionAsync(() => Task.FromResult(true), TimeSpan.FromMilliseconds(100));
-
-        testScheduler.Advance(TimeSpan.FromSeconds(10));
-        var message2 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        Assert.Equal("second", message2);
+        // Ack to prevent "first" from being re-delivered on the next fetch
+        await client.AckAsync(envelope1);
 
         // Wait for processing to complete and next timer to be scheduled
         await AwaitConditionAsync(() => Task.FromResult(true), TimeSpan.FromMilliseconds(100));
 
         testScheduler.Advance(TimeSpan.FromSeconds(10));
-        var message3 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        Assert.Equal("third", message3);
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        Assert.Equal("second", envelope2.Message);
+
+        // Ack to prevent "second" from being re-delivered on the next fetch
+        await client.AckAsync(envelope2);
+
+        // Wait for processing to complete and next timer to be scheduled
+        await AwaitConditionAsync(() => Task.FromResult(true), TimeSpan.FromMilliseconds(100));
+
+        testScheduler.Advance(TimeSpan.FromSeconds(10));
+        var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        Assert.Equal("third", envelope3.Message);
     }
 
     [Fact]
@@ -184,11 +190,14 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         Output?.WriteLine($"Before first advance - TestScheduler.Now: {testScheduler.Now}");
         testScheduler.Advance(TimeSpan.FromSeconds(6));
         Output?.WriteLine($"After first advance - TestScheduler.Now: {testScheduler.Now}");
-        var message1 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        Assert.Equal("recurring message", message1);
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        Assert.Equal("recurring message", envelope1.Message);
         Output?.WriteLine($"Received first recurring message");
 
-        // Allow async processing to complete, then verify deterministically
+        // Ack the first delivery so the scheduler schedules the next occurrence
+        await client.AckAsync(envelope1);
+
+        // Allow async processing to complete, then verify the next occurrence is scheduled
         testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
         var list1 = await client.ListRemindersAsync();
         Assert.Single(list1.Reminders);
@@ -198,8 +207,11 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         Output?.WriteLine($"Before second advance - TestScheduler.Now: {testScheduler.Now}");
         testScheduler.Advance(interval);
         Output?.WriteLine($"After second advance - TestScheduler.Now: {testScheduler.Now}");
-        var message2 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        Assert.Equal("recurring message", message2);
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        Assert.Equal("recurring message", envelope2.Message);
+
+        // Ack the second delivery
+        await client.AckAsync(envelope2);
 
         // Allow async processing to complete
         testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
@@ -208,8 +220,8 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
 
         // Verify third occurrence
         testScheduler.Advance(interval);
-        var message3 = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        Assert.Equal("recurring message", message3);
+        var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        Assert.Equal("recurring message", envelope3.Message);
     }
 
     [Fact]
@@ -270,7 +282,7 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         testScheduler.Advance(TimeSpan.FromSeconds(2));
 
         // Assert
-        var message = await testProbe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
-        Assert.Equal("immediate message", message);
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        Assert.Equal("immediate message", envelope.Message);
     }
 }

--- a/src/Akka.Reminders.Tests/ReminderSchedulerTimingSpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderSchedulerTimingSpecs.cs
@@ -301,6 +301,12 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         testScheduler.Advance(TimeSpan.FromSeconds(6));
         var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
 
+        // Let the scheduler finish persisting and timer-scheduling the superseding occurrence
+        // before we advance virtual time again.
+        testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        var reminders = await client.ListRemindersAsync();
+        Assert.Contains(reminders.Reminders, r => r.DueTimeUtc == now.AddSeconds(10));
+
         testScheduler.Advance(interval);
         var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal(now.AddSeconds(10), envelope2.DueTimeUtc);

--- a/src/Akka.Reminders.Tests/ReminderSchedulerTimingSpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderSchedulerTimingSpecs.cs
@@ -225,6 +225,94 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
     }
 
     [Fact]
+    public async Task ReminderEnvelope_ShouldExposeDueTimeAndDeadlineMetadata()
+    {
+        var testProbe = CreateTestProbe();
+        _resolver.RegisterShardRegion("test-region", testProbe);
+
+        var client = Sys.ReminderClient().CreateClient("test-region", "entity-1");
+        var testScheduler = (TestScheduler)Sys.Scheduler;
+        var dueTime = testScheduler.Now.AddSeconds(5);
+
+        var result = await client.ScheduleSingleReminderAsync(
+            new ReminderKey("deadline-reminder"),
+            dueTime,
+            "deadline message",
+            maxDeliveryWindow: TimeSpan.FromSeconds(2));
+
+        Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
+
+        testScheduler.Advance(TimeSpan.FromSeconds(6));
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(dueTime, envelope.DueTimeUtc);
+        Assert.False(envelope.Deadline.IsInfinite);
+        Assert.False(envelope.Deadline.IsExpired(dueTime.AddSeconds(1)));
+        Assert.True(envelope.Deadline.IsExpired(dueTime.AddSeconds(3)));
+    }
+
+    [Fact]
+    public async Task RecurringReminder_ShouldScheduleNextOccurrenceWithoutWaitingForAck()
+    {
+        var testProbe = CreateTestProbe();
+        _resolver.RegisterShardRegion("test-region", testProbe);
+
+        var client = Sys.ReminderClient().CreateClient("test-region", "entity-1");
+        var testScheduler = (TestScheduler)Sys.Scheduler;
+        var now = testScheduler.Now;
+        var interval = TimeSpan.FromSeconds(5);
+
+        var result = await client.ScheduleRecurringReminderAsync(
+            new ReminderKey("latest-only-recurring"),
+            now.AddSeconds(5),
+            interval,
+            "recurring message");
+
+        Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
+
+        testScheduler.Advance(TimeSpan.FromSeconds(6));
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        Assert.Equal(now.AddSeconds(5), envelope1.DueTimeUtc);
+
+        testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        var reminders = await client.ListRemindersAsync();
+        Assert.Contains(reminders.Reminders, r => r.DueTimeUtc == now.AddSeconds(10));
+    }
+
+    [Fact]
+    public async Task LateAckForSupersededRecurringOccurrence_ShouldReturnNotFound()
+    {
+        var testProbe = CreateTestProbe();
+        _resolver.RegisterShardRegion("test-region", testProbe);
+
+        var client = Sys.ReminderClient().CreateClient("test-region", "entity-1");
+        var testScheduler = (TestScheduler)Sys.Scheduler;
+        var now = testScheduler.Now;
+        var interval = TimeSpan.FromSeconds(5);
+
+        var result = await client.ScheduleRecurringReminderAsync(
+            new ReminderKey("superseded-recurring"),
+            now.AddSeconds(5),
+            interval,
+            "recurring message");
+
+        Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
+
+        testScheduler.Advance(TimeSpan.FromSeconds(6));
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+
+        testScheduler.Advance(interval);
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        Assert.Equal(now.AddSeconds(10), envelope2.DueTimeUtc);
+
+        var staleAck = await client.AckAsync(envelope1);
+        Assert.Equal(ReminderAckResponseCode.NotFound, staleAck.ResponseCode);
+
+        var currentAck = await client.AckAsync(envelope2);
+        Assert.Equal(ReminderAckResponseCode.Success, currentAck.ResponseCode);
+    }
+
+    [Fact]
     public async Task CancelledReminder_ShouldNotFire()
     {
         // Arrange

--- a/src/Akka.Reminders.Tests/ReminderSchedulerTimingSpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderSchedulerTimingSpecs.cs
@@ -92,7 +92,7 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         Output?.WriteLine($"TestScheduler.Now after second advance: {testScheduler.Now}");
 
         // Assert - Verify the reminder message was received
-        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("test message", envelope.Message);
     }
 
@@ -133,7 +133,7 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         Output?.WriteLine($"Advancing by 11 seconds...");
         testScheduler.Advance(TimeSpan.FromSeconds(11));
         Output?.WriteLine($"TestScheduler.Now after first advance: {testScheduler.Now}");
-        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("first", envelope1.Message);
         Output?.WriteLine($"Received first message");
 
@@ -144,7 +144,7 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         await AwaitConditionAsync(() => Task.FromResult(true), TimeSpan.FromMilliseconds(100));
 
         testScheduler.Advance(TimeSpan.FromSeconds(10));
-        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("second", envelope2.Message);
 
         // Ack to prevent "second" from being re-delivered on the next fetch
@@ -154,7 +154,7 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         await AwaitConditionAsync(() => Task.FromResult(true), TimeSpan.FromMilliseconds(100));
 
         testScheduler.Advance(TimeSpan.FromSeconds(10));
-        var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("third", envelope3.Message);
     }
 
@@ -190,7 +190,7 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         Output?.WriteLine($"Before first advance - TestScheduler.Now: {testScheduler.Now}");
         testScheduler.Advance(TimeSpan.FromSeconds(6));
         Output?.WriteLine($"After first advance - TestScheduler.Now: {testScheduler.Now}");
-        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("recurring message", envelope1.Message);
         Output?.WriteLine($"Received first recurring message");
 
@@ -207,7 +207,7 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         Output?.WriteLine($"Before second advance - TestScheduler.Now: {testScheduler.Now}");
         testScheduler.Advance(interval);
         Output?.WriteLine($"After second advance - TestScheduler.Now: {testScheduler.Now}");
-        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("recurring message", envelope2.Message);
 
         // Ack the second delivery
@@ -220,7 +220,7 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
 
         // Verify third occurrence
         testScheduler.Advance(interval);
-        var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("recurring message", envelope3.Message);
     }
 
@@ -282,7 +282,7 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         testScheduler.Advance(TimeSpan.FromSeconds(2));
 
         // Assert
-        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope>(TimeSpan.FromSeconds(5));
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
         Assert.Equal("immediate message", envelope.Message);
     }
 }

--- a/src/Akka.Reminders.Tests/Serialization/ReminderSerializerSpecs.cs
+++ b/src/Akka.Reminders.Tests/Serialization/ReminderSerializerSpecs.cs
@@ -237,6 +237,65 @@ public class ReminderSerializerSpecs : IDisposable
         Assert.Equal("Storage write failed: connection timeout", deserialized.Message);
     }
 
+    /// <summary>
+    /// Verifies that a plain C# class payload goes through Akka's Newtonsoft.Json
+    /// serializer for the inner message. This is the realistic case — user-defined
+    /// message types don't have custom serializers, so they fall through to JSON.
+    /// </summary>
+    [Fact]
+    public void ReminderEnvelope_ShouldRoundTrip_WithJsonSerializedPayload()
+    {
+        var payload = new InvoiceReminder
+        {
+            InvoiceId = "INV-2026-0042",
+            AmountDue = 1299.99m,
+            Currency = "USD",
+            CustomerEmail = "billing@example.com"
+        };
+
+        var original = new ReminderEnvelope<InvoiceReminder>(
+            new ReminderEntity("invoices", "customer-7"),
+            new ReminderKey("payment-due"),
+            new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
+            new ReminderDeadline(new DateTimeOffset(2026, 4, 8, 0, 0, 0, TimeSpan.Zero)),
+            payload);
+
+        // Verify the inner payload actually uses the JSON serializer, not a built-in one.
+        var innerSerializer = _serialization.FindSerializerFor(payload);
+        Assert.Contains("Json", innerSerializer.GetType().Name);
+
+        var deserialized = (ReminderEnvelope<InvoiceReminder>)RoundTrip<ReminderEnvelope>(original);
+
+        Assert.Equal(payload.InvoiceId, deserialized.Message.InvoiceId);
+        Assert.Equal(payload.AmountDue, deserialized.Message.AmountDue);
+        Assert.Equal(payload.Currency, deserialized.Message.Currency);
+        Assert.Equal(payload.CustomerEmail, deserialized.Message.CustomerEmail);
+        Assert.Equal(original.Entity, deserialized.Entity);
+        Assert.Equal(original.Key, deserialized.Key);
+    }
+
+    /// <summary>
+    /// Same test but with a C# record type — records are common for domain messages
+    /// and their equality semantics make assertions cleaner.
+    /// </summary>
+    [Fact]
+    public void ReminderEnvelope_ShouldRoundTrip_WithJsonSerializedRecord()
+    {
+        var payload = new ShipmentNotification("SHIP-99", DateTimeOffset.UtcNow, ["item-a", "item-b"]);
+
+        var original = new ReminderEnvelope<ShipmentNotification>(
+            new ReminderEntity("shipments", "warehouse-3"),
+            new ReminderKey("notify-shipped"),
+            DateTimeOffset.UtcNow,
+            ReminderDeadline.Infinite,
+            payload);
+
+        var deserialized = (ReminderEnvelope<ShipmentNotification>)RoundTrip<ReminderEnvelope>(original);
+
+        Assert.Equal(payload.ShipmentId, deserialized.Message.ShipmentId);
+        Assert.Equal(payload.Items, deserialized.Message.Items);
+    }
+
     #endregion
 
     /// <summary>
@@ -250,3 +309,20 @@ public class ReminderSerializerSpecs : IDisposable
         return (T)_serialization.Deserialize(bytes, serializer.Identifier, manifest);
     }
 }
+
+/// <summary>
+/// Plain class payload — will be serialized by Akka's Newtonsoft.Json serializer.
+/// </summary>
+public class InvoiceReminder
+{
+    public string InvoiceId { get; set; } = "";
+    public decimal AmountDue { get; set; }
+    public string Currency { get; set; } = "";
+    public string CustomerEmail { get; set; } = "";
+}
+
+/// <summary>
+/// Record payload — also serialized via JSON. Tests that records with
+/// collection properties survive the round-trip.
+/// </summary>
+public record ShipmentNotification(string ShipmentId, DateTimeOffset ShippedAt, List<string> Items);

--- a/src/Akka.Reminders.Tests/Serialization/ReminderSerializerSpecs.cs
+++ b/src/Akka.Reminders.Tests/Serialization/ReminderSerializerSpecs.cs
@@ -1,0 +1,252 @@
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Reminders.Serialization;
+using Akka.Serialization;
+
+namespace Akka.Reminders.Tests.Serialization;
+
+/// <summary>
+/// Round-trip serialization tests for <see cref="ReminderSerializer"/>.
+///
+/// These tests verify that every message type handled by the serializer survives
+/// a ToBinary → FromBinary cycle with all fields intact. This is critical for
+/// cluster deployments where these messages cross node boundaries via Akka.Remote.
+///
+/// The serializer is registered via HOCON (see <see cref="AkkaHostingExtensions.SerializerHocon"/>)
+/// and bound to <see cref="ReminderEnvelope"/>, <see cref="ReminderProtocol.ReminderAck"/>,
+/// and <see cref="ReminderProtocol.ReminderAckResponse"/>.
+/// </summary>
+public class ReminderSerializerSpecs : IDisposable
+{
+    private readonly ActorSystem _system;
+    private readonly Akka.Serialization.Serialization _serialization;
+
+    public ReminderSerializerSpecs()
+    {
+        // Register the reminder serializer via the same HOCON used in production.
+        var config = ConfigurationFactory.ParseString(AkkaHostingExtensions.SerializerHocon);
+        _system = ActorSystem.Create("serializer-test", config);
+        _serialization = _system.Serialization;
+    }
+
+    public void Dispose()
+    {
+        _system.Terminate().Wait(TimeSpan.FromSeconds(5));
+    }
+
+    /// <summary>
+    /// Verifies that the serialization system resolves <see cref="ReminderSerializer"/>
+    /// for all three bound types — not the default Newtonsoft.Json serializer.
+    /// </summary>
+    [Fact]
+    public void Serializer_ShouldBeResolved_ForAllBoundTypes()
+    {
+        var envelope = new ReminderEnvelope<string>(
+            new ReminderEntity("r", "e"), new ReminderKey("k"),
+            DateTimeOffset.UtcNow, ReminderDeadline.Infinite, "msg");
+
+        var ack = new ReminderProtocol.ReminderAck(
+            new ReminderEntity("r", "e"), new ReminderKey("k"),
+            DateTimeOffset.UtcNow);
+
+        var ackResponse = new ReminderProtocol.ReminderAckResponse(
+            new ReminderEntity("r", "e"), new ReminderKey("k"),
+            DateTimeOffset.UtcNow, ReminderAckResponseCode.Success);
+
+        Assert.IsType<ReminderSerializer>(_serialization.FindSerializerFor(envelope));
+        Assert.IsType<ReminderSerializer>(_serialization.FindSerializerFor(ack));
+        Assert.IsType<ReminderSerializer>(_serialization.FindSerializerFor(ackResponse));
+    }
+
+    #region ReminderEnvelope round-trip tests
+
+    /// <summary>
+    /// Basic round-trip: a ReminderEnvelope with a string payload should survive
+    /// serialization with all fields intact — entity, key, due time, deadline, and message.
+    /// </summary>
+    [Fact]
+    public void ReminderEnvelope_ShouldRoundTrip_WithStringPayload()
+    {
+        var entity = new ReminderEntity("my-region", "entity-42");
+        var key = new ReminderKey("daily-report");
+        var dueTime = new DateTimeOffset(2026, 3, 20, 12, 0, 0, TimeSpan.Zero);
+        var deadline = new ReminderDeadline(dueTime.AddMinutes(5));
+
+        var original = new ReminderEnvelope<string>(entity, key, dueTime, deadline, "generate report");
+
+        var bytes = _serialization.Serialize(original);
+        var deserialized = (ReminderEnvelope<string>)_serialization.Deserialize(bytes,
+            _serialization.FindSerializerFor(original).Identifier,
+            Akka.Serialization.Serialization.ManifestFor(_serialization.FindSerializerFor(original), original));
+
+        Assert.Equal(original.Entity, deserialized.Entity);
+        Assert.Equal(original.Key, deserialized.Key);
+        Assert.Equal(original.DueTimeUtc, deserialized.DueTimeUtc);
+        Assert.Equal(original.Deadline.UtcDateTime, deserialized.Deadline.UtcDateTime);
+        Assert.Equal(original.Message, deserialized.Message);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ReminderDeadline.Infinite"/> (DateTimeOffset.MaxValue)
+    /// survives the round-trip. This is the default for reminders without a MaxDeliveryWindow.
+    /// </summary>
+    [Fact]
+    public void ReminderEnvelope_ShouldRoundTrip_WithInfiniteDeadline()
+    {
+        var original = new ReminderEnvelope<string>(
+            new ReminderEntity("region", "entity"),
+            new ReminderKey("key"),
+            DateTimeOffset.UtcNow,
+            ReminderDeadline.Infinite,
+            "unbounded reminder");
+
+        var deserialized = RoundTrip<ReminderEnvelope>(original);
+
+        Assert.True(deserialized.Deadline.IsInfinite);
+        Assert.Equal("unbounded reminder", ((ReminderEnvelope<string>)deserialized).Message);
+    }
+
+    /// <summary>
+    /// Verifies that entity/key fields with special characters (spaces, unicode,
+    /// punctuation) survive the length-prefixed UTF-8 encoding.
+    /// </summary>
+    [Fact]
+    public void ReminderEnvelope_ShouldRoundTrip_WithSpecialCharacters()
+    {
+        var entity = new ReminderEntity("región-España", "entité-日本語");
+        var key = new ReminderKey("clé/with spaces & symbols!");
+
+        var original = new ReminderEnvelope<string>(
+            entity, key,
+            DateTimeOffset.UtcNow,
+            ReminderDeadline.Infinite,
+            "message with émojis 🎉");
+
+        var deserialized = (ReminderEnvelope<string>)RoundTrip<ReminderEnvelope>(original);
+
+        Assert.Equal(entity, deserialized.Entity);
+        Assert.Equal(key, deserialized.Key);
+        Assert.Equal("message with émojis 🎉", deserialized.Message);
+    }
+
+    /// <summary>
+    /// The inner message type determines the generic type parameter of the deserialized
+    /// envelope. This test verifies that a non-string payload (int) produces a
+    /// ReminderEnvelope&lt;int&gt; via the MakeGenericType reflection path.
+    /// </summary>
+    [Fact]
+    public void ReminderEnvelope_ShouldRoundTrip_WithNonStringPayload()
+    {
+        var original = new ReminderEnvelope<int>(
+            new ReminderEntity("region", "entity"),
+            new ReminderKey("counter"),
+            DateTimeOffset.UtcNow,
+            ReminderDeadline.Infinite,
+            42);
+
+        var deserialized = RoundTrip<ReminderEnvelope>(original);
+
+        Assert.IsType<ReminderEnvelope<int>>(deserialized);
+        Assert.Equal(42, ((ReminderEnvelope<int>)deserialized).Message);
+    }
+
+    #endregion
+
+    #region ReminderAck round-trip tests
+
+    /// <summary>
+    /// ReminderAck is the message entities send back to the scheduler to confirm
+    /// delivery. It carries the occurrence key (Entity, Key, DueTimeUtc) so the
+    /// scheduler can match it to the correct AwaitingAck row.
+    /// </summary>
+    [Fact]
+    public void ReminderAck_ShouldRoundTrip()
+    {
+        var entity = new ReminderEntity("orders", "order-123");
+        var key = new ReminderKey("payment-reminder");
+        var dueTime = new DateTimeOffset(2026, 6, 15, 9, 30, 0, TimeSpan.Zero);
+
+        var original = new ReminderProtocol.ReminderAck(entity, key, dueTime);
+
+        var deserialized = RoundTrip<ReminderProtocol.ReminderAck>(original);
+
+        Assert.Equal(original.Entity, deserialized.Entity);
+        Assert.Equal(original.Key, deserialized.Key);
+        Assert.Equal(original.DueTimeUtc, deserialized.DueTimeUtc);
+    }
+
+    #endregion
+
+    #region ReminderAckResponse round-trip tests
+
+    /// <summary>
+    /// Successful ack response — the scheduler confirmed the occurrence was
+    /// marked as delivered. No error message.
+    /// </summary>
+    [Fact]
+    public void ReminderAckResponse_ShouldRoundTrip_WithSuccess()
+    {
+        var original = new ReminderProtocol.ReminderAckResponse(
+            new ReminderEntity("region", "entity"),
+            new ReminderKey("key"),
+            DateTimeOffset.UtcNow,
+            ReminderAckResponseCode.Success);
+
+        var deserialized = RoundTrip<ReminderProtocol.ReminderAckResponse>(original);
+
+        Assert.Equal(ReminderAckResponseCode.Success, deserialized.ResponseCode);
+        Assert.Null(deserialized.Message);
+    }
+
+    /// <summary>
+    /// NotFound response — the occurrence was already completed, expired, or
+    /// superseded. This is the "harmless late ack" case.
+    /// </summary>
+    [Fact]
+    public void ReminderAckResponse_ShouldRoundTrip_WithNotFound()
+    {
+        var original = new ReminderProtocol.ReminderAckResponse(
+            new ReminderEntity("region", "entity"),
+            new ReminderKey("key"),
+            DateTimeOffset.UtcNow,
+            ReminderAckResponseCode.NotFound,
+            "Reminder occurrence was not awaiting acknowledgement or was already stale.");
+
+        var deserialized = RoundTrip<ReminderProtocol.ReminderAckResponse>(original);
+
+        Assert.Equal(ReminderAckResponseCode.NotFound, deserialized.ResponseCode);
+        Assert.Equal(original.Message, deserialized.Message);
+    }
+
+    /// <summary>
+    /// Error response with a message — verifies the error string survives the round-trip.
+    /// </summary>
+    [Fact]
+    public void ReminderAckResponse_ShouldRoundTrip_WithError()
+    {
+        var original = new ReminderProtocol.ReminderAckResponse(
+            new ReminderEntity("region", "entity"),
+            new ReminderKey("key"),
+            DateTimeOffset.UtcNow,
+            ReminderAckResponseCode.Error,
+            "Storage write failed: connection timeout");
+
+        var deserialized = RoundTrip<ReminderProtocol.ReminderAckResponse>(original);
+
+        Assert.Equal(ReminderAckResponseCode.Error, deserialized.ResponseCode);
+        Assert.Equal("Storage write failed: connection timeout", deserialized.Message);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Helper: serialize then deserialize an object through the Akka serialization system.
+    /// </summary>
+    private T RoundTrip<T>(object original)
+    {
+        var serializer = _serialization.FindSerializerFor(original);
+        var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, original);
+        var bytes = serializer.ToBinary(original);
+        return (T)_serialization.Deserialize(bytes, serializer.Identifier, manifest);
+    }
+}

--- a/src/Akka.Reminders.Tests/Serialization/ReminderSerializerSpecs.cs
+++ b/src/Akka.Reminders.Tests/Serialization/ReminderSerializerSpecs.cs
@@ -10,9 +10,9 @@ namespace Akka.Reminders.Tests.Serialization;
 /// Round-trip serialization tests for <see cref="ReminderSerializer"/>.
 ///
 /// Follows the core Akka.NET pattern (see ClusterMessageSerializerSpec):
-/// wire the serializer via HOCON, use a small <see cref="AssertAndReturn{T}"/>
-/// helper that verifies the correct serializer is resolved and the message
-/// survives a ToBinary → FromBinary cycle.
+/// register the serializer via <see cref="AkkaConfigurationBuilder.WithCustomSerializer"/>,
+/// use a small <see cref="AssertAndReturn{T}"/> helper that verifies the correct serializer
+/// is resolved and the message survives a ToBinary → FromBinary cycle.
 /// </summary>
 public class ReminderSerializerSpecs : Akka.Hosting.TestKit.TestKit
 {
@@ -23,7 +23,10 @@ public class ReminderSerializerSpecs : Akka.Hosting.TestKit.TestKit
 
     protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
-        builder.AddHocon(AkkaHostingExtensions.SerializerHocon, HoconAddMode.Prepend);
+        builder.WithCustomSerializer(
+            "reminder-serializer",
+            [typeof(IReminderWireMessage)],
+            system => new ReminderSerializer(system));
     }
 
     /// <summary>

--- a/src/Akka.Reminders.Tests/Serialization/ReminderSerializerSpecs.cs
+++ b/src/Akka.Reminders.Tests/Serialization/ReminderSerializerSpecs.cs
@@ -1,249 +1,131 @@
-using Akka.Actor;
-using Akka.Configuration;
+using Akka.Hosting;
+using Akka.Hosting.TestKit;
 using Akka.Reminders.Serialization;
 using Akka.Serialization;
+using Xunit.Abstractions;
 
 namespace Akka.Reminders.Tests.Serialization;
 
 /// <summary>
 /// Round-trip serialization tests for <see cref="ReminderSerializer"/>.
 ///
-/// These tests verify that every message type handled by the serializer survives
-/// a ToBinary → FromBinary cycle with all fields intact. This is critical for
-/// cluster deployments where these messages cross node boundaries via Akka.Remote.
-///
-/// The serializer is registered via HOCON (see <see cref="AkkaHostingExtensions.SerializerHocon"/>)
-/// and bound to <see cref="ReminderEnvelope"/>, <see cref="ReminderProtocol.ReminderAck"/>,
-/// and <see cref="ReminderProtocol.ReminderAckResponse"/>.
+/// Follows the core Akka.NET pattern (see ClusterMessageSerializerSpec):
+/// wire the serializer via HOCON, use a small <see cref="AssertAndReturn{T}"/>
+/// helper that verifies the correct serializer is resolved and the message
+/// survives a ToBinary → FromBinary cycle.
 /// </summary>
-public class ReminderSerializerSpecs : IDisposable
+public class ReminderSerializerSpecs : Akka.Hosting.TestKit.TestKit
 {
-    private readonly ActorSystem _system;
-    private readonly Akka.Serialization.Serialization _serialization;
-
-    public ReminderSerializerSpecs()
+    public ReminderSerializerSpecs(ITestOutputHelper output)
+        : base(output: output)
     {
-        // Register the reminder serializer via the same HOCON used in production.
-        var config = ConfigurationFactory.ParseString(AkkaHostingExtensions.SerializerHocon);
-        _system = ActorSystem.Create("serializer-test", config);
-        _serialization = _system.Serialization;
     }
 
-    public void Dispose()
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
-        _system.Terminate().Wait(TimeSpan.FromSeconds(5));
+        builder.AddHocon(AkkaHostingExtensions.SerializerHocon, HoconAddMode.Prepend);
     }
 
     /// <summary>
-    /// Verifies that the serialization system resolves <see cref="ReminderSerializer"/>
-    /// for all three bound types — not the default Newtonsoft.Json serializer.
+    /// Serializes and deserializes a message, asserting that <see cref="ReminderSerializer"/>
+    /// is the resolved serializer. Returns the deserialized instance for further assertions.
     /// </summary>
+    private T AssertAndReturn<T>(T message) where T : notnull
+    {
+        var serializer = (SerializerWithStringManifest)Sys.Serialization.FindSerializerFor(message);
+        Assert.IsType<ReminderSerializer>(serializer);
+
+        var bytes = serializer.ToBinary(message);
+        var manifest = serializer.Manifest(message);
+        return (T)serializer.FromBinary(bytes, manifest);
+    }
+
+    /// <summary>
+    /// Asserts that a message round-trips to an equal value.
+    /// </summary>
+    private void AssertEqual<T>(T message) where T : notnull
+    {
+        var deserialized = AssertAndReturn(message);
+        Assert.Equal(message, deserialized);
+    }
+
+    #region ReminderEnvelope
+
     [Fact]
-    public void Serializer_ShouldBeResolved_ForAllBoundTypes()
+    public void Can_serialize_ReminderEnvelope_with_string_payload()
     {
         var envelope = new ReminderEnvelope<string>(
-            new ReminderEntity("r", "e"), new ReminderKey("k"),
-            DateTimeOffset.UtcNow, ReminderDeadline.Infinite, "msg");
+            new ReminderEntity("my-region", "entity-42"),
+            new ReminderKey("daily-report"),
+            new DateTimeOffset(2026, 3, 20, 12, 0, 0, TimeSpan.Zero),
+            new ReminderDeadline(new DateTimeOffset(2026, 3, 20, 12, 5, 0, TimeSpan.Zero)),
+            "generate report");
 
-        var ack = new ReminderProtocol.ReminderAck(
-            new ReminderEntity("r", "e"), new ReminderKey("k"),
-            DateTimeOffset.UtcNow);
+        var result = AssertAndReturn<ReminderEnvelope>(envelope);
+        var typed = Assert.IsType<ReminderEnvelope<string>>(result);
 
-        var ackResponse = new ReminderProtocol.ReminderAckResponse(
-            new ReminderEntity("r", "e"), new ReminderKey("k"),
-            DateTimeOffset.UtcNow, ReminderAckResponseCode.Success);
-
-        Assert.IsType<ReminderSerializer>(_serialization.FindSerializerFor(envelope));
-        Assert.IsType<ReminderSerializer>(_serialization.FindSerializerFor(ack));
-        Assert.IsType<ReminderSerializer>(_serialization.FindSerializerFor(ackResponse));
+        Assert.Equal(envelope.Entity, typed.Entity);
+        Assert.Equal(envelope.Key, typed.Key);
+        Assert.Equal(envelope.DueTimeUtc, typed.DueTimeUtc);
+        Assert.Equal(envelope.Deadline.UtcDateTime, typed.Deadline.UtcDateTime);
+        Assert.Equal("generate report", typed.Message);
     }
 
-    #region ReminderEnvelope round-trip tests
-
-    /// <summary>
-    /// Basic round-trip: a ReminderEnvelope with a string payload should survive
-    /// serialization with all fields intact — entity, key, due time, deadline, and message.
-    /// </summary>
     [Fact]
-    public void ReminderEnvelope_ShouldRoundTrip_WithStringPayload()
+    public void Can_serialize_ReminderEnvelope_with_infinite_deadline()
     {
-        var entity = new ReminderEntity("my-region", "entity-42");
-        var key = new ReminderKey("daily-report");
-        var dueTime = new DateTimeOffset(2026, 3, 20, 12, 0, 0, TimeSpan.Zero);
-        var deadline = new ReminderDeadline(dueTime.AddMinutes(5));
-
-        var original = new ReminderEnvelope<string>(entity, key, dueTime, deadline, "generate report");
-
-        var bytes = _serialization.Serialize(original);
-        var deserialized = (ReminderEnvelope<string>)_serialization.Deserialize(bytes,
-            _serialization.FindSerializerFor(original).Identifier,
-            Akka.Serialization.Serialization.ManifestFor(_serialization.FindSerializerFor(original), original));
-
-        Assert.Equal(original.Entity, deserialized.Entity);
-        Assert.Equal(original.Key, deserialized.Key);
-        Assert.Equal(original.DueTimeUtc, deserialized.DueTimeUtc);
-        Assert.Equal(original.Deadline.UtcDateTime, deserialized.Deadline.UtcDateTime);
-        Assert.Equal(original.Message, deserialized.Message);
-    }
-
-    /// <summary>
-    /// Verifies that <see cref="ReminderDeadline.Infinite"/> (DateTimeOffset.MaxValue)
-    /// survives the round-trip. This is the default for reminders without a MaxDeliveryWindow.
-    /// </summary>
-    [Fact]
-    public void ReminderEnvelope_ShouldRoundTrip_WithInfiniteDeadline()
-    {
-        var original = new ReminderEnvelope<string>(
+        var envelope = new ReminderEnvelope<string>(
             new ReminderEntity("region", "entity"),
             new ReminderKey("key"),
             DateTimeOffset.UtcNow,
             ReminderDeadline.Infinite,
-            "unbounded reminder");
+            "unbounded");
 
-        var deserialized = RoundTrip<ReminderEnvelope>(original);
+        var result = AssertAndReturn<ReminderEnvelope>(envelope);
 
-        Assert.True(deserialized.Deadline.IsInfinite);
-        Assert.Equal("unbounded reminder", ((ReminderEnvelope<string>)deserialized).Message);
+        Assert.True(result.Deadline.IsInfinite);
     }
 
-    /// <summary>
-    /// Verifies that entity/key fields with special characters (spaces, unicode,
-    /// punctuation) survive the length-prefixed UTF-8 encoding.
-    /// </summary>
     [Fact]
-    public void ReminderEnvelope_ShouldRoundTrip_WithSpecialCharacters()
+    public void Can_serialize_ReminderEnvelope_with_unicode_fields()
     {
-        var entity = new ReminderEntity("región-España", "entité-日本語");
-        var key = new ReminderKey("clé/with spaces & symbols!");
-
-        var original = new ReminderEnvelope<string>(
-            entity, key,
+        var envelope = new ReminderEnvelope<string>(
+            new ReminderEntity("región-España", "entité-日本語"),
+            new ReminderKey("clé/with spaces & symbols!"),
             DateTimeOffset.UtcNow,
             ReminderDeadline.Infinite,
             "message with émojis 🎉");
 
-        var deserialized = (ReminderEnvelope<string>)RoundTrip<ReminderEnvelope>(original);
+        var result = (ReminderEnvelope<string>)AssertAndReturn<ReminderEnvelope>(envelope);
 
-        Assert.Equal(entity, deserialized.Entity);
-        Assert.Equal(key, deserialized.Key);
-        Assert.Equal("message with émojis 🎉", deserialized.Message);
+        Assert.Equal("región-España", result.Entity.ShardRegionName);
+        Assert.Equal("entité-日本語", result.Entity.EntityId);
+        Assert.Equal("clé/with spaces & symbols!", result.Key.Name);
+        Assert.Equal("message with émojis 🎉", result.Message);
     }
 
-    /// <summary>
-    /// The inner message type determines the generic type parameter of the deserialized
-    /// envelope. This test verifies that a non-string payload (int) produces a
-    /// ReminderEnvelope&lt;int&gt; via the MakeGenericType reflection path.
-    /// </summary>
     [Fact]
-    public void ReminderEnvelope_ShouldRoundTrip_WithNonStringPayload()
+    public void Can_serialize_ReminderEnvelope_with_int_payload()
     {
-        var original = new ReminderEnvelope<int>(
+        var envelope = new ReminderEnvelope<int>(
             new ReminderEntity("region", "entity"),
             new ReminderKey("counter"),
             DateTimeOffset.UtcNow,
             ReminderDeadline.Infinite,
             42);
 
-        var deserialized = RoundTrip<ReminderEnvelope>(original);
+        var result = AssertAndReturn<ReminderEnvelope>(envelope);
 
-        Assert.IsType<ReminderEnvelope<int>>(deserialized);
-        Assert.Equal(42, ((ReminderEnvelope<int>)deserialized).Message);
-    }
-
-    #endregion
-
-    #region ReminderAck round-trip tests
-
-    /// <summary>
-    /// ReminderAck is the message entities send back to the scheduler to confirm
-    /// delivery. It carries the occurrence key (Entity, Key, DueTimeUtc) so the
-    /// scheduler can match it to the correct AwaitingAck row.
-    /// </summary>
-    [Fact]
-    public void ReminderAck_ShouldRoundTrip()
-    {
-        var entity = new ReminderEntity("orders", "order-123");
-        var key = new ReminderKey("payment-reminder");
-        var dueTime = new DateTimeOffset(2026, 6, 15, 9, 30, 0, TimeSpan.Zero);
-
-        var original = new ReminderProtocol.ReminderAck(entity, key, dueTime);
-
-        var deserialized = RoundTrip<ReminderProtocol.ReminderAck>(original);
-
-        Assert.Equal(original.Entity, deserialized.Entity);
-        Assert.Equal(original.Key, deserialized.Key);
-        Assert.Equal(original.DueTimeUtc, deserialized.DueTimeUtc);
-    }
-
-    #endregion
-
-    #region ReminderAckResponse round-trip tests
-
-    /// <summary>
-    /// Successful ack response — the scheduler confirmed the occurrence was
-    /// marked as delivered. No error message.
-    /// </summary>
-    [Fact]
-    public void ReminderAckResponse_ShouldRoundTrip_WithSuccess()
-    {
-        var original = new ReminderProtocol.ReminderAckResponse(
-            new ReminderEntity("region", "entity"),
-            new ReminderKey("key"),
-            DateTimeOffset.UtcNow,
-            ReminderAckResponseCode.Success);
-
-        var deserialized = RoundTrip<ReminderProtocol.ReminderAckResponse>(original);
-
-        Assert.Equal(ReminderAckResponseCode.Success, deserialized.ResponseCode);
-        Assert.Null(deserialized.Message);
+        var typed = Assert.IsType<ReminderEnvelope<int>>(result);
+        Assert.Equal(42, typed.Message);
     }
 
     /// <summary>
-    /// NotFound response — the occurrence was already completed, expired, or
-    /// superseded. This is the "harmless late ack" case.
+    /// User-defined class payloads go through Akka's Newtonsoft.Json serializer.
+    /// This verifies the inner-serializer delegation works for JSON-serialized types.
     /// </summary>
     [Fact]
-    public void ReminderAckResponse_ShouldRoundTrip_WithNotFound()
-    {
-        var original = new ReminderProtocol.ReminderAckResponse(
-            new ReminderEntity("region", "entity"),
-            new ReminderKey("key"),
-            DateTimeOffset.UtcNow,
-            ReminderAckResponseCode.NotFound,
-            "Reminder occurrence was not awaiting acknowledgement or was already stale.");
-
-        var deserialized = RoundTrip<ReminderProtocol.ReminderAckResponse>(original);
-
-        Assert.Equal(ReminderAckResponseCode.NotFound, deserialized.ResponseCode);
-        Assert.Equal(original.Message, deserialized.Message);
-    }
-
-    /// <summary>
-    /// Error response with a message — verifies the error string survives the round-trip.
-    /// </summary>
-    [Fact]
-    public void ReminderAckResponse_ShouldRoundTrip_WithError()
-    {
-        var original = new ReminderProtocol.ReminderAckResponse(
-            new ReminderEntity("region", "entity"),
-            new ReminderKey("key"),
-            DateTimeOffset.UtcNow,
-            ReminderAckResponseCode.Error,
-            "Storage write failed: connection timeout");
-
-        var deserialized = RoundTrip<ReminderProtocol.ReminderAckResponse>(original);
-
-        Assert.Equal(ReminderAckResponseCode.Error, deserialized.ResponseCode);
-        Assert.Equal("Storage write failed: connection timeout", deserialized.Message);
-    }
-
-    /// <summary>
-    /// Verifies that a plain C# class payload goes through Akka's Newtonsoft.Json
-    /// serializer for the inner message. This is the realistic case — user-defined
-    /// message types don't have custom serializers, so they fall through to JSON.
-    /// </summary>
-    [Fact]
-    public void ReminderEnvelope_ShouldRoundTrip_WithJsonSerializedPayload()
+    public void Can_serialize_ReminderEnvelope_with_json_class_payload()
     {
         var payload = new InvoiceReminder
         {
@@ -253,65 +135,113 @@ public class ReminderSerializerSpecs : IDisposable
             CustomerEmail = "billing@example.com"
         };
 
-        var original = new ReminderEnvelope<InvoiceReminder>(
+        var envelope = new ReminderEnvelope<InvoiceReminder>(
             new ReminderEntity("invoices", "customer-7"),
             new ReminderKey("payment-due"),
             new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
             new ReminderDeadline(new DateTimeOffset(2026, 4, 8, 0, 0, 0, TimeSpan.Zero)),
             payload);
 
-        // Verify the inner payload actually uses the JSON serializer, not a built-in one.
-        var innerSerializer = _serialization.FindSerializerFor(payload);
-        Assert.Contains("Json", innerSerializer.GetType().Name);
+        var result = (ReminderEnvelope<InvoiceReminder>)AssertAndReturn<ReminderEnvelope>(envelope);
 
-        var deserialized = (ReminderEnvelope<InvoiceReminder>)RoundTrip<ReminderEnvelope>(original);
-
-        Assert.Equal(payload.InvoiceId, deserialized.Message.InvoiceId);
-        Assert.Equal(payload.AmountDue, deserialized.Message.AmountDue);
-        Assert.Equal(payload.Currency, deserialized.Message.Currency);
-        Assert.Equal(payload.CustomerEmail, deserialized.Message.CustomerEmail);
-        Assert.Equal(original.Entity, deserialized.Entity);
-        Assert.Equal(original.Key, deserialized.Key);
+        Assert.Equal(payload.InvoiceId, result.Message.InvoiceId);
+        Assert.Equal(payload.AmountDue, result.Message.AmountDue);
+        Assert.Equal(payload.Currency, result.Message.Currency);
+        Assert.Equal(payload.CustomerEmail, result.Message.CustomerEmail);
     }
 
     /// <summary>
-    /// Same test but with a C# record type — records are common for domain messages
-    /// and their equality semantics make assertions cleaner.
+    /// Record types with collection properties — also JSON-serialized.
     /// </summary>
     [Fact]
-    public void ReminderEnvelope_ShouldRoundTrip_WithJsonSerializedRecord()
+    public void Can_serialize_ReminderEnvelope_with_json_record_payload()
     {
         var payload = new ShipmentNotification("SHIP-99", DateTimeOffset.UtcNow, ["item-a", "item-b"]);
 
-        var original = new ReminderEnvelope<ShipmentNotification>(
+        var envelope = new ReminderEnvelope<ShipmentNotification>(
             new ReminderEntity("shipments", "warehouse-3"),
             new ReminderKey("notify-shipped"),
             DateTimeOffset.UtcNow,
             ReminderDeadline.Infinite,
             payload);
 
-        var deserialized = (ReminderEnvelope<ShipmentNotification>)RoundTrip<ReminderEnvelope>(original);
+        var result = (ReminderEnvelope<ShipmentNotification>)AssertAndReturn<ReminderEnvelope>(envelope);
 
-        Assert.Equal(payload.ShipmentId, deserialized.Message.ShipmentId);
-        Assert.Equal(payload.Items, deserialized.Message.Items);
+        Assert.Equal(payload.ShipmentId, result.Message.ShipmentId);
+        Assert.Equal(payload.Items, result.Message.Items);
     }
 
     #endregion
 
-    /// <summary>
-    /// Helper: serialize then deserialize an object through the Akka serialization system.
-    /// </summary>
-    private T RoundTrip<T>(object original)
+    #region ReminderAck
+
+    [Fact]
+    public void Can_serialize_ReminderAck()
     {
-        var serializer = _serialization.FindSerializerFor(original);
-        var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, original);
-        var bytes = serializer.ToBinary(original);
-        return (T)_serialization.Deserialize(bytes, serializer.Identifier, manifest);
+        var message = new ReminderProtocol.ReminderAck(
+            new ReminderEntity("orders", "order-123"),
+            new ReminderKey("payment-reminder"),
+            new DateTimeOffset(2026, 6, 15, 9, 30, 0, TimeSpan.Zero));
+
+        AssertEqual(message);
     }
+
+    #endregion
+
+    #region ReminderAckResponse
+
+    [Fact]
+    public void Can_serialize_ReminderAckResponse_Success()
+    {
+        var message = new ReminderProtocol.ReminderAckResponse(
+            new ReminderEntity("region", "entity"),
+            new ReminderKey("key"),
+            DateTimeOffset.UtcNow,
+            ReminderAckResponseCode.Success);
+
+        var result = AssertAndReturn(message);
+
+        Assert.Equal(ReminderAckResponseCode.Success, result.ResponseCode);
+        Assert.Null(result.Message);
+    }
+
+    [Fact]
+    public void Can_serialize_ReminderAckResponse_NotFound()
+    {
+        var message = new ReminderProtocol.ReminderAckResponse(
+            new ReminderEntity("region", "entity"),
+            new ReminderKey("key"),
+            DateTimeOffset.UtcNow,
+            ReminderAckResponseCode.NotFound,
+            "Reminder occurrence was not awaiting acknowledgement.");
+
+        var result = AssertAndReturn(message);
+
+        Assert.Equal(ReminderAckResponseCode.NotFound, result.ResponseCode);
+        Assert.Equal(message.Message, result.Message);
+    }
+
+    [Fact]
+    public void Can_serialize_ReminderAckResponse_Error()
+    {
+        var message = new ReminderProtocol.ReminderAckResponse(
+            new ReminderEntity("region", "entity"),
+            new ReminderKey("key"),
+            DateTimeOffset.UtcNow,
+            ReminderAckResponseCode.Error,
+            "Storage write failed: connection timeout");
+
+        var result = AssertAndReturn(message);
+
+        Assert.Equal(ReminderAckResponseCode.Error, result.ResponseCode);
+        Assert.Equal("Storage write failed: connection timeout", result.Message);
+    }
+
+    #endregion
 }
 
 /// <summary>
-/// Plain class payload — will be serialized by Akka's Newtonsoft.Json serializer.
+/// Plain class payload — serialized by Akka's Newtonsoft.Json serializer.
 /// </summary>
 public class InvoiceReminder
 {
@@ -322,7 +252,6 @@ public class InvoiceReminder
 }
 
 /// <summary>
-/// Record payload — also serialized via JSON. Tests that records with
-/// collection properties survive the round-trip.
+/// Record payload with a collection property — also JSON-serialized.
 /// </summary>
 public record ShipmentNotification(string ShipmentId, DateTimeOffset ShippedAt, List<string> Items);

--- a/src/Akka.Reminders.Tests/Storage/ReminderStorageSpecBase.cs
+++ b/src/Akka.Reminders.Tests/Storage/ReminderStorageSpecBase.cs
@@ -532,6 +532,11 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
 
     #region Awaiting Ack / Deadline Tests
 
+    /// <summary>
+    /// When a reminder is delivered, the scheduler moves it from Pending to AwaitingAck.
+    /// AwaitingAck reminders must NOT appear in the pending overview — otherwise the
+    /// scheduler would re-fetch and re-deliver them on the next tick, causing duplicates.
+    /// </summary>
     [Fact]
     public async Task MarkRemindersAsAwaitingAck_ShouldRemoveReminderFromPendingOverview()
     {
@@ -539,20 +544,31 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var reminder = CreateTestReminder(when: now.AddMinutes(5));
         await Storage!.ScheduleReminderAsync(reminder);
 
+        // Transition to AwaitingAck — simulates what the scheduler does after delivering
+        // the reminder via Tell. The ackDeadline is when the scheduler will retry if no
+        // ack arrives (now + AckTimeout).
         var awaitingAck = new AwaitingAckReminder(
             reminder.Entity,
             reminder.Key,
             reminder.DueTimeUtc,
-            now,
-            now.AddMinutes(1));
+            now,           // deliveredAt
+            now.AddMinutes(1)); // ackDeadline
 
         var result = await Storage.MarkRemindersAsAwaitingAckAsync([awaitingAck]);
         Assert.True(result);
 
+        // The overview only counts Pending rows. AwaitingAck rows are invisible to the
+        // fetch loop — they're tracked by the ack-timeout checker instead.
         var overview = await Storage.GetRemindersOverviewAsync(now);
         Assert.Equal(0, overview.TotalPendingReminders);
     }
 
+    /// <summary>
+    /// Acks are matched by the full occurrence key: (Entity, Key, DueTimeUtc).
+    /// A DueTimeUtc mismatch — even by one second — must return NotFound.
+    /// This is critical for recurring reminders: a late ack for an old occurrence
+    /// (different DueTimeUtc) must not accidentally complete the current one.
+    /// </summary>
     [Fact]
     public async Task AcknowledgeReminderAsync_ShouldRequireMatchingDueTime()
     {
@@ -568,15 +584,18 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             now.AddMinutes(1));
         await Storage.MarkRemindersAsAwaitingAckAsync([awaitingAck]);
 
+        // Ack with wrong DueTimeUtc — off by 1 second. This simulates a late ack
+        // arriving for a superseded occurrence of a recurring reminder.
         var wrongAck = await Storage.AcknowledgeReminderAsync(
             reminder.Entity,
             reminder.Key,
-            reminder.DueTimeUtc.AddSeconds(1),
+            reminder.DueTimeUtc.AddSeconds(1), // wrong occurrence
             now.AddSeconds(10));
 
         Assert.False(wrongAck.Success);
         Assert.Equal(ReminderAckStorageStatus.NotFound, wrongAck.Status);
 
+        // Ack with correct DueTimeUtc — matches the occurrence identity exactly.
         var correctAck = await Storage.AcknowledgeReminderAsync(
             reminder.Entity,
             reminder.Key,
@@ -587,6 +606,18 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         Assert.Equal(ReminderAckStorageStatus.Success, correctAck.Status);
     }
 
+    /// <summary>
+    /// This test exercises the core delivery-commit pattern: in a single atomic batch,
+    /// the scheduler must (1) insert the next recurring occurrence as Pending and
+    /// (2) move the current occurrence to AwaitingAck. Both must succeed or neither.
+    ///
+    /// After the commit:
+    /// - The overview should show exactly 1 pending reminder (the next occurrence).
+    ///   The current occurrence is AwaitingAck and invisible to the fetch loop.
+    /// - Both occurrences should be visible via GetRemindersForEntityAsync (which
+    ///   returns both Pending and AwaitingAck rows for the entity).
+    /// - The current (AwaitingAck) occurrence should be ackable.
+    /// </summary>
     [Fact]
     public async Task CommitReminderMutationsAsync_ShouldAtomicallyMovePendingToAwaitingAckAndUpsertNextOccurrence()
     {
@@ -601,6 +632,8 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
 
         await Storage!.ScheduleReminderAsync(reminder);
 
+        // Create the next recurring occurrence — due 1 interval later.
+        // In production, CreateNextRecurringOccurrence does this.
         var nextOccurrence = reminder with
         {
             When = reminder.DueTimeUtc.AddMinutes(1),
@@ -614,25 +647,39 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             now,
             now.AddMinutes(1));
 
+        // Commit both the next occurrence upsert and the AwaitingAck transition
+        // in a single batch — this is the atomicity boundary that prevents
+        // partial state during failures.
         var result = await Storage.CommitReminderMutationsAsync(new ReminderMutationBatch(
-            [nextOccurrence],
-            [],
-            [awaiting]));
+            [nextOccurrence],  // PendingUpserts: next recurring occurrence
+            [],                // CompletedReminders: none
+            [awaiting]));      // AwaitingAckReminders: current occurrence
 
         Assert.True(result);
 
+        // Only the next occurrence is Pending — the current one is AwaitingAck
+        // and excluded from the overview.
         var overview = await Storage.GetRemindersOverviewAsync(now);
         Assert.Equal(1, overview.TotalPendingReminders);
 
+        // GetRemindersForEntityAsync returns both Pending and AwaitingAck rows,
+        // so both occurrences should be visible (two different DueTimeUtc values).
         var reminders = await Storage.GetRemindersForEntityAsync(reminder.Entity);
         Assert.Equal(2, reminders.Count);
         Assert.Contains(reminders, r => Math.Abs((r.DueTimeUtc - reminder.DueTimeUtc).TotalMilliseconds) < 0.001);
         Assert.Contains(reminders, r => Math.Abs((r.DueTimeUtc - nextOccurrence.DueTimeUtc).TotalMilliseconds) < 0.001);
 
+        // The AwaitingAck occurrence should be ackable by its original DueTimeUtc.
         var ack = await Storage.AcknowledgeReminderAsync(reminder.Entity, reminder.Key, reminder.DueTimeUtc, now.AddSeconds(5));
         Assert.True(ack.Success);
     }
 
+    /// <summary>
+    /// When acks are flushed in a batch, the storage must return per-occurrence results.
+    /// A batch might contain both valid acks (matching an AwaitingAck row) and stale acks
+    /// (no matching row — the occurrence was already completed, expired, or superseded).
+    /// Each result must independently report Success or NotFound.
+    /// </summary>
     [Fact]
     public async Task AcknowledgeRemindersAsync_ShouldReturnPerOccurrenceResults()
     {
@@ -640,22 +687,32 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var reminder = CreateTestReminder(when: now.AddMinutes(5));
         await Storage!.ScheduleReminderAsync(reminder);
 
+        // Move to AwaitingAck so there's something to acknowledge.
         await Storage.CommitReminderMutationsAsync(new ReminderMutationBatch(
             [],
             [],
             [new AwaitingAckReminder(reminder.Entity, reminder.Key, reminder.DueTimeUtc, now, now.AddMinutes(1))]));
 
+        // Ack two occurrences in a single batch: one that exists (correct DueTimeUtc)
+        // and one that doesn't (DueTimeUtc + 1 minute — no such occurrence).
         var missingDueTime = reminder.DueTimeUtc.AddMinutes(1);
         var results = await Storage.AcknowledgeRemindersAsync([
             new ReminderAcknowledgement(reminder.Entity, reminder.Key, reminder.DueTimeUtc, now.AddSeconds(5)),
             new ReminderAcknowledgement(reminder.Entity, reminder.Key, missingDueTime, now.AddSeconds(5))
         ]);
 
+        // Results are positional — one per ack in the input batch.
         Assert.Equal(2, results.Count);
-        Assert.Equal(ReminderAckStorageStatus.Success, results[0].Status);
-        Assert.Equal(ReminderAckStorageStatus.NotFound, results[1].Status);
+        Assert.Equal(ReminderAckStorageStatus.Success, results[0].Status);  // valid ack
+        Assert.Equal(ReminderAckStorageStatus.NotFound, results[1].Status); // stale/missing ack
     }
 
+    /// <summary>
+    /// The scheduler uses event-driven ack-timeout checking. After delivering reminders,
+    /// it queries storage for the earliest ack deadline to schedule a one-shot timer.
+    /// This test verifies that GetNextAwaitingAckDeadlineAsync returns the minimum
+    /// ack deadline across all AwaitingAck rows, regardless of insertion order.
+    /// </summary>
     [Fact]
     public async Task GetNextAwaitingAckDeadlineAsync_ShouldReturnEarliestAwaitingDeadline()
     {
@@ -666,6 +723,9 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         await Storage!.ScheduleReminderAsync(first);
         await Storage.ScheduleReminderAsync(second);
 
+        // Move both to AwaitingAck with different deadlines.
+        // "first" has a later deadline (20s), "second" has an earlier one (10s).
+        // The query must return the earlier deadline regardless of insertion order.
         await Storage.CommitReminderMutationsAsync(new ReminderMutationBatch(
             [],
             [],
@@ -676,32 +736,46 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
 
         var deadline = await Storage.GetNextAwaitingAckDeadlineAsync();
 
+        // Should be the earlier deadline (now + 10s), not the first-inserted one (now + 20s).
         Assert.NotNull(deadline);
         Assert.True(Math.Abs((deadline!.Value - now.AddSeconds(10)).TotalMilliseconds) < 0.001);
     }
 
+    /// <summary>
+    /// Reminders with a MaxDeliveryWindow have a computed DeliveryDeadlineUtc.
+    /// When the current time passes that deadline, ExpireRemindersAsync should
+    /// mark the reminder as completed with status Expired and remove it from
+    /// the pending set. This prevents stale reminders from being delivered
+    /// long after they're relevant.
+    ///
+    /// In this test, the reminder was due 2 minutes ago with a 1-minute delivery
+    /// window, so its deadline was 1 minute ago — it should be expired.
+    /// </summary>
     [Fact]
     public async Task ExpireRemindersAsync_ShouldCompleteExpiredPendingReminder()
     {
         var now = DateTimeOffset.UtcNow;
-        var dueTime = now.AddMinutes(-2);
+        var dueTime = now.AddMinutes(-2); // due 2 minutes ago
         var reminder = new ScheduledReminder(
             CreateTestEntity(),
             CreateTestKey("expiring-reminder"),
             dueTime,
             "stale",
-            MaxDeliveryWindow: TimeSpan.FromMinutes(1),
-            DeliveryDeadlineUtc: dueTime.AddMinutes(1),
+            MaxDeliveryWindow: TimeSpan.FromMinutes(1),           // 1-minute window
+            DeliveryDeadlineUtc: dueTime.AddMinutes(1),           // deadline was 1 minute ago
             OccurrenceDueTimeUtc: dueTime);
 
         await Storage!.ScheduleReminderAsync(reminder);
 
+        // Expire should find this reminder because now > dueTime + 1 minute.
         var expiredCount = await Storage.ExpireRemindersAsync(now);
         Assert.True(expiredCount >= 1);
 
+        // The reminder is gone from the pending set — it won't be fetched or delivered.
         var overview = await Storage.GetRemindersOverviewAsync(now);
         Assert.Equal(0, overview.TotalPendingReminders);
 
+        // GetRemindersForEntityAsync also excludes expired reminders.
         var reminders = await Storage.GetRemindersForEntityAsync(reminder.Entity);
         Assert.Empty(reminders);
     }

--- a/src/Akka.Reminders.Tests/Storage/ReminderStorageSpecBase.cs
+++ b/src/Akka.Reminders.Tests/Storage/ReminderStorageSpecBase.cs
@@ -657,6 +657,30 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
     }
 
     [Fact]
+    public async Task GetNextAwaitingAckDeadlineAsync_ShouldReturnEarliestAwaitingDeadline()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var first = CreateTestReminder(CreateTestEntity("a", "1"), CreateTestKey("first"), now.AddMinutes(1));
+        var second = CreateTestReminder(CreateTestEntity("a", "2"), CreateTestKey("second"), now.AddMinutes(2));
+
+        await Storage!.ScheduleReminderAsync(first);
+        await Storage.ScheduleReminderAsync(second);
+
+        await Storage.CommitReminderMutationsAsync(new ReminderMutationBatch(
+            [],
+            [],
+            [
+                new AwaitingAckReminder(first.Entity, first.Key, first.DueTimeUtc, now, now.AddSeconds(20)),
+                new AwaitingAckReminder(second.Entity, second.Key, second.DueTimeUtc, now, now.AddSeconds(10))
+            ]));
+
+        var deadline = await Storage.GetNextAwaitingAckDeadlineAsync();
+
+        Assert.NotNull(deadline);
+        Assert.True(Math.Abs((deadline!.Value - now.AddSeconds(10)).TotalMilliseconds) < 0.001);
+    }
+
+    [Fact]
     public async Task ExpireRemindersAsync_ShouldCompleteExpiredPendingReminder()
     {
         var now = DateTimeOffset.UtcNow;

--- a/src/Akka.Reminders.Tests/Storage/ReminderStorageSpecBase.cs
+++ b/src/Akka.Reminders.Tests/Storage/ReminderStorageSpecBase.cs
@@ -530,6 +530,89 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
 
     #endregion
 
+    #region Awaiting Ack / Deadline Tests
+
+    [Fact]
+    public async Task MarkRemindersAsAwaitingAck_ShouldRemoveReminderFromPendingOverview()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var reminder = CreateTestReminder(when: now.AddMinutes(5));
+        await Storage!.ScheduleReminderAsync(reminder);
+
+        var awaitingAck = new AwaitingAckReminder(
+            reminder.Entity,
+            reminder.Key,
+            reminder.DueTimeUtc,
+            now,
+            now.AddMinutes(1));
+
+        var result = await Storage.MarkRemindersAsAwaitingAckAsync([awaitingAck]);
+        Assert.True(result);
+
+        var overview = await Storage.GetRemindersOverviewAsync(now);
+        Assert.Equal(0, overview.TotalPendingReminders);
+    }
+
+    [Fact]
+    public async Task AcknowledgeReminderAsync_ShouldRequireMatchingDueTime()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var reminder = CreateTestReminder(when: now.AddMinutes(5));
+        await Storage!.ScheduleReminderAsync(reminder);
+
+        var awaitingAck = new AwaitingAckReminder(
+            reminder.Entity,
+            reminder.Key,
+            reminder.DueTimeUtc,
+            now,
+            now.AddMinutes(1));
+        await Storage.MarkRemindersAsAwaitingAckAsync([awaitingAck]);
+
+        var wrongAck = await Storage.AcknowledgeReminderAsync(
+            reminder.Entity,
+            reminder.Key,
+            reminder.DueTimeUtc.AddSeconds(1),
+            now.AddSeconds(10));
+
+        Assert.False(wrongAck.Success);
+
+        var correctAck = await Storage.AcknowledgeReminderAsync(
+            reminder.Entity,
+            reminder.Key,
+            reminder.DueTimeUtc,
+            now.AddSeconds(10));
+
+        Assert.True(correctAck.Success);
+    }
+
+    [Fact]
+    public async Task ExpireRemindersAsync_ShouldCompleteExpiredPendingReminder()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var dueTime = now.AddMinutes(-2);
+        var reminder = new ScheduledReminder(
+            CreateTestEntity(),
+            CreateTestKey("expiring-reminder"),
+            dueTime,
+            "stale",
+            MaxDeliveryWindow: TimeSpan.FromMinutes(1),
+            DeliveryDeadlineUtc: dueTime.AddMinutes(1),
+            OccurrenceDueTimeUtc: dueTime);
+
+        await Storage!.ScheduleReminderAsync(reminder);
+
+        var expiredCount = await Storage.ExpireRemindersAsync(now);
+        Assert.True(expiredCount >= 1);
+
+        var overview = await Storage.GetRemindersOverviewAsync(now);
+        Assert.Equal(0, overview.TotalPendingReminders);
+
+        var reminders = await Storage.GetRemindersForEntityAsync(reminder.Entity);
+        Assert.Empty(reminders);
+    }
+
+    #endregion
+
     #region Mark Completed Tests
 
     [Fact]
@@ -539,7 +622,7 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var reminder = CreateTestReminder();
         await Storage!.ScheduleReminderAsync(reminder);
 
-        var completed = new CompletedReminder(reminder.Entity, reminder.Key, DateTimeOffset.UtcNow);
+        var completed = new CompletedReminder(reminder.Entity, reminder.Key, reminder.DueTimeUtc, DateTimeOffset.UtcNow);
 
         // Act
         var result = await Storage.MarkRemindersAsCompletedAsync(new[] { completed });
@@ -555,7 +638,7 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var reminder = CreateTestReminder();
         await Storage!.ScheduleReminderAsync(reminder);
 
-        var completed = new CompletedReminder(reminder.Entity, reminder.Key, DateTimeOffset.UtcNow);
+        var completed = new CompletedReminder(reminder.Entity, reminder.Key, reminder.DueTimeUtc, DateTimeOffset.UtcNow);
         await Storage.MarkRemindersAsCompletedAsync(new[] { completed });
 
         // Act
@@ -576,8 +659,8 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         await Storage!.ScheduleReminderAsync(reminder1);
         await Storage.ScheduleReminderAsync(reminder2);
 
-        var completed1 = new CompletedReminder(reminder1.Entity, reminder1.Key, DateTimeOffset.UtcNow);
-        var completed2 = new CompletedReminder(reminder2.Entity, reminder2.Key, DateTimeOffset.UtcNow);
+        var completed1 = new CompletedReminder(reminder1.Entity, reminder1.Key, reminder1.DueTimeUtc, DateTimeOffset.UtcNow);
+        var completed2 = new CompletedReminder(reminder2.Entity, reminder2.Key, reminder2.DueTimeUtc, DateTimeOffset.UtcNow);
 
         // Act
         var result = await Storage.MarkRemindersAsCompletedAsync(new[] { completed1, completed2 });
@@ -600,7 +683,7 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         await Storage!.ScheduleReminderAsync(reminder);
 
         var completedTime = DateTimeOffset.UtcNow.AddDays(-10);
-        var completed = new CompletedReminder(reminder.Entity, reminder.Key, completedTime);
+        var completed = new CompletedReminder(reminder.Entity, reminder.Key, reminder.DueTimeUtc, completedTime);
         await Storage.MarkRemindersAsCompletedAsync(new[] { completed });
 
         // Act
@@ -618,7 +701,7 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         await Storage!.ScheduleReminderAsync(reminder);
 
         var recentCompletedTime = DateTimeOffset.UtcNow.AddDays(-3);
-        var completed = new CompletedReminder(reminder.Entity, reminder.Key, recentCompletedTime);
+        var completed = new CompletedReminder(reminder.Entity, reminder.Key, reminder.DueTimeUtc, recentCompletedTime);
         await Storage.MarkRemindersAsCompletedAsync(new[] { completed });
 
         // Act - cleanup reminders older than 5 days

--- a/src/Akka.Reminders.Tests/Storage/ReminderStorageSpecBase.cs
+++ b/src/Akka.Reminders.Tests/Storage/ReminderStorageSpecBase.cs
@@ -575,6 +575,7 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             now.AddSeconds(10));
 
         Assert.False(wrongAck.Success);
+        Assert.Equal(ReminderAckStorageStatus.NotFound, wrongAck.Status);
 
         var correctAck = await Storage.AcknowledgeReminderAsync(
             reminder.Entity,
@@ -583,6 +584,76 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             now.AddSeconds(10));
 
         Assert.True(correctAck.Success);
+        Assert.Equal(ReminderAckStorageStatus.Success, correctAck.Status);
+    }
+
+    [Fact]
+    public async Task CommitReminderMutationsAsync_ShouldAtomicallyMovePendingToAwaitingAckAndUpsertNextOccurrence()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var reminder = new ScheduledReminder(
+            CreateTestEntity(),
+            CreateTestKey("atomic-recurring"),
+            now.AddMinutes(1),
+            "payload",
+            RepeatInterval: TimeSpan.FromMinutes(1),
+            OccurrenceDueTimeUtc: now.AddMinutes(1));
+
+        await Storage!.ScheduleReminderAsync(reminder);
+
+        var nextOccurrence = reminder with
+        {
+            When = reminder.DueTimeUtc.AddMinutes(1),
+            OccurrenceDueTimeUtc = reminder.DueTimeUtc.AddMinutes(1)
+        };
+
+        var awaiting = new AwaitingAckReminder(
+            reminder.Entity,
+            reminder.Key,
+            reminder.DueTimeUtc,
+            now,
+            now.AddMinutes(1));
+
+        var result = await Storage.CommitReminderMutationsAsync(new ReminderMutationBatch(
+            [nextOccurrence],
+            [],
+            [awaiting]));
+
+        Assert.True(result);
+
+        var overview = await Storage.GetRemindersOverviewAsync(now);
+        Assert.Equal(1, overview.TotalPendingReminders);
+
+        var reminders = await Storage.GetRemindersForEntityAsync(reminder.Entity);
+        Assert.Equal(2, reminders.Count);
+        Assert.Contains(reminders, r => Math.Abs((r.DueTimeUtc - reminder.DueTimeUtc).TotalMilliseconds) < 0.001);
+        Assert.Contains(reminders, r => Math.Abs((r.DueTimeUtc - nextOccurrence.DueTimeUtc).TotalMilliseconds) < 0.001);
+
+        var ack = await Storage.AcknowledgeReminderAsync(reminder.Entity, reminder.Key, reminder.DueTimeUtc, now.AddSeconds(5));
+        Assert.True(ack.Success);
+    }
+
+    [Fact]
+    public async Task AcknowledgeRemindersAsync_ShouldReturnPerOccurrenceResults()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var reminder = CreateTestReminder(when: now.AddMinutes(5));
+        await Storage!.ScheduleReminderAsync(reminder);
+
+        await Storage.CommitReminderMutationsAsync(new ReminderMutationBatch(
+            [],
+            [],
+            [new AwaitingAckReminder(reminder.Entity, reminder.Key, reminder.DueTimeUtc, now, now.AddMinutes(1))]));
+
+        var missingDueTime = reminder.DueTimeUtc.AddMinutes(1);
+        var results = await Storage.AcknowledgeRemindersAsync([
+            new ReminderAcknowledgement(reminder.Entity, reminder.Key, reminder.DueTimeUtc, now.AddSeconds(5)),
+            new ReminderAcknowledgement(reminder.Entity, reminder.Key, missingDueTime, now.AddSeconds(5))
+        ]);
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal(ReminderAckStorageStatus.Success, results[0].Status);
+        Assert.Equal(ReminderAckStorageStatus.NotFound, results[1].Status);
     }
 
     [Fact]

--- a/src/Akka.Reminders.Tests/WriteCircuitBreakerSpecs.cs
+++ b/src/Akka.Reminders.Tests/WriteCircuitBreakerSpecs.cs
@@ -50,12 +50,12 @@ public class WriteCircuitBreakerSpecs : Akka.Hosting.TestKit.TestKit
             $"reminder-scheduler-{Guid.NewGuid():N}");
     }
 
-    private async Task<List<ReminderEnvelope>> CollectMessages(TestProbe probe, int count, TimeSpan timeout)
+    private async Task<List<ReminderEnvelope<string>>> CollectMessages(TestProbe probe, int count, TimeSpan timeout)
     {
-        var messages = new List<ReminderEnvelope>();
+        var messages = new List<ReminderEnvelope<string>>();
         for (var i = 0; i < count; i++)
         {
-            messages.Add(await probe.ExpectMsgAsync<ReminderEnvelope>(timeout));
+            messages.Add(await probe.ExpectMsgAsync<ReminderEnvelope<string>>(timeout));
         }
         return messages;
     }

--- a/src/Akka.Reminders.Tests/WriteCircuitBreakerSpecs.cs
+++ b/src/Akka.Reminders.Tests/WriteCircuitBreakerSpecs.cs
@@ -50,12 +50,12 @@ public class WriteCircuitBreakerSpecs : Akka.Hosting.TestKit.TestKit
             $"reminder-scheduler-{Guid.NewGuid():N}");
     }
 
-    private async Task<List<string>> CollectMessages(TestProbe probe, int count, TimeSpan timeout)
+    private async Task<List<ReminderEnvelope>> CollectMessages(TestProbe probe, int count, TimeSpan timeout)
     {
-        var messages = new List<string>();
+        var messages = new List<ReminderEnvelope>();
         for (var i = 0; i < count; i++)
         {
-            messages.Add(await probe.ExpectMsgAsync<string>(timeout));
+            messages.Add(await probe.ExpectMsgAsync<ReminderEnvelope>(timeout));
         }
         return messages;
     }

--- a/src/Akka.Reminders.Tests/WriteCircuitBreakerSpecs.cs
+++ b/src/Akka.Reminders.Tests/WriteCircuitBreakerSpecs.cs
@@ -101,11 +101,8 @@ public class WriteCircuitBreakerSpecs : Akka.Hosting.TestKit.TestKit
         var scheduler = CreateScheduler(maxBatchSize: 1000, deliveryCommitChunkSize: 1000);
         await WaitForSchedulerReady(scheduler);
 
-        // Tick 1: all 5 delivered before mark-complete fails -> circuit opens.
+        // Tick 1: delivery-tracking write fails before any reminders are sent -> circuit opens.
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
-        var firstTickMessages = await CollectMessages(testProbe, 5, TimeSpan.FromSeconds(5));
-        Assert.Equal(5, firstTickMessages.Count);
-
         await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
     }
 
@@ -145,9 +142,8 @@ public class WriteCircuitBreakerSpecs : Akka.Hosting.TestKit.TestKit
         await WaitForSchedulerReady(scheduler);
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
 
-        // First failed tick should be bounded by DeliveryCommitChunkSize.
-        await CollectMessages(testProbe, 3, TimeSpan.FromSeconds(5));
-        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
+        // Failed writes now prevent delivery entirely, reducing the first-failure blast radius to zero.
+        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
     }
 
     [Fact]
@@ -164,22 +160,15 @@ public class WriteCircuitBreakerSpecs : Akka.Hosting.TestKit.TestKit
         var scheduler = CreateScheduler(maxBatchSize: 1000, deliveryCommitChunkSize: 3);
         await WaitForSchedulerReady(scheduler);
 
-        // Outage tick: first-failure blast radius is bounded by chunk size.
+        // Outage tick: failed writes prevent any delivery.
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
-        await CollectMessages(testProbe, 3, TimeSpan.FromSeconds(5));
-        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
+        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
 
-        // Database recovers: first successful probe should close the circuit,
-        // and the following tick should resume full-batch processing.
+        // Database recovers: the probe succeeds, closes the circuit, and the same run resumes full-batch processing.
         _storage.FailWrites = false;
 
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
-        await CollectMessages(testProbe, 1, TimeSpan.FromSeconds(5));
-
-        testScheduler.Advance(TimeSpan.FromMilliseconds(100));
-        await CollectMessages(testProbe, 5, TimeSpan.FromSeconds(5));
-
-        testScheduler.Advance(TimeSpan.FromMilliseconds(100));
+        await CollectMessages(testProbe, 6, TimeSpan.FromSeconds(5));
         await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
     }
 }

--- a/src/Akka.Reminders/AkkaHostingExtensions.cs
+++ b/src/Akka.Reminders/AkkaHostingExtensions.cs
@@ -11,21 +11,16 @@ namespace Akka.Reminders;
 public static class AkkaHostingExtensions
 {
     /// <summary>
-    /// HOCON configuration that registers the <see cref="Serialization.ReminderSerializer"/> and binds
-    /// it to all types that need to cross node boundaries in a cluster:
-    /// <see cref="ReminderEnvelope"/>, <see cref="ReminderProtocol.ReminderAck"/>, and
-    /// <see cref="ReminderProtocol.ReminderAckResponse"/>.
+    /// Registers the <see cref="Serialization.ReminderSerializer"/> for all
+    /// <see cref="IReminderWireMessage"/> types using the Akka.Hosting serializer API.
     /// </summary>
-    internal const string SerializerHocon = """
-        akka.actor.serializers {
-            reminder-serializer = "Akka.Reminders.Serialization.ReminderSerializer, Akka.Reminders"
-        }
-        akka.actor.serialization-bindings {
-            "Akka.Reminders.ReminderEnvelope, Akka.Reminders" = reminder-serializer
-            "Akka.Reminders.ReminderProtocol+ReminderAck, Akka.Reminders" = reminder-serializer
-            "Akka.Reminders.ReminderProtocol+ReminderAckResponse, Akka.Reminders" = reminder-serializer
-        }
-        """;
+    private static void RegisterReminderSerializer(AkkaConfigurationBuilder builder)
+    {
+        builder.WithCustomSerializer(
+            "reminder-serializer",
+            [typeof(IReminderWireMessage)],
+            system => new Serialization.ReminderSerializer(system));
+    }
 
     /// <summary>
     /// Adds the Akka.Reminders system to the actor system.
@@ -54,9 +49,8 @@ public static class AkkaHostingExtensions
         configure?.Invoke(reminderBuilder);
         var setup = reminderBuilder.Build();
 
-        // Register the reminder serializer so ReminderEnvelope, ReminderAck, and ReminderAckResponse
-        // are properly serialized across cluster boundaries.
-        builder.AddHocon(SerializerHocon, HoconAddMode.Prepend);
+        // Register the reminder serializer for all IReminderWireMessage types.
+        RegisterReminderSerializer(builder);
 
         // Add the setup to the actor system
         builder.AddSetup(setup);
@@ -157,9 +151,8 @@ public static class AkkaHostingExtensions
         var localBuilder = new LocalReminderConfigurationBuilder();
         configure?.Invoke(localBuilder);
 
-        // Register the reminder serializer so ReminderEnvelope, ReminderAck, and ReminderAckResponse
-        // are properly serialized across cluster boundaries.
-        builder.AddHocon(SerializerHocon, HoconAddMode.Prepend);
+        // Register the reminder serializer for all IReminderWireMessage types.
+        RegisterReminderSerializer(builder);
 
         builder.WithActors((system, registry) =>
         {

--- a/src/Akka.Reminders/AkkaHostingExtensions.cs
+++ b/src/Akka.Reminders/AkkaHostingExtensions.cs
@@ -11,6 +11,23 @@ namespace Akka.Reminders;
 public static class AkkaHostingExtensions
 {
     /// <summary>
+    /// HOCON configuration that registers the <see cref="Serialization.ReminderSerializer"/> and binds
+    /// it to all types that need to cross node boundaries in a cluster:
+    /// <see cref="ReminderEnvelope"/>, <see cref="ReminderProtocol.ReminderAck"/>, and
+    /// <see cref="ReminderProtocol.ReminderAckResponse"/>.
+    /// </summary>
+    internal const string SerializerHocon = """
+        akka.actor.serializers {
+            reminder-serializer = "Akka.Reminders.Serialization.ReminderSerializer, Akka.Reminders"
+        }
+        akka.actor.serialization-bindings {
+            "Akka.Reminders.ReminderEnvelope, Akka.Reminders" = reminder-serializer
+            "Akka.Reminders.ReminderProtocol+ReminderAck, Akka.Reminders" = reminder-serializer
+            "Akka.Reminders.ReminderProtocol+ReminderAckResponse, Akka.Reminders" = reminder-serializer
+        }
+        """;
+
+    /// <summary>
     /// Adds the Akka.Reminders system to the actor system.
     /// </summary>
     /// <param name="builder">The Akka configuration builder.</param>
@@ -36,6 +53,10 @@ public static class AkkaHostingExtensions
         reminderBuilder.WithRole(role);
         configure?.Invoke(reminderBuilder);
         var setup = reminderBuilder.Build();
+
+        // Register the reminder serializer so ReminderEnvelope, ReminderAck, and ReminderAckResponse
+        // are properly serialized across cluster boundaries.
+        builder.AddHocon(SerializerHocon, HoconAddMode.Prepend);
 
         // Add the setup to the actor system
         builder.AddSetup(setup);
@@ -135,6 +156,10 @@ public static class AkkaHostingExtensions
     {
         var localBuilder = new LocalReminderConfigurationBuilder();
         configure?.Invoke(localBuilder);
+
+        // Register the reminder serializer so ReminderEnvelope, ReminderAck, and ReminderAckResponse
+        // are properly serialized across cluster boundaries.
+        builder.AddHocon(SerializerHocon, HoconAddMode.Prepend);
 
         builder.WithActors((system, registry) =>
         {

--- a/src/Akka.Reminders/IReminderClient.cs
+++ b/src/Akka.Reminders/IReminderClient.cs
@@ -14,11 +14,10 @@ public interface IReminderClient
     /// Schedule a one-off reminder.
     /// If a reminder with the same key already exists, it will be overwritten.
     /// </summary>
-    /// <typeparam name="T">The type of the message payload to deliver when the reminder fires.</typeparam>
-    Task<ReminderProtocol.ReminderScheduled> ScheduleSingleReminderAsync<T>(
+    Task<ReminderProtocol.ReminderScheduled> ScheduleSingleReminderAsync(
         ReminderKey key,
         DateTimeOffset when,
-        T message,
+        object message,
         TimeSpan? maxDeliveryWindow = null,
         CancellationToken ct = default);
 
@@ -26,12 +25,11 @@ public interface IReminderClient
     /// Schedule a recurring reminder that fires at regular intervals.
     /// If a reminder with the same key already exists, it will be overwritten.
     /// </summary>
-    /// <typeparam name="T">The type of the message payload to deliver when the reminder fires.</typeparam>
-    Task<ReminderProtocol.ReminderScheduled> ScheduleRecurringReminderAsync<T>(
+    Task<ReminderProtocol.ReminderScheduled> ScheduleRecurringReminderAsync(
         ReminderKey key,
         DateTimeOffset firstOccurrence,
         TimeSpan interval,
-        T message,
+        object message,
         TimeSpan? maxDeliveryWindow = null,
         CancellationToken ct = default);
 

--- a/src/Akka.Reminders/IReminderClient.cs
+++ b/src/Akka.Reminders/IReminderClient.cs
@@ -15,14 +15,25 @@ public interface IReminderClient
     /// If a reminder with the same key already exists, it will be overwritten.
     /// </summary>
     /// <typeparam name="T">The type of the message payload to deliver when the reminder fires.</typeparam>
-    Task<ReminderProtocol.ReminderScheduled> ScheduleSingleReminderAsync<T>(ReminderKey key, DateTimeOffset when, T message, CancellationToken ct = default);
+    Task<ReminderProtocol.ReminderScheduled> ScheduleSingleReminderAsync<T>(
+        ReminderKey key,
+        DateTimeOffset when,
+        T message,
+        TimeSpan? maxDeliveryWindow = null,
+        CancellationToken ct = default);
 
     /// <summary>
     /// Schedule a recurring reminder that fires at regular intervals.
     /// If a reminder with the same key already exists, it will be overwritten.
     /// </summary>
     /// <typeparam name="T">The type of the message payload to deliver when the reminder fires.</typeparam>
-    Task<ReminderProtocol.ReminderScheduled> ScheduleRecurringReminderAsync<T>(ReminderKey key, DateTimeOffset firstOccurrence, TimeSpan interval, T message, CancellationToken ct = default);
+    Task<ReminderProtocol.ReminderScheduled> ScheduleRecurringReminderAsync<T>(
+        ReminderKey key,
+        DateTimeOffset firstOccurrence,
+        TimeSpan interval,
+        T message,
+        TimeSpan? maxDeliveryWindow = null,
+        CancellationToken ct = default);
 
     Task<ReminderProtocol.RemindersCancelled> CancelReminderAsync(ReminderKey key, CancellationToken ct = default);
 

--- a/src/Akka.Reminders/IReminderClient.cs
+++ b/src/Akka.Reminders/IReminderClient.cs
@@ -14,17 +14,31 @@ public interface IReminderClient
     /// Schedule a one-off reminder.
     /// If a reminder with the same key already exists, it will be overwritten.
     /// </summary>
-    Task<ReminderProtocol.ReminderScheduled> ScheduleSingleReminderAsync(ReminderKey key, DateTimeOffset when, object message, CancellationToken ct = default);
+    /// <typeparam name="T">The type of the message payload to deliver when the reminder fires.</typeparam>
+    Task<ReminderProtocol.ReminderScheduled> ScheduleSingleReminderAsync<T>(ReminderKey key, DateTimeOffset when, T message, CancellationToken ct = default);
 
     /// <summary>
     /// Schedule a recurring reminder that fires at regular intervals.
     /// If a reminder with the same key already exists, it will be overwritten.
     /// </summary>
-    Task<ReminderProtocol.ReminderScheduled> ScheduleRecurringReminderAsync(ReminderKey key, DateTimeOffset firstOccurrence, TimeSpan interval, object message, CancellationToken ct = default);
+    /// <typeparam name="T">The type of the message payload to deliver when the reminder fires.</typeparam>
+    Task<ReminderProtocol.ReminderScheduled> ScheduleRecurringReminderAsync<T>(ReminderKey key, DateTimeOffset firstOccurrence, TimeSpan interval, T message, CancellationToken ct = default);
 
     Task<ReminderProtocol.RemindersCancelled> CancelReminderAsync(ReminderKey key, CancellationToken ct = default);
 
     Task<ReminderProtocol.RemindersCancelled> CancelAllRemindersAsync(CancellationToken ct = default);
 
     Task<ReminderProtocol.RemindersForEntity> ListRemindersAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Acknowledge receipt of a reminder. Returns when the scheduler confirms.
+    /// If this Task faults or times out, a duplicate delivery may occur.
+    /// </summary>
+    /// <param name="envelope">The envelope received when the reminder fired.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// A task containing the scheduler's acknowledgement response.
+    /// Check <see cref="ReminderProtocol.ReminderAckResponse.ResponseCode"/> to determine success.
+    /// </returns>
+    Task<ReminderProtocol.ReminderAckResponse> AckAsync(ReminderEnvelope envelope, CancellationToken ct = default);
 }

--- a/src/Akka.Reminders/ReminderClient.cs
+++ b/src/Akka.Reminders/ReminderClient.cs
@@ -30,10 +30,10 @@ internal sealed class ReminderClient : IReminderClient
     public ReminderEntity Entity { get; }
 
     /// <inheritdoc />
-    public async Task<ReminderProtocol.ReminderScheduled> ScheduleSingleReminderAsync<T>(
+    public async Task<ReminderProtocol.ReminderScheduled> ScheduleSingleReminderAsync(
         ReminderKey key,
         DateTimeOffset when,
-        T message,
+        object message,
         TimeSpan? maxDeliveryWindow = null,
         CancellationToken ct = default)
     {
@@ -41,7 +41,7 @@ internal sealed class ReminderClient : IReminderClient
             Entity,
             key,
             when,
-            message!,
+            message,
             RepeatInterval: null,
             MaxDeliveryWindow: maxDeliveryWindow);
 
@@ -73,11 +73,11 @@ internal sealed class ReminderClient : IReminderClient
     }
 
     /// <inheritdoc />
-    public async Task<ReminderProtocol.ReminderScheduled> ScheduleRecurringReminderAsync<T>(
+    public async Task<ReminderProtocol.ReminderScheduled> ScheduleRecurringReminderAsync(
         ReminderKey key,
         DateTimeOffset firstOccurrence,
         TimeSpan interval,
-        T message,
+        object message,
         TimeSpan? maxDeliveryWindow = null,
         CancellationToken ct = default)
     {
@@ -85,7 +85,7 @@ internal sealed class ReminderClient : IReminderClient
             Entity,
             key,
             firstOccurrence,
-            message!,
+            message,
             RepeatInterval: interval,
             MaxDeliveryWindow: maxDeliveryWindow);
 

--- a/src/Akka.Reminders/ReminderClient.cs
+++ b/src/Akka.Reminders/ReminderClient.cs
@@ -28,7 +28,7 @@ internal sealed class ReminderClient : IReminderClient
         T message,
         CancellationToken ct = default)
     {
-        var command = new ReminderProtocol.ScheduleReminder(Entity, key, when, message, RepeatInterval: null);
+        var command = new ReminderProtocol.ScheduleReminder(Entity, key, when, message!, RepeatInterval: null);
 
         try
         {
@@ -65,7 +65,7 @@ internal sealed class ReminderClient : IReminderClient
         T message,
         CancellationToken ct = default)
     {
-        var command = new ReminderProtocol.ScheduleReminder(Entity, key, firstOccurrence, message, RepeatInterval: interval);
+        var command = new ReminderProtocol.ScheduleReminder(Entity, key, firstOccurrence, message!, RepeatInterval: interval);
 
         try
         {

--- a/src/Akka.Reminders/ReminderClient.cs
+++ b/src/Akka.Reminders/ReminderClient.cs
@@ -34,9 +34,16 @@ internal sealed class ReminderClient : IReminderClient
         ReminderKey key,
         DateTimeOffset when,
         T message,
+        TimeSpan? maxDeliveryWindow = null,
         CancellationToken ct = default)
     {
-        var command = new ReminderProtocol.ScheduleReminder(Entity, key, when, message!, RepeatInterval: null);
+        var command = new ReminderProtocol.ScheduleReminder(
+            Entity,
+            key,
+            when,
+            message!,
+            RepeatInterval: null,
+            MaxDeliveryWindow: maxDeliveryWindow);
 
         try
         {
@@ -71,9 +78,16 @@ internal sealed class ReminderClient : IReminderClient
         DateTimeOffset firstOccurrence,
         TimeSpan interval,
         T message,
+        TimeSpan? maxDeliveryWindow = null,
         CancellationToken ct = default)
     {
-        var command = new ReminderProtocol.ScheduleReminder(Entity, key, firstOccurrence, message!, RepeatInterval: interval);
+        var command = new ReminderProtocol.ScheduleReminder(
+            Entity,
+            key,
+            firstOccurrence,
+            message!,
+            RepeatInterval: interval,
+            MaxDeliveryWindow: maxDeliveryWindow);
 
         try
         {
@@ -205,7 +219,7 @@ internal sealed class ReminderClient : IReminderClient
         ReminderEnvelope envelope,
         CancellationToken ct = default)
     {
-        var command = new ReminderProtocol.ReminderAck(envelope.Entity, envelope.Key);
+        var command = new ReminderProtocol.ReminderAck(envelope.Entity, envelope.Key, envelope.DueTimeUtc);
 
         try
         {
@@ -219,6 +233,7 @@ internal sealed class ReminderClient : IReminderClient
             return new ReminderProtocol.ReminderAckResponse(
                 envelope.Entity,
                 envelope.Key,
+                envelope.DueTimeUtc,
                 ReminderAckResponseCode.Error,
                 "Request timed out while acknowledging reminder");
         }
@@ -227,6 +242,7 @@ internal sealed class ReminderClient : IReminderClient
             return new ReminderProtocol.ReminderAckResponse(
                 envelope.Entity,
                 envelope.Key,
+                envelope.DueTimeUtc,
                 ReminderAckResponseCode.Error,
                 $"Error acknowledging reminder: {ex.Message}");
         }

--- a/src/Akka.Reminders/ReminderClient.cs
+++ b/src/Akka.Reminders/ReminderClient.cs
@@ -12,6 +12,14 @@ internal sealed class ReminderClient : IReminderClient
     private readonly IActorRef _schedulerProxy;
     private readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(5);
 
+    /// <summary>
+    /// Longer timeout for ack operations. The scheduler's ack handler performs a storage write
+    /// that may take up to <c>StorageTimeout</c> (default 5 s) to complete. Using the same
+    /// 5-second default as <see cref="_defaultTimeout"/> would race against that write and cause
+    /// the caller to misreport a successful ack as a timeout failure.
+    /// </summary>
+    private readonly TimeSpan _ackTimeout = TimeSpan.FromSeconds(15);
+
     public ReminderClient(IActorRef schedulerProxy, ReminderEntity entity)
     {
         _schedulerProxy = schedulerProxy;
@@ -202,7 +210,7 @@ internal sealed class ReminderClient : IReminderClient
         try
         {
             var response = await _schedulerProxy.Ask<ReminderProtocol.ReminderAckResponse>(
-                command, _defaultTimeout, ct);
+                command, _ackTimeout, ct);
 
             return response;
         }

--- a/src/Akka.Reminders/ReminderClient.cs
+++ b/src/Akka.Reminders/ReminderClient.cs
@@ -22,10 +22,10 @@ internal sealed class ReminderClient : IReminderClient
     public ReminderEntity Entity { get; }
 
     /// <inheritdoc />
-    public async Task<ReminderProtocol.ReminderScheduled> ScheduleSingleReminderAsync(
+    public async Task<ReminderProtocol.ReminderScheduled> ScheduleSingleReminderAsync<T>(
         ReminderKey key,
         DateTimeOffset when,
-        object message,
+        T message,
         CancellationToken ct = default)
     {
         var command = new ReminderProtocol.ScheduleReminder(Entity, key, when, message, RepeatInterval: null);
@@ -58,11 +58,11 @@ internal sealed class ReminderClient : IReminderClient
     }
 
     /// <inheritdoc />
-    public async Task<ReminderProtocol.ReminderScheduled> ScheduleRecurringReminderAsync(
+    public async Task<ReminderProtocol.ReminderScheduled> ScheduleRecurringReminderAsync<T>(
         ReminderKey key,
         DateTimeOffset firstOccurrence,
         TimeSpan interval,
-        object message,
+        T message,
         CancellationToken ct = default)
     {
         var command = new ReminderProtocol.ScheduleReminder(Entity, key, firstOccurrence, message, RepeatInterval: interval);
@@ -113,7 +113,7 @@ internal sealed class ReminderClient : IReminderClient
             return new ReminderProtocol.RemindersCancelled(
                 Entity,
                 ReminderCancelResponseCode.Error,
-                Array.Empty<ReminderKey>(),
+                [],
                 "Request timed out while communicating with reminder scheduler");
         }
         catch (Exception ex)
@@ -121,7 +121,7 @@ internal sealed class ReminderClient : IReminderClient
             return new ReminderProtocol.RemindersCancelled(
                 Entity,
                 ReminderCancelResponseCode.Error,
-                Array.Empty<ReminderKey>(),
+                [],
                 $"Error canceling reminder: {ex.Message}");
         }
     }
@@ -146,7 +146,7 @@ internal sealed class ReminderClient : IReminderClient
             return new ReminderProtocol.RemindersCancelled(
                 Entity,
                 ReminderCancelResponseCode.Error,
-                Array.Empty<ReminderKey>(),
+                [],
                 "Request timed out while communicating with reminder scheduler");
         }
         catch (Exception ex)
@@ -154,7 +154,7 @@ internal sealed class ReminderClient : IReminderClient
             return new ReminderProtocol.RemindersCancelled(
                 Entity,
                 ReminderCancelResponseCode.Error,
-                Array.Empty<ReminderKey>(),
+                [],
                 $"Error canceling all reminders: {ex.Message}");
         }
     }
@@ -179,7 +179,7 @@ internal sealed class ReminderClient : IReminderClient
             return new ReminderProtocol.RemindersForEntity(
                 Entity,
                 FetchRemindersResponseCode.Error,
-                Array.Empty<ScheduledReminder>(),
+                [],
                 "Request timed out while communicating with reminder scheduler");
         }
         catch (Exception ex)
@@ -187,8 +187,40 @@ internal sealed class ReminderClient : IReminderClient
             return new ReminderProtocol.RemindersForEntity(
                 Entity,
                 FetchRemindersResponseCode.Error,
-                Array.Empty<ScheduledReminder>(),
+                [],
                 $"Error fetching reminders: {ex.Message}");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<ReminderProtocol.ReminderAckResponse> AckAsync(
+        ReminderEnvelope envelope,
+        CancellationToken ct = default)
+    {
+        var command = new ReminderProtocol.ReminderAck(envelope.Entity, envelope.Key);
+
+        try
+        {
+            var response = await _schedulerProxy.Ask<ReminderProtocol.ReminderAckResponse>(
+                command, _defaultTimeout, ct);
+
+            return response;
+        }
+        catch (AskTimeoutException)
+        {
+            return new ReminderProtocol.ReminderAckResponse(
+                envelope.Entity,
+                envelope.Key,
+                ReminderAckResponseCode.Error,
+                "Request timed out while acknowledging reminder");
+        }
+        catch (Exception ex)
+        {
+            return new ReminderProtocol.ReminderAckResponse(
+                envelope.Entity,
+                envelope.Key,
+                ReminderAckResponseCode.Error,
+                $"Error acknowledging reminder: {ex.Message}");
         }
     }
 }

--- a/src/Akka.Reminders/ReminderClientExtension.cs
+++ b/src/Akka.Reminders/ReminderClientExtension.cs
@@ -105,7 +105,7 @@ public sealed class ReminderClientExtension : IExtension
         T message,
         CancellationToken ct = default)
     {
-        var command = new ReminderProtocol.ScheduleReminder(entity, key, when, message, RepeatInterval: null);
+        var command = new ReminderProtocol.ScheduleReminder(entity, key, when, message!, RepeatInterval: null);
         return SendToSchedulerAsync<ReminderProtocol.ScheduleReminder, ReminderProtocol.ReminderScheduled>(
             command,
             ct,
@@ -164,7 +164,7 @@ public sealed class ReminderClientExtension : IExtension
         T message,
         CancellationToken ct = default)
     {
-        var command = new ReminderProtocol.ScheduleReminder(entity, key, firstOccurrence, message, RepeatInterval: interval);
+        var command = new ReminderProtocol.ScheduleReminder(entity, key, firstOccurrence, message!, RepeatInterval: interval);
         return SendToSchedulerAsync<ReminderProtocol.ScheduleReminder, ReminderProtocol.ReminderScheduled>(
             command,
             ct,

--- a/src/Akka.Reminders/ReminderClientExtension.cs
+++ b/src/Akka.Reminders/ReminderClientExtension.cs
@@ -87,6 +87,7 @@ public sealed class ReminderClientExtension : IExtension
     /// <summary>
     /// Schedules a single reminder for the specified entity without creating a client.
     /// </summary>
+    /// <typeparam name="T">The type of the message payload to deliver when the reminder fires.</typeparam>
     /// <param name="entity">The entity that will receive the reminder.</param>
     /// <param name="key">The unique key for this reminder.</param>
     /// <param name="when">When the reminder should fire.</param>
@@ -97,11 +98,11 @@ public sealed class ReminderClientExtension : IExtension
     /// This is a convenience method for scheduling reminders without creating a client first.
     /// Useful for bulk scheduling operations where you don't need to retain a client instance.
     /// </remarks>
-    public Task<ReminderProtocol.ReminderScheduled> ScheduleSingleReminderAsync(
+    public Task<ReminderProtocol.ReminderScheduled> ScheduleSingleReminderAsync<T>(
         ReminderEntity entity,
         ReminderKey key,
         DateTimeOffset when,
-        object message,
+        T message,
         CancellationToken ct = default)
     {
         var command = new ReminderProtocol.ScheduleReminder(entity, key, when, message, RepeatInterval: null);
@@ -117,6 +118,7 @@ public sealed class ReminderClientExtension : IExtension
     /// <summary>
     /// Schedules a single reminder for the specified shard region and entity ID without creating a client.
     /// </summary>
+    /// <typeparam name="T">The type of the message payload to deliver when the reminder fires.</typeparam>
     /// <param name="shardRegionName">The name of the shard region.</param>
     /// <param name="entityId">The entity identifier.</param>
     /// <param name="key">The unique key for this reminder.</param>
@@ -128,12 +130,12 @@ public sealed class ReminderClientExtension : IExtension
     /// This is a convenience method for scheduling reminders without creating a client first.
     /// Useful for bulk scheduling operations where you don't need to retain a client instance.
     /// </remarks>
-    public Task<ReminderProtocol.ReminderScheduled> ScheduleSingleReminderAsync(
+    public Task<ReminderProtocol.ReminderScheduled> ScheduleSingleReminderAsync<T>(
         string shardRegionName,
         string entityId,
         ReminderKey key,
         DateTimeOffset when,
-        object message,
+        T message,
         CancellationToken ct = default)
     {
         return ScheduleSingleReminderAsync(new ReminderEntity(shardRegionName, entityId), key, when, message, ct);
@@ -142,6 +144,7 @@ public sealed class ReminderClientExtension : IExtension
     /// <summary>
     /// Schedules a recurring reminder for the specified entity without creating a client.
     /// </summary>
+    /// <typeparam name="T">The type of the message payload to deliver when the reminder fires.</typeparam>
     /// <param name="entity">The entity that will receive the reminder.</param>
     /// <param name="key">The unique key for this reminder.</param>
     /// <param name="firstOccurrence">When the reminder should fire for the first time.</param>
@@ -153,12 +156,12 @@ public sealed class ReminderClientExtension : IExtension
     /// This is a convenience method for scheduling recurring reminders without creating a client first.
     /// Useful for bulk scheduling operations where you don't need to retain a client instance.
     /// </remarks>
-    public Task<ReminderProtocol.ReminderScheduled> ScheduleRecurringReminderAsync(
+    public Task<ReminderProtocol.ReminderScheduled> ScheduleRecurringReminderAsync<T>(
         ReminderEntity entity,
         ReminderKey key,
         DateTimeOffset firstOccurrence,
         TimeSpan interval,
-        object message,
+        T message,
         CancellationToken ct = default)
     {
         var command = new ReminderProtocol.ScheduleReminder(entity, key, firstOccurrence, message, RepeatInterval: interval);
@@ -174,6 +177,7 @@ public sealed class ReminderClientExtension : IExtension
     /// <summary>
     /// Schedules a recurring reminder for the specified shard region and entity ID without creating a client.
     /// </summary>
+    /// <typeparam name="T">The type of the message payload to deliver when the reminder fires.</typeparam>
     /// <param name="shardRegionName">The name of the shard region.</param>
     /// <param name="entityId">The entity identifier.</param>
     /// <param name="key">The unique key for this reminder.</param>
@@ -186,13 +190,13 @@ public sealed class ReminderClientExtension : IExtension
     /// This is a convenience method for scheduling recurring reminders without creating a client first.
     /// Useful for bulk scheduling operations where you don't need to retain a client instance.
     /// </remarks>
-    public Task<ReminderProtocol.ReminderScheduled> ScheduleRecurringReminderAsync(
+    public Task<ReminderProtocol.ReminderScheduled> ScheduleRecurringReminderAsync<T>(
         string shardRegionName,
         string entityId,
         ReminderKey key,
         DateTimeOffset firstOccurrence,
         TimeSpan interval,
-        object message,
+        T message,
         CancellationToken ct = default)
     {
         return ScheduleRecurringReminderAsync(
@@ -202,6 +206,31 @@ public sealed class ReminderClientExtension : IExtension
             interval,
             message,
             ct);
+    }
+
+    /// <summary>
+    /// Acknowledges receipt of a reminder without creating a client.
+    /// </summary>
+    /// <param name="envelope">The envelope received when the reminder fired.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// A task containing the scheduler's acknowledgement response.
+    /// Check <see cref="ReminderProtocol.ReminderAckResponse.ResponseCode"/> to determine success.
+    /// If this Task faults or times out, a duplicate delivery may occur.
+    /// </returns>
+    public Task<ReminderProtocol.ReminderAckResponse> AckAsync(
+        ReminderEnvelope envelope,
+        CancellationToken ct = default)
+    {
+        var command = new ReminderProtocol.ReminderAck(envelope.Entity, envelope.Key);
+        return SendToSchedulerAsync<ReminderProtocol.ReminderAck, ReminderProtocol.ReminderAckResponse>(
+            command,
+            ct,
+            errorMessage => new ReminderProtocol.ReminderAckResponse(
+                envelope.Entity,
+                envelope.Key,
+                ReminderAckResponseCode.Error,
+                errorMessage));
     }
 
     /// <summary>

--- a/src/Akka.Reminders/ReminderClientExtension.cs
+++ b/src/Akka.Reminders/ReminderClientExtension.cs
@@ -58,18 +58,28 @@ public sealed class ReminderClientExtension : IExtension
     }
 
     /// <summary>
+    /// Longer timeout applied specifically to ack operations. The scheduler's ack handler performs
+    /// a storage write that may take up to <c>StorageTimeout</c> (default 5 s) to complete.
+    /// Using the same 5-second default would race against that write and cause the caller to
+    /// misreport a successful ack as a timeout failure.
+    /// </summary>
+    private static readonly TimeSpan AckTimeout = TimeSpan.FromSeconds(15);
+
+    /// <summary>
     /// Helper method to send a command to the scheduler proxy with error handling.
+    /// Uses <paramref name="timeout"/> for the Ask call; defaults to 5 seconds when not specified.
     /// </summary>
     private async Task<TResponse> SendToSchedulerAsync<TCommand, TResponse>(
         TCommand command,
         CancellationToken ct,
-        Func<string, TResponse> errorFactory)
+        Func<string, TResponse> errorFactory,
+        TimeSpan? timeout = null)
     {
         try
         {
             var response = await _schedulerProxy.Value.Ask<TResponse>(
                 command,
-                TimeSpan.FromSeconds(5),
+                timeout ?? TimeSpan.FromSeconds(5),
                 ct);
 
             return response;
@@ -230,7 +240,8 @@ public sealed class ReminderClientExtension : IExtension
                 envelope.Entity,
                 envelope.Key,
                 ReminderAckResponseCode.Error,
-                errorMessage));
+                errorMessage),
+            AckTimeout);
     }
 
     /// <summary>

--- a/src/Akka.Reminders/ReminderClientExtension.cs
+++ b/src/Akka.Reminders/ReminderClientExtension.cs
@@ -102,6 +102,7 @@ public sealed class ReminderClientExtension : IExtension
     /// <param name="key">The unique key for this reminder.</param>
     /// <param name="when">When the reminder should fire.</param>
     /// <param name="message">The message to deliver when the reminder fires.</param>
+    /// <param name="maxDeliveryWindow">Optional maximum amount of time the reminder occurrence remains actionable after its due time.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A task that completes when the reminder is scheduled.</returns>
     /// <remarks>
@@ -113,9 +114,16 @@ public sealed class ReminderClientExtension : IExtension
         ReminderKey key,
         DateTimeOffset when,
         T message,
+        TimeSpan? maxDeliveryWindow = null,
         CancellationToken ct = default)
     {
-        var command = new ReminderProtocol.ScheduleReminder(entity, key, when, message!, RepeatInterval: null);
+        var command = new ReminderProtocol.ScheduleReminder(
+            entity,
+            key,
+            when,
+            message!,
+            RepeatInterval: null,
+            MaxDeliveryWindow: maxDeliveryWindow);
         return SendToSchedulerAsync<ReminderProtocol.ScheduleReminder, ReminderProtocol.ReminderScheduled>(
             command,
             ct,
@@ -134,6 +142,7 @@ public sealed class ReminderClientExtension : IExtension
     /// <param name="key">The unique key for this reminder.</param>
     /// <param name="when">When the reminder should fire.</param>
     /// <param name="message">The message to deliver when the reminder fires.</param>
+    /// <param name="maxDeliveryWindow">Optional maximum amount of time the reminder occurrence remains actionable after its due time.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A task that completes when the reminder is scheduled.</returns>
     /// <remarks>
@@ -146,9 +155,16 @@ public sealed class ReminderClientExtension : IExtension
         ReminderKey key,
         DateTimeOffset when,
         T message,
+        TimeSpan? maxDeliveryWindow = null,
         CancellationToken ct = default)
     {
-        return ScheduleSingleReminderAsync(new ReminderEntity(shardRegionName, entityId), key, when, message, ct);
+        return ScheduleSingleReminderAsync(
+            new ReminderEntity(shardRegionName, entityId),
+            key,
+            when,
+            message,
+            maxDeliveryWindow,
+            ct);
     }
 
     /// <summary>
@@ -160,6 +176,7 @@ public sealed class ReminderClientExtension : IExtension
     /// <param name="firstOccurrence">When the reminder should fire for the first time.</param>
     /// <param name="interval">The interval between recurring reminders.</param>
     /// <param name="message">The message to deliver when the reminder fires.</param>
+    /// <param name="maxDeliveryWindow">Optional maximum amount of time each recurring occurrence remains actionable after its due time.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A task that completes when the reminder is scheduled.</returns>
     /// <remarks>
@@ -172,9 +189,16 @@ public sealed class ReminderClientExtension : IExtension
         DateTimeOffset firstOccurrence,
         TimeSpan interval,
         T message,
+        TimeSpan? maxDeliveryWindow = null,
         CancellationToken ct = default)
     {
-        var command = new ReminderProtocol.ScheduleReminder(entity, key, firstOccurrence, message!, RepeatInterval: interval);
+        var command = new ReminderProtocol.ScheduleReminder(
+            entity,
+            key,
+            firstOccurrence,
+            message!,
+            RepeatInterval: interval,
+            MaxDeliveryWindow: maxDeliveryWindow);
         return SendToSchedulerAsync<ReminderProtocol.ScheduleReminder, ReminderProtocol.ReminderScheduled>(
             command,
             ct,
@@ -194,6 +218,7 @@ public sealed class ReminderClientExtension : IExtension
     /// <param name="firstOccurrence">When the reminder should fire for the first time.</param>
     /// <param name="interval">The interval between recurring reminders.</param>
     /// <param name="message">The message to deliver when the reminder fires.</param>
+    /// <param name="maxDeliveryWindow">Optional maximum amount of time each recurring occurrence remains actionable after its due time.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A task that completes when the reminder is scheduled.</returns>
     /// <remarks>
@@ -207,6 +232,7 @@ public sealed class ReminderClientExtension : IExtension
         DateTimeOffset firstOccurrence,
         TimeSpan interval,
         T message,
+        TimeSpan? maxDeliveryWindow = null,
         CancellationToken ct = default)
     {
         return ScheduleRecurringReminderAsync(
@@ -215,6 +241,7 @@ public sealed class ReminderClientExtension : IExtension
             firstOccurrence,
             interval,
             message,
+            maxDeliveryWindow,
             ct);
     }
 
@@ -232,13 +259,14 @@ public sealed class ReminderClientExtension : IExtension
         ReminderEnvelope envelope,
         CancellationToken ct = default)
     {
-        var command = new ReminderProtocol.ReminderAck(envelope.Entity, envelope.Key);
+        var command = new ReminderProtocol.ReminderAck(envelope.Entity, envelope.Key, envelope.DueTimeUtc);
         return SendToSchedulerAsync<ReminderProtocol.ReminderAck, ReminderProtocol.ReminderAckResponse>(
             command,
             ct,
             errorMessage => new ReminderProtocol.ReminderAckResponse(
                 envelope.Entity,
                 envelope.Key,
+                envelope.DueTimeUtc,
                 ReminderAckResponseCode.Error,
                 errorMessage),
             AckTimeout);

--- a/src/Akka.Reminders/ReminderClientExtension.cs
+++ b/src/Akka.Reminders/ReminderClientExtension.cs
@@ -97,7 +97,6 @@ public sealed class ReminderClientExtension : IExtension
     /// <summary>
     /// Schedules a single reminder for the specified entity without creating a client.
     /// </summary>
-    /// <typeparam name="T">The type of the message payload to deliver when the reminder fires.</typeparam>
     /// <param name="entity">The entity that will receive the reminder.</param>
     /// <param name="key">The unique key for this reminder.</param>
     /// <param name="when">When the reminder should fire.</param>
@@ -109,11 +108,11 @@ public sealed class ReminderClientExtension : IExtension
     /// This is a convenience method for scheduling reminders without creating a client first.
     /// Useful for bulk scheduling operations where you don't need to retain a client instance.
     /// </remarks>
-    public Task<ReminderProtocol.ReminderScheduled> ScheduleSingleReminderAsync<T>(
+    public Task<ReminderProtocol.ReminderScheduled> ScheduleSingleReminderAsync(
         ReminderEntity entity,
         ReminderKey key,
         DateTimeOffset when,
-        T message,
+        object message,
         TimeSpan? maxDeliveryWindow = null,
         CancellationToken ct = default)
     {
@@ -121,7 +120,7 @@ public sealed class ReminderClientExtension : IExtension
             entity,
             key,
             when,
-            message!,
+            message,
             RepeatInterval: null,
             MaxDeliveryWindow: maxDeliveryWindow);
         return SendToSchedulerAsync<ReminderProtocol.ScheduleReminder, ReminderProtocol.ReminderScheduled>(
@@ -136,7 +135,6 @@ public sealed class ReminderClientExtension : IExtension
     /// <summary>
     /// Schedules a single reminder for the specified shard region and entity ID without creating a client.
     /// </summary>
-    /// <typeparam name="T">The type of the message payload to deliver when the reminder fires.</typeparam>
     /// <param name="shardRegionName">The name of the shard region.</param>
     /// <param name="entityId">The entity identifier.</param>
     /// <param name="key">The unique key for this reminder.</param>
@@ -149,12 +147,12 @@ public sealed class ReminderClientExtension : IExtension
     /// This is a convenience method for scheduling reminders without creating a client first.
     /// Useful for bulk scheduling operations where you don't need to retain a client instance.
     /// </remarks>
-    public Task<ReminderProtocol.ReminderScheduled> ScheduleSingleReminderAsync<T>(
+    public Task<ReminderProtocol.ReminderScheduled> ScheduleSingleReminderAsync(
         string shardRegionName,
         string entityId,
         ReminderKey key,
         DateTimeOffset when,
-        T message,
+        object message,
         TimeSpan? maxDeliveryWindow = null,
         CancellationToken ct = default)
     {
@@ -170,7 +168,6 @@ public sealed class ReminderClientExtension : IExtension
     /// <summary>
     /// Schedules a recurring reminder for the specified entity without creating a client.
     /// </summary>
-    /// <typeparam name="T">The type of the message payload to deliver when the reminder fires.</typeparam>
     /// <param name="entity">The entity that will receive the reminder.</param>
     /// <param name="key">The unique key for this reminder.</param>
     /// <param name="firstOccurrence">When the reminder should fire for the first time.</param>
@@ -183,12 +180,12 @@ public sealed class ReminderClientExtension : IExtension
     /// This is a convenience method for scheduling recurring reminders without creating a client first.
     /// Useful for bulk scheduling operations where you don't need to retain a client instance.
     /// </remarks>
-    public Task<ReminderProtocol.ReminderScheduled> ScheduleRecurringReminderAsync<T>(
+    public Task<ReminderProtocol.ReminderScheduled> ScheduleRecurringReminderAsync(
         ReminderEntity entity,
         ReminderKey key,
         DateTimeOffset firstOccurrence,
         TimeSpan interval,
-        T message,
+        object message,
         TimeSpan? maxDeliveryWindow = null,
         CancellationToken ct = default)
     {
@@ -196,7 +193,7 @@ public sealed class ReminderClientExtension : IExtension
             entity,
             key,
             firstOccurrence,
-            message!,
+            message,
             RepeatInterval: interval,
             MaxDeliveryWindow: maxDeliveryWindow);
         return SendToSchedulerAsync<ReminderProtocol.ScheduleReminder, ReminderProtocol.ReminderScheduled>(
@@ -211,7 +208,6 @@ public sealed class ReminderClientExtension : IExtension
     /// <summary>
     /// Schedules a recurring reminder for the specified shard region and entity ID without creating a client.
     /// </summary>
-    /// <typeparam name="T">The type of the message payload to deliver when the reminder fires.</typeparam>
     /// <param name="shardRegionName">The name of the shard region.</param>
     /// <param name="entityId">The entity identifier.</param>
     /// <param name="key">The unique key for this reminder.</param>
@@ -225,13 +221,13 @@ public sealed class ReminderClientExtension : IExtension
     /// This is a convenience method for scheduling recurring reminders without creating a client first.
     /// Useful for bulk scheduling operations where you don't need to retain a client instance.
     /// </remarks>
-    public Task<ReminderProtocol.ReminderScheduled> ScheduleRecurringReminderAsync<T>(
+    public Task<ReminderProtocol.ReminderScheduled> ScheduleRecurringReminderAsync(
         string shardRegionName,
         string entityId,
         ReminderKey key,
         DateTimeOffset firstOccurrence,
         TimeSpan interval,
-        T message,
+        object message,
         TimeSpan? maxDeliveryWindow = null,
         CancellationToken ct = default)
     {

--- a/src/Akka.Reminders/ReminderProtocol.cs
+++ b/src/Akka.Reminders/ReminderProtocol.cs
@@ -48,10 +48,17 @@ public readonly record struct ReminderDeadline
 }
 
 /// <summary>
+/// Marker interface for all reminder messages that need to cross node boundaries
+/// via Akka.Remote / Akka.Cluster. Used to bind the <see cref="Serialization.ReminderSerializer"/>
+/// to all wire-visible types in a single registration.
+/// </summary>
+public interface IReminderWireMessage;
+
+/// <summary>
 /// Wraps a reminder message with its originating entity, key, and occurrence metadata,
 /// allowing recipients to acknowledge delivery via <see cref="IReminderClient.AckAsync"/>.
 /// </summary>
-public class ReminderEnvelope : IWrappedMessage
+public class ReminderEnvelope : IWrappedMessage, IReminderWireMessage
 {
     /// <summary>
     /// The entity that scheduled this reminder.
@@ -278,7 +285,7 @@ public static class ReminderProtocol
     public sealed record ReminderAck(
         ReminderEntity Entity,
         ReminderKey Key,
-        DateTimeOffset DueTimeUtc) : IReminderCommand;
+        DateTimeOffset DueTimeUtc) : IReminderCommand, IReminderWireMessage;
 
     /// <summary>
     /// Returned by the scheduler after processing a <see cref="ReminderAck"/>.
@@ -288,7 +295,7 @@ public static class ReminderProtocol
         ReminderKey Key,
         DateTimeOffset DueTimeUtc,
         ReminderAckResponseCode ResponseCode,
-        string? Message = null) : IReminderResponse;
+        string? Message = null) : IReminderResponse, IReminderWireMessage;
 }
 
 /// <summary>

--- a/src/Akka.Reminders/ReminderProtocol.cs
+++ b/src/Akka.Reminders/ReminderProtocol.cs
@@ -1,10 +1,55 @@
-﻿using Akka.Actor;
+using System;
+using System.Collections.Generic;
+using Akka.Actor;
 
 namespace Akka.Reminders;
 
 /// <summary>
-/// Wraps a reminder message with its originating entity and key, allowing recipients
-/// to acknowledge delivery via <see cref="IReminderClient.AckAsync"/>.
+/// Absolute UTC deadline metadata attached to a delivered reminder occurrence.
+/// </summary>
+public readonly record struct ReminderDeadline
+{
+    public static ReminderDeadline Infinite => new(DateTimeOffset.MaxValue);
+
+    public ReminderDeadline(DateTimeOffset utcDateTime)
+    {
+        UtcDateTime = utcDateTime.ToUniversalTime();
+    }
+
+    /// <summary>
+    /// Absolute UTC timestamp after which the reminder occurrence is stale.
+    /// </summary>
+    public DateTimeOffset UtcDateTime { get; }
+
+    /// <summary>
+    /// Returns <c>true</c> when this deadline never expires.
+    /// </summary>
+    public bool IsInfinite => UtcDateTime == DateTimeOffset.MaxValue;
+
+    /// <summary>
+    /// Returns <c>true</c> when the supplied time is at or beyond the deadline.
+    /// </summary>
+    public bool IsExpired(DateTimeOffset now) => !IsInfinite && now >= UtcDateTime;
+
+    /// <summary>
+    /// Returns <c>true</c> when the current UTC time is at or beyond the deadline.
+    /// </summary>
+    public bool IsExpired() => IsExpired(DateTimeOffset.UtcNow);
+
+    /// <summary>
+    /// Returns the remaining time until the deadline.
+    /// </summary>
+    public TimeSpan TimeRemaining(DateTimeOffset now) => IsInfinite ? TimeSpan.MaxValue : UtcDateTime - now;
+
+    /// <summary>
+    /// Returns the remaining time until the deadline using the current UTC time.
+    /// </summary>
+    public TimeSpan TimeRemaining() => TimeRemaining(DateTimeOffset.UtcNow);
+}
+
+/// <summary>
+/// Wraps a reminder message with its originating entity, key, and occurrence metadata,
+/// allowing recipients to acknowledge delivery via <see cref="IReminderClient.AckAsync"/>.
 /// </summary>
 public class ReminderEnvelope : IWrappedMessage
 {
@@ -19,6 +64,17 @@ public class ReminderEnvelope : IWrappedMessage
     public ReminderKey Key { get; }
 
     /// <summary>
+    /// The original due time for this reminder occurrence in UTC.
+    /// </summary>
+    public DateTimeOffset DueTimeUtc { get; }
+
+    /// <summary>
+    /// Absolute delivery deadline for this reminder occurrence.
+    /// Unbounded reminders use <see cref="ReminderDeadline.Infinite"/>.
+    /// </summary>
+    public ReminderDeadline Deadline { get; }
+
+    /// <summary>
     /// The payload that was originally scheduled.
     /// </summary>
     public object Message { get; }
@@ -28,11 +84,20 @@ public class ReminderEnvelope : IWrappedMessage
     /// </summary>
     /// <param name="entity">The entity that scheduled this reminder.</param>
     /// <param name="key">The unique key identifying this reminder.</param>
+    /// <param name="dueTimeUtc">The original due time for this reminder occurrence.</param>
+    /// <param name="deadline">The absolute delivery deadline for this reminder occurrence.</param>
     /// <param name="message">The payload to deliver.</param>
-    public ReminderEnvelope(ReminderEntity entity, ReminderKey key, object message)
+    public ReminderEnvelope(
+        ReminderEntity entity,
+        ReminderKey key,
+        DateTimeOffset dueTimeUtc,
+        ReminderDeadline deadline,
+        object message)
     {
         Entity = entity;
         Key = key;
+        DueTimeUtc = dueTimeUtc.ToUniversalTime();
+        Deadline = deadline;
         Message = message;
     }
 }
@@ -53,9 +118,16 @@ public sealed class ReminderEnvelope<T> : ReminderEnvelope
     /// </summary>
     /// <param name="entity">The entity that scheduled this reminder.</param>
     /// <param name="key">The unique key identifying this reminder.</param>
+    /// <param name="dueTimeUtc">The original due time for this reminder occurrence.</param>
+    /// <param name="deadline">The absolute delivery deadline for this reminder occurrence.</param>
     /// <param name="message">The strongly-typed payload to deliver.</param>
-    public ReminderEnvelope(ReminderEntity entity, ReminderKey key, T message)
-        : base(entity, key, message!)
+    public ReminderEnvelope(
+        ReminderEntity entity,
+        ReminderKey key,
+        DateTimeOffset dueTimeUtc,
+        ReminderDeadline deadline,
+        T message)
+        : base(entity, key, dueTimeUtc, deadline, message!)
     {
         Message = message;
     }
@@ -150,9 +222,16 @@ public static class ReminderProtocol
         ReminderKey Key,
         DateTimeOffset When,
         object Message,
-        TimeSpan? RepeatInterval = null) : IReminderCommand
+        TimeSpan? RepeatInterval = null,
+        TimeSpan? MaxDeliveryWindow = null) : IReminderCommand
     {
-        public ScheduledReminder ToScheduledReminder() => new(Entity, Key, When, Message, RepeatInterval);
+        public ScheduledReminder ToScheduledReminder() => new(
+            Entity,
+            Key,
+            When,
+            Message,
+            RepeatInterval,
+            MaxDeliveryWindow: MaxDeliveryWindow);
     }
 
     public sealed record CancelReminder(ReminderEntity Entity, ReminderKey Key) : IReminderCommand;
@@ -196,7 +275,10 @@ public static class ReminderProtocol
     /// Sent by a recipient to confirm that a reminder has been successfully processed.
     /// Prevents duplicate delivery for at-least-once reminders.
     /// </summary>
-    public sealed record ReminderAck(ReminderEntity Entity, ReminderKey Key) : IReminderCommand;
+    public sealed record ReminderAck(
+        ReminderEntity Entity,
+        ReminderKey Key,
+        DateTimeOffset DueTimeUtc) : IReminderCommand;
 
     /// <summary>
     /// Returned by the scheduler after processing a <see cref="ReminderAck"/>.
@@ -204,6 +286,7 @@ public static class ReminderProtocol
     public sealed record ReminderAckResponse(
         ReminderEntity Entity,
         ReminderKey Key,
+        DateTimeOffset DueTimeUtc,
         ReminderAckResponseCode ResponseCode,
         string? Message = null) : IReminderResponse;
 }
@@ -229,15 +312,18 @@ public readonly record struct ReminderEntity(string ShardRegionName, string Enti
 /// </remarks>
 /// <param name="Entity">The entity identifier.</param>
 /// <param name="Key">The identifier for this specific reminder for this entity.</param>
-/// <param name="When">When we expect this message to fire.</param>
+/// <param name="When">When the next delivery attempt for this occurrence should happen.</param>
 /// <param name="Message">The payload to be delivered to <see cref="Entity"/>.
 ///
 /// This will be serialized using the configured binary serialization available
 /// for this type in Akka.NET and stored using the (serializerId, manifest) scheme that
 /// Akka.Persistence also uses.</param>
-/// <param name="RepeatInterval">If specified, this reminder will automatically reschedule itself after firing by creating a new entry with When = UtcNow + RepeatInterval. Null means one-time reminder.</param>
+/// <param name="RepeatInterval">If specified, this reminder will automatically create a new occurrence after delivery at the configured interval.</param>
 /// <param name="AttemptCount">Number of delivery attempts made for this reminder. Starts at 0, increments on each retry.</param>
 /// <param name="LastFailureReason">If the previous delivery attempt failed, contains the reason. Null if no failures or first attempt.</param>
+/// <param name="MaxDeliveryWindow">Optional maximum amount of time this occurrence remains actionable after its due time.</param>
+/// <param name="DeliveryDeadlineUtc">Absolute UTC deadline after which this occurrence is stale.</param>
+/// <param name="OccurrenceDueTimeUtc">Original due time for this occurrence. Null means <paramref name="When"/> is the due time.</param>
 public sealed record ScheduledReminder(
     ReminderEntity Entity,
     ReminderKey Key,
@@ -245,12 +331,27 @@ public sealed record ScheduledReminder(
     object Message,
     TimeSpan? RepeatInterval = null,
     int AttemptCount = 0,
-    string? LastFailureReason = null)
+    string? LastFailureReason = null,
+    TimeSpan? MaxDeliveryWindow = null,
+    DateTimeOffset? DeliveryDeadlineUtc = null,
+    DateTimeOffset? OccurrenceDueTimeUtc = null)
 {
     /// <summary>
-    /// Converts this scheduled reminder back to a <see cref="ReminderProtocol.ScheduleReminder"/> command.
-    /// Useful for retry scenarios where you need to resubmit the original command.
+    /// The original due time for this occurrence in UTC.
     /// </summary>
+    public DateTimeOffset DueTimeUtc => (OccurrenceDueTimeUtc ?? When).ToUniversalTime();
+
+    /// <summary>
+    /// Strongly-typed deadline metadata for this occurrence, if one exists.
+    /// </summary>
+    public ReminderDeadline Deadline => DeliveryDeadlineUtc.HasValue
+        ? new ReminderDeadline(DeliveryDeadlineUtc.Value)
+        : ReminderDeadline.Infinite;
+
+    /// <summary>
+     /// Converts this scheduled reminder back to a <see cref="ReminderProtocol.ScheduleReminder"/> command.
+     /// Useful for retry scenarios where you need to resubmit the original command.
+     /// </summary>
     public ReminderProtocol.ScheduleReminder ToScheduleReminder()
-        => new(Entity, Key, When, Message, RepeatInterval);
+        => new(Entity, Key, DueTimeUtc, Message, RepeatInterval, MaxDeliveryWindow);
 }

--- a/src/Akka.Reminders/ReminderProtocol.cs
+++ b/src/Akka.Reminders/ReminderProtocol.cs
@@ -1,4 +1,65 @@
-﻿namespace Akka.Reminders;
+﻿using Akka.Actor;
+
+namespace Akka.Reminders;
+
+/// <summary>
+/// Wraps a reminder message with its originating entity and key, allowing recipients
+/// to acknowledge delivery via <see cref="IReminderClient.AckAsync"/>.
+/// </summary>
+public class ReminderEnvelope : IWrappedMessage
+{
+    /// <summary>
+    /// The entity that scheduled this reminder.
+    /// </summary>
+    public ReminderEntity Entity { get; }
+
+    /// <summary>
+    /// The unique key identifying this reminder for the entity.
+    /// </summary>
+    public ReminderKey Key { get; }
+
+    /// <summary>
+    /// The payload that was originally scheduled.
+    /// </summary>
+    public object Message { get; }
+
+    /// <summary>
+    /// Creates a new <see cref="ReminderEnvelope"/>.
+    /// </summary>
+    /// <param name="entity">The entity that scheduled this reminder.</param>
+    /// <param name="key">The unique key identifying this reminder.</param>
+    /// <param name="message">The payload to deliver.</param>
+    public ReminderEnvelope(ReminderEntity entity, ReminderKey key, object message)
+    {
+        Entity = entity;
+        Key = key;
+        Message = message;
+    }
+}
+
+/// <summary>
+/// Strongly-typed wrapper for a reminder message, providing compile-time access to the payload type.
+/// </summary>
+/// <typeparam name="T">The type of the reminder payload.</typeparam>
+public sealed class ReminderEnvelope<T> : ReminderEnvelope
+{
+    /// <summary>
+    /// The strongly-typed payload that was originally scheduled.
+    /// </summary>
+    public new T Message { get; }
+
+    /// <summary>
+    /// Creates a new <see cref="ReminderEnvelope{T}"/>.
+    /// </summary>
+    /// <param name="entity">The entity that scheduled this reminder.</param>
+    /// <param name="key">The unique key identifying this reminder.</param>
+    /// <param name="message">The strongly-typed payload to deliver.</param>
+    public ReminderEnvelope(ReminderEntity entity, ReminderKey key, T message)
+        : base(entity, key, message!)
+    {
+        Message = message;
+    }
+}
 
 public interface IReminderProtocol
 {
@@ -61,6 +122,27 @@ public enum FetchRemindersResponseCode
     NotFound = 2,
 }
 
+/// <summary>
+/// Response codes for a reminder acknowledgement operation.
+/// </summary>
+public enum ReminderAckResponseCode
+{
+    /// <summary>
+    /// The reminder was found and successfully acknowledged.
+    /// </summary>
+    Success = 0,
+
+    /// <summary>
+    /// No reminder was found matching the entity and key.
+    /// </summary>
+    NotFound = 1,
+
+    /// <summary>
+    /// An error occurred while attempting to acknowledge the reminder.
+    /// </summary>
+    Error = 2
+}
+
 public static class ReminderProtocol
 {
     public sealed record ScheduleReminder(
@@ -108,6 +190,21 @@ public static class ReminderProtocol
         ReminderEntity Entity,
         FetchRemindersResponseCode ResponseCode,
         IReadOnlyList<ScheduledReminder> Reminders,
+        string? Message = null) : IReminderResponse;
+
+    /// <summary>
+    /// Sent by a recipient to confirm that a reminder has been successfully processed.
+    /// Prevents duplicate delivery for at-least-once reminders.
+    /// </summary>
+    public sealed record ReminderAck(ReminderEntity Entity, ReminderKey Key) : IReminderCommand;
+
+    /// <summary>
+    /// Returned by the scheduler after processing a <see cref="ReminderAck"/>.
+    /// </summary>
+    public sealed record ReminderAckResponse(
+        ReminderEntity Entity,
+        ReminderKey Key,
+        ReminderAckResponseCode ResponseCode,
         string? Message = null) : IReminderResponse;
 }
 

--- a/src/Akka.Reminders/ReminderScheduler.cs
+++ b/src/Akka.Reminders/ReminderScheduler.cs
@@ -75,6 +75,11 @@ public sealed record ReminderSettings
     public TimeSpan AckTimeoutCheckInterval { get; init; } = TimeSpan.FromSeconds(10);
 
     /// <summary>
+    /// Maximum number of acknowledgements to flush in a single storage batch.
+    /// </summary>
+    public int AckFlushBatchSize { get; init; } = 256;
+
+    /// <summary>
     /// Validates reminder settings.
     /// </summary>
     public void Validate()
@@ -86,6 +91,9 @@ public sealed record ReminderSettings
         if (DeliveryCommitChunkSize < 1)
             throw new ArgumentOutOfRangeException(nameof(DeliveryCommitChunkSize),
                 "DeliveryCommitChunkSize must be greater than or equal to 1.");
+        if (AckFlushBatchSize < 1)
+            throw new ArgumentOutOfRangeException(nameof(AckFlushBatchSize),
+                "AckFlushBatchSize must be greater than or equal to 1.");
     }
 }
 
@@ -129,6 +137,10 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
 
     private bool _processingReminders;
     private bool _processingAckTimeouts;
+    private bool _ackFlushScheduled;
+
+    private readonly Dictionary<(ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc), BufferedAckWrite>
+        _bufferedAcknowledgements = new();
 
     private readonly ILoggingAdapter _log = Context.GetLogger();
 
@@ -198,6 +210,33 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         }
     }
 
+    private sealed class FlushBufferedAcks
+    {
+        public static readonly FlushBufferedAcks Instance = new();
+
+        private FlushBufferedAcks()
+        {
+        }
+    }
+
+    private sealed class BufferedAckWrite
+    {
+        public BufferedAckWrite(ReminderAcknowledgement acknowledgement, IActorRef replyTo)
+        {
+            Acknowledgement = acknowledgement;
+            ReplyTo = [replyTo];
+        }
+
+        public ReminderAcknowledgement Acknowledgement { get; }
+
+        public List<IActorRef> ReplyTo { get; }
+
+        public void AddReplyTo(IActorRef replyTo)
+        {
+            ReplyTo.Add(replyTo);
+        }
+    }
+
     private void TryScheduleFetchReminders()
     {
         if (PendingReminders?.TotalPendingReminders > 0)
@@ -213,6 +252,95 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 delay = TimeSpan.Zero;
             Timers.StartSingleTimer(FetchReminders.Instance, FetchReminders.Instance, delay);
         }
+    }
+
+    private static (ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc) ToOccurrenceKey(
+        ReminderEntity entity,
+        ReminderKey key,
+        DateTimeOffset dueTimeUtc)
+        => (entity, key, dueTimeUtc.ToUniversalTime());
+
+    private void ScheduleBufferedAckFlush()
+    {
+        if (_ackFlushScheduled || _bufferedAcknowledgements.Count == 0)
+            return;
+
+        _ackFlushScheduled = true;
+        Self.Tell(FlushBufferedAcks.Instance);
+    }
+
+    private static ReminderAckResponseCode MapAckStatus(ReminderAckStorageStatus status)
+        => status switch
+        {
+            ReminderAckStorageStatus.Success => ReminderAckResponseCode.Success,
+            ReminderAckStorageStatus.NotFound => ReminderAckResponseCode.NotFound,
+            _ => ReminderAckResponseCode.Error
+        };
+
+    private async Task FlushBufferedAcksAsync()
+    {
+        while (_bufferedAcknowledgements.Count > 0)
+        {
+            var batch = _bufferedAcknowledgements
+                .Take(Settings.AckFlushBatchSize)
+                .ToList();
+
+            foreach (var entry in batch)
+                _bufferedAcknowledgements.Remove(entry.Key);
+
+            IReadOnlyList<AckResult> results;
+            try
+            {
+                using var cts = new CancellationTokenSource(Settings.StorageTimeout);
+                results = await Storage.AcknowledgeRemindersAsync(
+                    batch.Select(b => b.Value.Acknowledgement),
+                    cts.Token);
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex, "Failed to flush [{0}] buffered reminder acknowledgements", batch.Count);
+                results = batch
+                    .Select(b => new AckResult(
+                        b.Value.Acknowledgement.Entity,
+                        b.Value.Acknowledgement.Key,
+                        b.Value.Acknowledgement.DueTimeUtc,
+                        ReminderAckStorageStatus.Error,
+                        ex.Message))
+                    .ToList();
+            }
+
+            for (var i = 0; i < batch.Count; i++)
+            {
+                var buffered = batch[i].Value;
+                var result = i < results.Count
+                    ? results[i]
+                    : new AckResult(
+                        buffered.Acknowledgement.Entity,
+                        buffered.Acknowledgement.Key,
+                        buffered.Acknowledgement.DueTimeUtc,
+                        ReminderAckStorageStatus.Error,
+                        "Storage returned an incomplete acknowledgement batch result.");
+
+                var response = new ReminderProtocol.ReminderAckResponse(
+                    result.Entity,
+                    result.Key,
+                    result.DueTimeUtc,
+                    MapAckStatus(result.Status),
+                    result.ErrorMessage);
+
+                foreach (var replyTo in buffered.ReplyTo)
+                    replyTo.Tell(response, ActorRefs.NoSender);
+            }
+        }
+    }
+
+    private async Task FlushBufferedAcksIfAnyAsync()
+    {
+        if (_bufferedAcknowledgements.Count == 0)
+            return;
+
+        _ackFlushScheduled = false;
+        await FlushBufferedAcksAsync();
     }
 
     // Initial behavior: recover our schedule
@@ -259,6 +387,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 {
                     try
                     {
+                        await FlushBufferedAcksIfAnyAsync();
                         await ExpireRemindersAsync(TimeProvider.Now);
                         await ProcessReminders(TimeProvider.Now + Settings.MaxSlippage);
                     }
@@ -275,6 +404,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
             case ReminderProtocol.ScheduleReminder scheduleSingle:
             {
                 _log.Debug("Scheduling reminder {0}", scheduleSingle);
+                var replyTo = Sender;
                 RunTask(async () =>
                 {
                     using var cts = new CancellationTokenSource(Settings.StorageTimeout);
@@ -285,7 +415,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                         var shardRegion = ShardRegionResolver.TryResolve(reminder.Entity);
                         if (shardRegion is null)
                         {
-                            Sender.Tell(new ReminderProtocol.ReminderScheduled(scheduleSingle,
+                            replyTo.Tell(new ReminderProtocol.ReminderScheduled(scheduleSingle,
                                 ReminderScheduleResponseCode.ShardRegionNotFound,
                                 $"ShardRegion [{reminder.Entity.ShardRegionName}] not found"), ActorRefs.NoSender);
                             return;
@@ -293,7 +423,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
 
                         // persist the reminder
                         var r = await Storage.ScheduleReminderAsync(reminder, cts.Token);
-                        Sender.Tell(r, ActorRefs.NoSender);
+                        replyTo.Tell(r, ActorRefs.NoSender);
 
                         // bail out early if we couldn't schedule or if it was a no-op
                         if (r.ResponseCode != ReminderScheduleResponseCode.Success)
@@ -305,7 +435,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                     catch (Exception ex)
                     {
                         _log.Error(ex, "Failed to schedule reminder {0}", scheduleSingle);
-                        Sender.Tell(new ReminderProtocol.ReminderScheduled(scheduleSingle,
+                        replyTo.Tell(new ReminderProtocol.ReminderScheduled(scheduleSingle,
                             ReminderScheduleResponseCode.Error, ex.Message), ActorRefs.NoSender);
                     }
                 });
@@ -314,6 +444,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
             case ReminderProtocol.CancelReminder cancel:
             {
                 _log.Debug("Cancelling reminder {0}", cancel);
+                var replyTo = Sender;
                 RunTask(async () =>
                 {
                     try
@@ -321,7 +452,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                         using var cts = new CancellationTokenSource(Settings.StorageTimeout);
                         var cancellationResult =
                             await Storage.CancelReminderAsync(cancel.Entity, cancel.Key, cts.Token);
-                        Sender.Tell(cancellationResult, ActorRefs.NoSender);
+                        replyTo.Tell(cancellationResult, ActorRefs.NoSender);
 
                         await ReloadPendingOverviewAsync();
                         TryScheduleFetchReminders();
@@ -329,7 +460,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                     catch (Exception ex)
                     {
                         _log.Error(ex, "Failed to cancel reminder {0}", cancel);
-                        Sender.Tell(new ReminderProtocol.RemindersCancelled(cancel.Entity,
+                        replyTo.Tell(new ReminderProtocol.RemindersCancelled(cancel.Entity,
                             ReminderCancelResponseCode.Error,
                             [cancel.Key], ex.Message), ActorRefs.NoSender);
                     }
@@ -339,6 +470,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
             case ReminderProtocol.CancelAllReminders cancelAll:
             {
                 _log.Debug("Cancelling all reminders for {0}", cancelAll.Entity);
+                var replyTo = Sender;
                 RunTask(async () =>
                 {
                     try
@@ -346,7 +478,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                         using var cts = new CancellationTokenSource(Settings.StorageTimeout);
                         var cancellationResult =
                             await Storage.CancelAllRemindersForEntityAsync(cancelAll.Entity, cts.Token);
-                        Sender.Tell(cancellationResult, ActorRefs.NoSender);
+                        replyTo.Tell(cancellationResult, ActorRefs.NoSender);
 
                         await ReloadPendingOverviewAsync();
                         TryScheduleFetchReminders();
@@ -354,7 +486,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                     catch (Exception ex)
                     {
                         _log.Error(ex, "Failed to cancel all reminders for {0}", cancelAll);
-                        Sender.Tell(new ReminderProtocol.RemindersCancelled(cancelAll.Entity,
+                        replyTo.Tell(new ReminderProtocol.RemindersCancelled(cancelAll.Entity,
                             ReminderCancelResponseCode.Error,
                             [], ex.Message), ActorRefs.NoSender);
                     }
@@ -363,6 +495,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
             }
             case ReminderProtocol.GetReminders getReminders:
             {
+                var replyTo = Sender;
                 RunTask(async () =>
                 {
                     try
@@ -371,7 +504,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                         // TODO: add skip / take support
                         var queryResult = Storage.GetRemindersForEntityAsync(getReminders.Entity, ct:cts.Token);
                         var reminders = await queryResult;
-                        Sender.Tell(new ReminderProtocol.RemindersForEntity(
+                        replyTo.Tell(new ReminderProtocol.RemindersForEntity(
                             getReminders.Entity,
                             FetchRemindersResponseCode.Success,
                             reminders), ActorRefs.NoSender);
@@ -379,7 +512,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                     catch (Exception ex)
                     {
                         _log.Error(ex, "Failed to get reminders for {0}", getReminders);
-                        Sender.Tell(new ReminderProtocol.RemindersForEntity(getReminders.Entity,
+                        replyTo.Tell(new ReminderProtocol.RemindersForEntity(getReminders.Entity,
                             FetchRemindersResponseCode.Error,
                             [], ex.Message), ActorRefs.NoSender);
                     }
@@ -416,50 +549,28 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
             {
                 _log.Debug("Received ReminderAck for [{0}] / [{1}] due at [{2}]", ack.Entity, ack.Key, ack.DueTimeUtc);
                 var ackSender = Sender;
-
-                RunTask(async () =>
+                var occurrenceKey = ToOccurrenceKey(ack.Entity, ack.Key, ack.DueTimeUtc);
+                if (_bufferedAcknowledgements.TryGetValue(occurrenceKey, out var bufferedAck))
                 {
-                    try
-                    {
-                        using var ackCts = new CancellationTokenSource(Settings.StorageTimeout);
-                        var ackResult = await Storage.AcknowledgeReminderAsync(
-                            ack.Entity,
-                            ack.Key,
-                            ack.DueTimeUtc,
-                            TimeProvider.Now,
-                            ackCts.Token);
+                    bufferedAck.AddReplyTo(ackSender);
+                }
+                else
+                {
+                    _bufferedAcknowledgements[occurrenceKey] = new BufferedAckWrite(
+                        new ReminderAcknowledgement(ack.Entity, ack.Key, ack.DueTimeUtc, TimeProvider.Now),
+                        ackSender);
+                }
 
-                        if (ackResult.Success)
-                        {
-                            ackSender.Tell(new ReminderProtocol.ReminderAckResponse(
-                                ack.Entity,
-                                ack.Key,
-                                ack.DueTimeUtc,
-                                ReminderAckResponseCode.Success), ActorRefs.NoSender);
-                        }
-                        else
-                        {
-                            ackSender.Tell(new ReminderProtocol.ReminderAckResponse(
-                                ack.Entity,
-                                ack.Key,
-                                ack.DueTimeUtc,
-                                ReminderAckResponseCode.NotFound), ActorRefs.NoSender);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        _log.Error(ex,
-                            "Error processing ReminderAck for [{0}] / [{1}] / [{2}]",
-                            ack.Entity, ack.Key, ack.DueTimeUtc);
-                        ackSender.Tell(new ReminderProtocol.ReminderAckResponse(
-                            ack.Entity,
-                            ack.Key,
-                            ack.DueTimeUtc,
-                            ReminderAckResponseCode.Error,
-                            ex.Message),
-                            ActorRefs.NoSender);
-                    }
-                });
+                ScheduleBufferedAckFlush();
+                break;
+            }
+            case FlushBufferedAcks:
+            {
+                _ackFlushScheduled = false;
+                if (_bufferedAcknowledgements.Count == 0)
+                    break;
+
+                RunTask(FlushBufferedAcksAsync);
                 break;
             }
             case CheckAckTimeouts:
@@ -472,6 +583,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 {
                     try
                     {
+                        await FlushBufferedAcksIfAnyAsync();
                         await ExpireRemindersAsync(TimeProvider.Now);
                         await ProcessAckTimeouts();
                     }
@@ -721,34 +833,27 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
 
             var writeFailed = false;
 
-            if (occurrencesToUpsert.Count > 0)
-            {
-                try
-                {
-                    using var upsertCts = new CancellationTokenSource(Settings.StorageTimeout);
-                    var upsertResult = await Storage.UpsertReminderOccurrencesAsync(occurrencesToUpsert, upsertCts.Token);
-                    if (!upsertResult)
-                        writeFailed = true;
-                }
-                catch (Exception ex)
-                {
-                    _log.Error(ex, "Failed to upsert [{0}] ack-timeout retry reminder(s)", occurrencesToUpsert.Count);
-                    writeFailed = true;
-                }
-            }
+            var mutationBatch = new ReminderMutationBatch(
+                occurrencesToUpsert,
+                terminalReminders,
+                []);
 
-            if (!writeFailed && terminalReminders.Count > 0)
+            if (!mutationBatch.IsEmpty)
             {
                 try
                 {
-                    using var markCts = new CancellationTokenSource(Settings.StorageTimeout);
-                    var markResult = await Storage.MarkRemindersAsCompletedAsync(terminalReminders, markCts.Token);
-                    if (!markResult)
+                    using var mutationCts = new CancellationTokenSource(Settings.StorageTimeout);
+                    var mutationResult = await Storage.CommitReminderMutationsAsync(mutationBatch, mutationCts.Token);
+                    if (!mutationResult)
                         writeFailed = true;
                 }
                 catch (Exception ex)
                 {
-                    _log.Error(ex, "Failed to mark [{0}] timed-out reminder(s) as terminal", terminalReminders.Count);
+                    _log.Error(ex,
+                        "Failed to commit [{0}] ack-timeout mutation(s) with [{1}] retry upsert(s) and [{2}] terminal completion(s)",
+                        occurrencesToUpsert.Count + terminalReminders.Count,
+                        occurrencesToUpsert.Count,
+                        terminalReminders.Count);
                     writeFailed = true;
                 }
             }
@@ -907,65 +1012,27 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 }
 
                 var writeFailed = false;
+                var mutationBatch = new ReminderMutationBatch(
+                    occurrencesToUpsert,
+                    terminalReminders,
+                    remindersToAwaitAck);
 
-                if (occurrencesToUpsert.Count > 0)
+                if (!mutationBatch.IsEmpty)
                 {
                     try
                     {
-                        using var upsertCts = new CancellationTokenSource(Settings.StorageTimeout);
-                        var upsertResult = await Storage.UpsertReminderOccurrencesAsync(occurrencesToUpsert, upsertCts.Token);
-                        if (!upsertResult)
-                        {
-                            _log.Error(
-                                "UpsertReminderOccurrencesAsync returned false for [{0}] reminder occurrence(s)",
-                                occurrencesToUpsert.Count);
+                        using var mutationCts = new CancellationTokenSource(Settings.StorageTimeout);
+                        var mutationResult = await Storage.CommitReminderMutationsAsync(mutationBatch, mutationCts.Token);
+                        if (!mutationResult)
                             writeFailed = true;
-                        }
                     }
                     catch (Exception ex)
                     {
                         _log.Error(ex,
-                            "Failed to upsert [{0}] reminder occurrence(s)",
-                            occurrencesToUpsert.Count);
-                        writeFailed = true;
-                    }
-                }
-
-                if (!writeFailed && terminalReminders.Count > 0)
-                {
-                    try
-                    {
-                        using var markCts = new CancellationTokenSource(Settings.StorageTimeout);
-                        var markResult = await Storage.MarkRemindersAsCompletedAsync(terminalReminders, markCts.Token);
-                        if (!markResult)
-                        {
-                            _log.Error(
-                                "MarkRemindersAsCompletedAsync returned false for [{0}] terminal reminder occurrence(s)",
-                                terminalReminders.Count);
-                            writeFailed = true;
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        _log.Error(ex,
-                            "Failed to mark [{0}] reminder occurrence(s) as terminal",
-                            terminalReminders.Count);
-                        writeFailed = true;
-                    }
-                }
-
-                if (!writeFailed && remindersToAwaitAck.Count > 0)
-                {
-                    try
-                    {
-                        using var awaitAckCts = new CancellationTokenSource(Settings.StorageTimeout);
-                        var awaitAckResult = await Storage.MarkRemindersAsAwaitingAckAsync(remindersToAwaitAck, awaitAckCts.Token);
-                        if (!awaitAckResult)
-                            writeFailed = true;
-                    }
-                    catch (Exception ex)
-                    {
-                        _log.Error(ex, "Failed to mark [{0}] reminder occurrence(s) as awaiting ack", remindersToAwaitAck.Count);
+                            "Failed to commit reminder mutation chunk with [{0}] upsert(s), [{1}] completion(s), and [{2}] awaiting-ack transition(s)",
+                            occurrencesToUpsert.Count,
+                            terminalReminders.Count,
+                            remindersToAwaitAck.Count);
                         writeFailed = true;
                     }
                 }

--- a/src/Akka.Reminders/ReminderScheduler.cs
+++ b/src/Akka.Reminders/ReminderScheduler.cs
@@ -400,6 +400,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 }
 
                 _awaitingAck.Remove(lookupKey);
+
                 var ackedReminder = entry.Reminder;
 
                 RunTask(async () =>
@@ -408,7 +409,8 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                     {
                         if (ackedReminder.RepeatInterval.HasValue)
                         {
-                            // Recurring reminder: schedule the next occurrence
+                            // Recurring reminder: schedule the next occurrence.
+                            // ScheduleReminderAsync clears any lingering AwaitingAck state for the key.
                             var nextOccurrence = ackedReminder with
                             {
                                 When = TimeProvider.Now.Add(ackedReminder.RepeatInterval.Value),
@@ -436,7 +438,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                         }
                         else
                         {
-                            // One-time reminder: mark as delivered
+                            // One-time reminder: mark as delivered and clear AwaitingAck state.
                             var completed = new CompletedReminder(
                                 ackedReminder.Entity, ackedReminder.Key,
                                 TimeProvider.Now, ReminderCompletionStatus.Delivered);
@@ -644,6 +646,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 // go through the immediate retry / permanent-fail path.
                 var failedRemindersToRetry = new List<ScheduledReminder>();
                 var permanentlyFailedReminders = new List<CompletedReminder>();
+                var deliveredReminders = new List<AwaitingAckReminder>();
 
                 foreach (var reminder in chunk)
                 {
@@ -683,15 +686,43 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
 
                         var ackDeadline = TimeProvider.Now.Add(Settings.AckTimeout);
                         _awaitingAck[(reminder.Entity, reminder.Key)] = (reminder, ackDeadline);
+                        deliveredReminders.Add(new AwaitingAckReminder(
+                            reminder.Entity, reminder.Key, completedAt, ackDeadline));
 
                         totalDelivered += 1;
                     }
                 }
 
+                // Phase 2.5: Persist AwaitingAck state for successfully delivered reminders.
+                // This prevents re-delivery on the next fetch and enables the circuit breaker
+                // to detect storage failures in the delivery hot path.
+                var writeFailed = false;
+                if (deliveredReminders.Count > 0)
+                {
+                    try
+                    {
+                        using var ackCts = new CancellationTokenSource(Settings.StorageTimeout);
+                        var ackResult = await Storage.MarkRemindersAsAwaitingAckAsync(deliveredReminders, ackCts.Token);
+                        if (!ackResult)
+                        {
+                            _log.Error(
+                                "MarkRemindersAsAwaitingAckAsync returned false for [{0}] delivered reminders",
+                                deliveredReminders.Count);
+                            writeFailed = true;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _log.Error(ex,
+                            "Failed to mark [{0}] reminders as awaiting ack",
+                            deliveredReminders.Count);
+                        writeFailed = true;
+                    }
+                }
+
                 // Phase 3: Mark permanently failed reminders as complete in storage.
                 // Delivered reminders are NOT marked here — that happens in the ReminderAck handler.
-                var writeFailed = false;
-                if (permanentlyFailedReminders.Count > 0)
+                if (!writeFailed && permanentlyFailedReminders.Count > 0)
                 {
                     try
                     {

--- a/src/Akka.Reminders/ReminderScheduler.cs
+++ b/src/Akka.Reminders/ReminderScheduler.cs
@@ -212,15 +212,6 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         }
     }
 
-    private sealed class RefreshAckTimeoutSchedule
-    {
-        public static readonly RefreshAckTimeoutSchedule Instance = new();
-
-        private RefreshAckTimeoutSchedule()
-        {
-        }
-    }
-
     private sealed class FlushBufferedAcks
     {
         public static readonly FlushBufferedAcks Instance = new();
@@ -417,13 +408,19 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
     {
         switch (message)
         {
-            case ReminderOverview overview:
-                _log.Info("Loaded reminder overview from storage: {0}", overview);
-                PendingReminders = overview;
+            case InitResult init:
+                _log.Info("Loaded reminder overview from storage: {0}", init.Overview);
+                PendingReminders = init.Overview;
+
+                // Schedule ack timeout check BEFORE unstashing so the mailbox is
+                // fully ready when client messages are replayed — no RunTask gap.
+                if (init.NextAckDeadline.HasValue)
+                    ScheduleAckTimeoutCheck(init.NextAckDeadline.Value);
+
                 Become(Scheduling);
-                Stash.UnstashAll(); // Process any messages that arrived during initialization
+                Stash.UnstashAll();
                 TryScheduleFetchReminders();
-                Timers.Cancel(RestartBackoffTimer.Instance); // if needed
+                Timers.Cancel(RestartBackoffTimer.Instance);
                 break;
             case Status.Failure failure:
                 _log.Error(failure.Cause, "Failed to load reminder overview from storage - restarting...");
@@ -666,21 +663,6 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 });
                 break;
             }
-            case RefreshAckTimeoutSchedule:
-            {
-                RunTask(async () =>
-                {
-                    try
-                    {
-                        await RefreshAckTimeoutScheduleFromStorageAsync();
-                    }
-                    catch (Exception ex)
-                    {
-                        _log.Warning(ex, "Failed to refresh next ack-timeout schedule from storage");
-                    }
-                });
-                break;
-            }
             case CheckAckTimeoutsCompleted:
                 _processingAckTimeouts = false;
                 break;
@@ -702,8 +684,6 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
             Settings.PruneInterval,
             Settings.PruneInterval);
         _log.Info("Scheduled periodic pruning every {0}", Settings.PruneInterval);
-
-        Self.Tell(RefreshAckTimeoutSchedule.Instance);
     }
 
     protected override void PostStop()
@@ -735,17 +715,26 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         }
     }
 
+    /// <summary>
+    /// Carries both the reminder overview and the next ack-timeout deadline so that
+    /// initialization completes in a single PipeTo — no stashed RunTask to block
+    /// the mailbox after UnstashAll.
+    /// </summary>
+    private sealed record InitResult(ReminderOverview Overview, DateTimeOffset? NextAckDeadline);
+
     private Task LoadReminderOverview()
     {
-        async Task<ReminderOverview> LoadAsync()
+        async Task<InitResult> LoadAsync()
         {
             await ExpireRemindersAsync(TimeProvider.Now);
             using var cts = new CancellationTokenSource(Settings.StorageTimeout);
-            return await Storage.GetRemindersOverviewAsync(TimeProvider.Now, cts.Token);
+            var overview = await Storage.GetRemindersOverviewAsync(TimeProvider.Now, cts.Token);
+            var nextAckDeadline = await Storage.GetNextAwaitingAckDeadlineAsync(cts.Token);
+            return new InitResult(overview, nextAckDeadline);
         }
 
-        var reminders = LoadAsync();
-        return reminders.PipeTo(Self, success: overview => overview, failure: ex => new Status.Failure(ex));
+        var init = LoadAsync();
+        return init.PipeTo(Self, success: r => r, failure: ex => new Status.Failure(ex));
     }
 
     private static readonly Type OpenGenericEnvelopeType = typeof(ReminderEnvelope<>);

--- a/src/Akka.Reminders/ReminderScheduler.cs
+++ b/src/Akka.Reminders/ReminderScheduler.cs
@@ -138,6 +138,8 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
     private bool _processingReminders;
     private bool _processingAckTimeouts;
     private bool _ackFlushScheduled;
+    private ICancelable? _nextAckTimeoutCheck;
+    private DateTimeOffset? _nextAckTimeoutAt;
 
     private readonly Dictionary<(ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc), BufferedAckWrite>
         _bufferedAcknowledgements = new();
@@ -210,6 +212,15 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         }
     }
 
+    private sealed class RefreshAckTimeoutSchedule
+    {
+        public static readonly RefreshAckTimeoutSchedule Instance = new();
+
+        private RefreshAckTimeoutSchedule()
+        {
+        }
+    }
+
     private sealed class FlushBufferedAcks
     {
         public static readonly FlushBufferedAcks Instance = new();
@@ -269,6 +280,56 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         Self.Tell(FlushBufferedAcks.Instance);
     }
 
+    private void CancelAckTimeoutCheck()
+    {
+        _nextAckTimeoutCheck?.Cancel();
+        _nextAckTimeoutCheck = null;
+        _nextAckTimeoutAt = null;
+    }
+
+    private void ScheduleAckTimeoutCheck(DateTimeOffset ackDeadlineUtc)
+    {
+        ackDeadlineUtc = ackDeadlineUtc.ToUniversalTime();
+
+        if (_nextAckTimeoutAt.HasValue && _nextAckTimeoutAt.Value <= ackDeadlineUtc)
+            return;
+
+        _nextAckTimeoutCheck?.Cancel();
+        _nextAckTimeoutAt = ackDeadlineUtc;
+
+        var delay = ackDeadlineUtc - TimeProvider.Now;
+        if (delay < TimeSpan.Zero)
+            delay = TimeSpan.Zero;
+
+        _nextAckTimeoutCheck = Context.System.Scheduler.ScheduleTellOnceCancelable(
+            delay,
+            Self,
+            CheckAckTimeouts.Instance,
+            Self);
+    }
+
+    private void TrackAckDeadlines(IEnumerable<AwaitingAckReminder> reminders)
+    {
+        var nextDeadline = reminders
+            .Select(r => r.AckDeadline.ToUniversalTime())
+            .DefaultIfEmpty(DateTimeOffset.MaxValue)
+            .Min();
+
+        if (nextDeadline != DateTimeOffset.MaxValue)
+            ScheduleAckTimeoutCheck(nextDeadline);
+    }
+
+    private async Task RefreshAckTimeoutScheduleFromStorageAsync()
+    {
+        using var cts = new CancellationTokenSource(Settings.StorageTimeout);
+        var nextAckDeadline = await Storage.GetNextAwaitingAckDeadlineAsync(cts.Token);
+
+        if (nextAckDeadline.HasValue)
+            ScheduleAckTimeoutCheck(nextAckDeadline.Value);
+        else
+            CancelAckTimeoutCheck();
+    }
+
     private static ReminderAckResponseCode MapAckStatus(ReminderAckStorageStatus status)
         => status switch
         {
@@ -279,6 +340,8 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
 
     private async Task FlushBufferedAcksAsync()
     {
+        var shouldRefreshAckTimeoutSchedule = false;
+
         while (_bufferedAcknowledgements.Count > 0)
         {
             var batch = _bufferedAcknowledgements
@@ -330,8 +393,14 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
 
                 foreach (var replyTo in buffered.ReplyTo)
                     replyTo.Tell(response, ActorRefs.NoSender);
+
+                if (result.Success)
+                    shouldRefreshAckTimeoutSchedule = true;
             }
         }
+
+        if (shouldRefreshAckTimeoutSchedule)
+            await RefreshAckTimeoutScheduleFromStorageAsync();
     }
 
     private async Task FlushBufferedAcksIfAnyAsync()
@@ -578,6 +647,9 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 if (_processingAckTimeouts)
                     break;
 
+                _nextAckTimeoutCheck = null;
+                _nextAckTimeoutAt = null;
+
                 _processingAckTimeouts = true;
                 RunTask(async () =>
                 {
@@ -590,6 +662,21 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                     finally
                     {
                         Self.Tell(CheckAckTimeoutsCompleted.Instance);
+                    }
+                });
+                break;
+            }
+            case RefreshAckTimeoutSchedule:
+            {
+                RunTask(async () =>
+                {
+                    try
+                    {
+                        await RefreshAckTimeoutScheduleFromStorageAsync();
+                    }
+                    catch (Exception ex)
+                    {
+                        _log.Warning(ex, "Failed to refresh next ack-timeout schedule from storage");
                     }
                 });
                 break;
@@ -616,13 +703,13 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
             Settings.PruneInterval);
         _log.Info("Scheduled periodic pruning every {0}", Settings.PruneInterval);
 
-        // Schedule periodic scan for reminders that have been delivered but not acknowledged
-        Timers.StartPeriodicTimer(
-            CheckAckTimeouts.Instance,
-            CheckAckTimeouts.Instance,
-            Settings.AckTimeoutCheckInterval,
-            Settings.AckTimeoutCheckInterval);
-        _log.Info("Scheduled ack-timeout check every {0}", Settings.AckTimeoutCheckInterval);
+        Self.Tell(RefreshAckTimeoutSchedule.Instance);
+    }
+
+    protected override void PostStop()
+    {
+        CancelAckTimeoutCheck();
+        base.PostStop();
     }
 
     private async Task ReloadPendingOverviewAsync()
@@ -772,7 +859,8 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         {
             When = retryAt,
             AttemptCount = reminder.AttemptCount + 1,
-            LastFailureReason = failureReason
+            LastFailureReason = failureReason,
+            OccurrenceDueTimeUtc = reminder.DueTimeUtc
         };
         terminalStatus = ReminderCompletionStatus.Pending;
         return true;
@@ -875,6 +963,8 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
             TryScheduleFetchReminders();
         }
 
+        await RefreshAckTimeoutScheduleFromStorageAsync();
+
         if (totalRetried > 0 || totalFailed > 0 || totalExpired > 0)
         {
             _log.Info(
@@ -891,6 +981,8 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         var totalRetried = 0;
         var totalFailed = 0;
         var totalExpired = 0;
+        var latestOverview = PendingReminders;
+        var needsOverviewReload = false;
 
         // When the write circuit is open, probe with a single reminder to test
         // write availability before resuming full-batch processing. This limits
@@ -913,12 +1005,14 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 batch = await Storage.GetNextRemindersAsync(untilDeadline, TimeProvider.Now,
                     new ReminderBatchSize(effectiveBatchSize), fetchCts.Token);
                 _log.Info("Fetched {0} due reminders (batch)", batch.Reminders.Count);
+                latestOverview = batch.NextOverview;
             }
             catch (Exception ex)
             {
                 // If fetch fails, no reminders were delivered and no write operations were attempted,
                 // so the write circuit remains unchanged.
                 _log.Error(ex, "Failed to fetch due reminders from storage");
+                needsOverviewReload = true;
                 break;
             }
 
@@ -927,6 +1021,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
 
             var stopProcessing = false;
             var recoveredFromProbe = false;
+            var batchOverview = batch.NextOverview;
 
             // Process the fetched batch in smaller chunks to cap duplicate blast radius
             // if writes fail after delivery.
@@ -1044,9 +1139,21 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                                  "Pausing batch processing until writes recover. " +
                                  "Delivered [{0}] reminders in this run before failure.",
                         totalDelivered);
+                    needsOverviewReload = true;
                     stopProcessing = true;
                     break;
                 }
+
+                if (occurrencesToUpsert.Count > 0)
+                {
+                    foreach (var pendingReminder in occurrencesToUpsert)
+                    {
+                        batchOverview = batchOverview.Apply(pendingReminder, completedAt).newOverview;
+                    }
+                }
+
+                if (remindersToAwaitAck.Count > 0)
+                    TrackAckDeadlines(remindersToAwaitAck);
 
                 if (_writeCircuitOpen)
                 {
@@ -1074,6 +1181,8 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 }
             }
 
+            latestOverview = batchOverview;
+
             if (stopProcessing)
                 break;
 
@@ -1087,15 +1196,21 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 break;
         }
 
-        // Final overview reload with its own CTS
-        try
+        if (needsOverviewReload)
         {
-            using var overviewCts = new CancellationTokenSource(Settings.StorageTimeout);
-            PendingReminders = await Storage.GetRemindersOverviewAsync(TimeProvider.Now, overviewCts.Token);
+            try
+            {
+                using var overviewCts = new CancellationTokenSource(Settings.StorageTimeout);
+                PendingReminders = await Storage.GetRemindersOverviewAsync(TimeProvider.Now, overviewCts.Token);
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex, "Failed to reload reminder overview after processing");
+            }
         }
-        catch (Exception ex)
+        else
         {
-            _log.Error(ex, "Failed to reload reminder overview after processing");
+            PendingReminders = latestOverview;
         }
 
         _log.Info(

--- a/src/Akka.Reminders/ReminderScheduler.cs
+++ b/src/Akka.Reminders/ReminderScheduler.cs
@@ -1166,7 +1166,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                         delivery.Reminder.DueTimeUtc,
                         delivery.Reminder.Deadline,
                         delivery.Reminder.Message);
-                    ShardRegionResolver.DeliverReminder(delivery.Reminder.Entity, envelope, Self);
+                    ShardRegionResolver.DeliverReminder(delivery.Reminder.Entity, envelope);
                     totalDelivered += 1;
                 }
             }

--- a/src/Akka.Reminders/ReminderScheduler.cs
+++ b/src/Akka.Reminders/ReminderScheduler.cs
@@ -70,11 +70,6 @@ public sealed record ReminderSettings
     public TimeSpan AckTimeout { get; init; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
-    /// How frequently to scan for reminders whose ack deadline has passed.
-    /// </summary>
-    public TimeSpan AckTimeoutCheckInterval { get; init; } = TimeSpan.FromSeconds(10);
-
-    /// <summary>
     /// Maximum number of acknowledgements to flush in a single storage batch.
     /// </summary>
     public int AckFlushBatchSize { get; init; } = 256;

--- a/src/Akka.Reminders/ReminderScheduler.cs
+++ b/src/Akka.Reminders/ReminderScheduler.cs
@@ -484,14 +484,20 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
 
                         // persist the reminder
                         var r = await Storage.ScheduleReminderAsync(reminder, cts.Token);
-                        replyTo.Tell(r, ActorRefs.NoSender);
 
                         // bail out early if we couldn't schedule or if it was a no-op
                         if (r.ResponseCode != ReminderScheduleResponseCode.Success)
+                        {
+                            replyTo.Tell(r, ActorRefs.NoSender);
                             return;
+                        }
 
                         await ReloadPendingOverviewAsync();
                         TryScheduleFetchReminders();
+
+                        // Reply AFTER the fetch timer is scheduled so the caller
+                        // knows the scheduler is ready to process this reminder.
+                        replyTo.Tell(r, ActorRefs.NoSender);
                     }
                     catch (Exception ex)
                     {
@@ -513,10 +519,10 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                         using var cts = new CancellationTokenSource(Settings.StorageTimeout);
                         var cancellationResult =
                             await Storage.CancelReminderAsync(cancel.Entity, cancel.Key, cts.Token);
-                        replyTo.Tell(cancellationResult, ActorRefs.NoSender);
 
                         await ReloadPendingOverviewAsync();
                         TryScheduleFetchReminders();
+                        replyTo.Tell(cancellationResult, ActorRefs.NoSender);
                     }
                     catch (Exception ex)
                     {
@@ -539,10 +545,10 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                         using var cts = new CancellationTokenSource(Settings.StorageTimeout);
                         var cancellationResult =
                             await Storage.CancelAllRemindersForEntityAsync(cancelAll.Entity, cts.Token);
-                        replyTo.Tell(cancellationResult, ActorRefs.NoSender);
 
                         await ReloadPendingOverviewAsync();
                         TryScheduleFetchReminders();
+                        replyTo.Tell(cancellationResult, ActorRefs.NoSender);
                     }
                     catch (Exception ex)
                     {

--- a/src/Akka.Reminders/ReminderScheduler.cs
+++ b/src/Akka.Reminders/ReminderScheduler.cs
@@ -54,6 +54,16 @@ public sealed record ReminderSettings
     public TimeSpan RetryBackoffBase { get; init; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
+    /// How long to wait for an acknowledgement after delivering a reminder before retrying.
+    /// </summary>
+    public TimeSpan AckTimeout { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// How frequently to scan for reminders whose ack deadline has passed.
+    /// </summary>
+    public TimeSpan AckTimeoutCheckInterval { get; init; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
     /// Validates reminder settings.
     /// </summary>
     public void Validate()
@@ -106,6 +116,14 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
     /// </summary>
     private bool _writeCircuitOpen;
 
+    /// <summary>
+    /// Tracks reminders that have been delivered to their target shard region but have not yet
+    /// been acknowledged. Keyed by (Entity, Key). Each entry stores the original reminder and
+    /// the absolute deadline by which an ack must arrive before the reminder is retried or
+    /// permanently failed.
+    /// </summary>
+    private readonly Dictionary<(ReminderEntity Entity, ReminderKey Key), (ScheduledReminder Reminder, DateTimeOffset AckDeadline)> _awaitingAck = new();
+
     private readonly ILoggingAdapter _log = Context.GetLogger();
 
     public IStash Stash { get; set; } = null!;
@@ -139,6 +157,19 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         public static readonly PruneCompletedReminders Instance = new();
 
         private PruneCompletedReminders()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Periodic timer message that triggers a scan of <see cref="_awaitingAck"/> to find
+    /// reminders whose ack deadline has elapsed and either retry or permanently fail them.
+    /// </summary>
+    private sealed class CheckAckTimeouts
+    {
+        public static readonly CheckAckTimeouts Instance = new();
+
+        private CheckAckTimeouts()
         {
         }
     }
@@ -352,6 +383,170 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 });
                 break;
             }
+            case ReminderProtocol.ReminderAck ack:
+            {
+                _log.Debug("Received ReminderAck for [{0}] / [{1}]", ack.Entity, ack.Key);
+                var ackSender = Sender;
+                var lookupKey = (ack.Entity, ack.Key);
+
+                if (!_awaitingAck.TryGetValue(lookupKey, out var entry))
+                {
+                    // Late or duplicate ack — harmless, nothing to do
+                    _log.Debug("ReminderAck for [{0}] / [{1}] not found in awaiting-ack set (late or duplicate)",
+                        ack.Entity, ack.Key);
+                    ackSender.Tell(new ReminderProtocol.ReminderAckResponse(
+                        ack.Entity, ack.Key, ReminderAckResponseCode.NotFound), ActorRefs.NoSender);
+                    break;
+                }
+
+                _awaitingAck.Remove(lookupKey);
+                var ackedReminder = entry.Reminder;
+
+                RunTask(async () =>
+                {
+                    try
+                    {
+                        if (ackedReminder.RepeatInterval.HasValue)
+                        {
+                            // Recurring reminder: schedule the next occurrence
+                            var nextOccurrence = ackedReminder with
+                            {
+                                When = TimeProvider.Now.Add(ackedReminder.RepeatInterval.Value),
+                                AttemptCount = 0,
+                                LastFailureReason = null
+                            };
+                            using var scheduleCts = new CancellationTokenSource(Settings.StorageTimeout);
+                            var result = await Storage.ScheduleReminderAsync(nextOccurrence, scheduleCts.Token);
+                            if (result.ResponseCode != ReminderScheduleResponseCode.Success)
+                            {
+                                _log.Error(
+                                    "Failed to schedule next occurrence of recurring reminder [{0}] / [{1}]: {2}",
+                                    ackedReminder.Entity, ackedReminder.Key, result.Message ?? "Unknown error");
+                            }
+                            else
+                            {
+                                _log.Info("Scheduled next occurrence of recurring reminder [{0}] / [{1}] at {2}",
+                                    ackedReminder.Entity, ackedReminder.Key, nextOccurrence.When);
+                                var (newOverview, hasNewerDate) =
+                                    PendingReminders.Apply(nextOccurrence, TimeProvider.Now);
+                                PendingReminders = newOverview;
+                                if (hasNewerDate)
+                                    TryScheduleFetchReminders();
+                            }
+                        }
+                        else
+                        {
+                            // One-time reminder: mark as delivered
+                            var completed = new CompletedReminder(
+                                ackedReminder.Entity, ackedReminder.Key,
+                                TimeProvider.Now, ReminderCompletionStatus.Delivered);
+                            using var markCts = new CancellationTokenSource(Settings.StorageTimeout);
+                            var markResult = await Storage.MarkRemindersAsCompletedAsync([completed], markCts.Token);
+                            if (!markResult)
+                            {
+                                _log.Error(
+                                    "MarkRemindersAsCompletedAsync returned false for acked reminder [{0}] / [{1}]",
+                                    ackedReminder.Entity, ackedReminder.Key);
+                            }
+                        }
+
+                        ackSender.Tell(new ReminderProtocol.ReminderAckResponse(
+                            ack.Entity, ack.Key, ReminderAckResponseCode.Success), ActorRefs.NoSender);
+                    }
+                    catch (Exception ex)
+                    {
+                        _log.Error(ex, "Error processing ReminderAck for [{0}] / [{1}]",
+                            ack.Entity, ack.Key);
+                        ackSender.Tell(new ReminderProtocol.ReminderAckResponse(
+                            ack.Entity, ack.Key, ReminderAckResponseCode.Error, ex.Message),
+                            ActorRefs.NoSender);
+                    }
+                });
+                break;
+            }
+            case CheckAckTimeouts:
+            {
+                var now = TimeProvider.Now;
+                var timedOut = _awaitingAck
+                    .Where(kvp => kvp.Value.AckDeadline <= now)
+                    .ToList();
+
+                if (timedOut.Count == 0)
+                    break;
+
+                _log.Debug("Ack-timeout scan found [{0}] timed-out reminder(s)", timedOut.Count);
+
+                foreach (var kvp in timedOut)
+                {
+                    _awaitingAck.Remove(kvp.Key);
+                    var timedOutReminder = kvp.Value.Reminder;
+
+                    if (timedOutReminder.AttemptCount + 1 < Settings.MaxDeliveryAttempts)
+                    {
+                        // Schedule a retry with exponential backoff
+                        var backoffSeconds =
+                            Settings.RetryBackoffBase.TotalSeconds * Math.Pow(2, timedOutReminder.AttemptCount);
+                        var retryReminder = timedOutReminder with
+                        {
+                            When = now.Add(TimeSpan.FromSeconds(backoffSeconds)),
+                            AttemptCount = timedOutReminder.AttemptCount + 1,
+                            LastFailureReason = "Ack timeout"
+                        };
+
+                        _log.Warning(
+                            "Ack timeout for reminder [{0}] / [{1}] (attempt {2} of {3}). Retrying at {4}.",
+                            timedOutReminder.Entity, timedOutReminder.Key,
+                            retryReminder.AttemptCount, Settings.MaxDeliveryAttempts,
+                            retryReminder.When);
+
+                        RunTask(async () =>
+                        {
+                            try
+                            {
+                                using var retryCts = new CancellationTokenSource(Settings.StorageTimeout);
+                                await Storage.ScheduleReminderAsync(retryReminder, retryCts.Token);
+                                var (newOverview, hasNewerDate) =
+                                    PendingReminders.Apply(retryReminder, TimeProvider.Now);
+                                PendingReminders = newOverview;
+                                if (hasNewerDate)
+                                    TryScheduleFetchReminders();
+                            }
+                            catch (Exception ex)
+                            {
+                                _log.Error(ex,
+                                    "Failed to schedule ack-timeout retry for reminder [{0}] / [{1}]",
+                                    retryReminder.Entity, retryReminder.Key);
+                            }
+                        });
+                    }
+                    else
+                    {
+                        _log.Error(
+                            "Reminder [{0}] / [{1}] exceeded max delivery attempts ({2}) after ack timeout. Marking as permanently failed.",
+                            timedOutReminder.Entity, timedOutReminder.Key, Settings.MaxDeliveryAttempts);
+
+                        RunTask(async () =>
+                        {
+                            try
+                            {
+                                var failed = new CompletedReminder(
+                                    timedOutReminder.Entity, timedOutReminder.Key,
+                                    TimeProvider.Now, ReminderCompletionStatus.Failed);
+                                using var failCts = new CancellationTokenSource(Settings.StorageTimeout);
+                                await Storage.MarkRemindersAsCompletedAsync([failed], failCts.Token);
+                            }
+                            catch (Exception ex)
+                            {
+                                _log.Error(ex,
+                                    "Failed to mark ack-timeout reminder [{0}] / [{1}] as permanently failed",
+                                    timedOutReminder.Entity, timedOutReminder.Key);
+                            }
+                        });
+                    }
+                }
+
+                break;
+            }
             default:
                 Unhandled(message);
                 break;
@@ -370,6 +565,14 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
             Settings.PruneInterval,
             Settings.PruneInterval);
         _log.Info("Scheduled periodic pruning every {0}", Settings.PruneInterval);
+
+        // Schedule periodic scan for reminders that have been delivered but not acknowledged
+        Timers.StartPeriodicTimer(
+            CheckAckTimeouts.Instance,
+            CheckAckTimeouts.Instance,
+            Settings.AckTimeoutCheckInterval,
+            Settings.AckTimeoutCheckInterval);
+        _log.Info("Scheduled ack-timeout check every {0}", Settings.AckTimeoutCheckInterval);
     }
 
     private Task LoadReminderOverview()
@@ -382,7 +585,6 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
     private async Task ProcessReminders(DateTimeOffset untilDeadline)
     {
         var totalDelivered = 0;
-        var totalRecurring = 0;
         var totalRetried = 0;
         var totalFailed = 0;
 
@@ -435,9 +637,11 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 // by (Status, When) efficiently.
                 var completedAt = TimeProvider.Now;
 
-                // Phase 2: Deliver reminders and categorize results
-                var completedReminders = new List<CompletedReminder>();
-                var recurringRemindersToSchedule = new List<ScheduledReminder>();
+                // Phase 2: Deliver reminders and categorize results.
+                // Successfully delivered reminders are placed in _awaitingAck; completion
+                // and recurring rescheduling happen only after the target entity sends a
+                // ReminderAck back. Infrastructure failures (shard region missing) still
+                // go through the immediate retry / permanent-fail path.
                 var failedRemindersToRetry = new List<ScheduledReminder>();
                 var permanentlyFailedReminders = new List<CompletedReminder>();
 
@@ -474,56 +678,44 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                     else
                     {
                         _log.Debug("Sending reminder {0} to {1}", reminder, shardRegion);
-                        ShardRegionResolver.DeliverReminder(reminder.Entity, reminder.Message);
+                        var envelope = new ReminderEnvelope(reminder.Entity, reminder.Key, reminder.Message);
+                        ShardRegionResolver.DeliverReminder(reminder.Entity, envelope, Self);
+
+                        var ackDeadline = TimeProvider.Now.Add(Settings.AckTimeout);
+                        _awaitingAck[(reminder.Entity, reminder.Key)] = (reminder, ackDeadline);
 
                         totalDelivered += 1;
-
-                        if (reminder.RepeatInterval.HasValue)
-                        {
-                            var nextOccurrence = reminder with
-                            {
-                                When = TimeProvider.Now.Add(reminder.RepeatInterval.Value),
-                                AttemptCount = 0,
-                                LastFailureReason = null
-                            };
-                            recurringRemindersToSchedule.Add(nextOccurrence);
-                            _log.Info("Scheduling next occurrence of recurring reminder {0} at {1}",
-                                reminder.Key, nextOccurrence.When);
-                        }
-                        else
-                        {
-                            completedReminders.Add(new CompletedReminder(reminder.Entity, reminder.Key, completedAt,
-                                ReminderCompletionStatus.Delivered));
-                        }
                     }
                 }
 
-                // Phase 3: Mark completed one-time reminders and permanently failed reminders
-                // Recurring reminders are not marked complete; their durability boundary is
-                // successful upsert of the next occurrence.
+                // Phase 3: Mark permanently failed reminders as complete in storage.
+                // Delivered reminders are NOT marked here — that happens in the ReminderAck handler.
                 var writeFailed = false;
-                try
+                if (permanentlyFailedReminders.Count > 0)
                 {
-                    var allCompleted = completedReminders.Concat(permanentlyFailedReminders);
-                    using var markCts = new CancellationTokenSource(Settings.StorageTimeout);
-                    var markResult = await Storage.MarkRemindersAsCompletedAsync(allCompleted, markCts.Token);
-                    if (!markResult)
+                    try
                     {
-                        _log.Error(
-                            "MarkRemindersAsCompletedAsync returned false for [{0}] reminders",
-                            completedReminders.Count + permanentlyFailedReminders.Count);
+                        using var markCts = new CancellationTokenSource(Settings.StorageTimeout);
+                        var markResult =
+                            await Storage.MarkRemindersAsCompletedAsync(permanentlyFailedReminders, markCts.Token);
+                        if (!markResult)
+                        {
+                            _log.Error(
+                                "MarkRemindersAsCompletedAsync returned false for [{0}] permanently-failed reminders",
+                                permanentlyFailedReminders.Count);
+                            writeFailed = true;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _log.Error(ex,
+                            "Failed to mark [{0}] reminders as permanently failed",
+                            permanentlyFailedReminders.Count);
                         writeFailed = true;
                     }
                 }
-                catch (Exception ex)
-                {
-                    _log.Error(ex,
-                        "Failed to mark [{0}] reminders as completed",
-                        completedReminders.Count + permanentlyFailedReminders.Count);
-                    writeFailed = true;
-                }
 
-                // Phase 4: Schedule retries for failed reminders
+                // Phase 4: Schedule retries for infrastructure-failed reminders
                 if (!writeFailed)
                 {
                     try
@@ -541,33 +733,6 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                     }
                 }
 
-                // Phase 5: Persist recurring next occurrences
-                if (!writeFailed)
-                {
-                    try
-                    {
-                        foreach (var recurringReminder in recurringRemindersToSchedule)
-                        {
-                            using var recurCts = new CancellationTokenSource(Settings.StorageTimeout);
-                            var result = await Storage.ScheduleReminderAsync(recurringReminder, recurCts.Token);
-                            if (result.ResponseCode != ReminderScheduleResponseCode.Success)
-                            {
-                                _log.Error("Failed to schedule recurring reminder {0}: {1}",
-                                    recurringReminder.Key, result.Message ?? "Unknown error");
-                                writeFailed = true;
-                                break;
-                            }
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        _log.Error(ex, "Failed to schedule [{0}] recurring reminders",
-                            recurringRemindersToSchedule.Count);
-                        writeFailed = true;
-                    }
-                }
-
-                totalRecurring += recurringRemindersToSchedule.Count;
                 totalRetried += failedRemindersToRetry.Count;
                 totalFailed += permanentlyFailedReminders.Count;
 
@@ -619,9 +784,9 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         }
 
         _log.Info(
-            "Successfully delivered [{0}] reminders; scheduled [{1}] recurring reminders; retrying [{2}] failed reminders; permanently failed [{3}] reminders. Next reminder due: {4}",
-            totalDelivered, totalRecurring, totalRetried,
-            totalFailed, PendingReminders.TimeUntilNext);
+            "Successfully delivered [{0}] reminders (awaiting ack); retrying [{1}] infrastructure-failed reminders; permanently failed [{2}] reminders. Awaiting ack: [{3}]. Next reminder due: {4}",
+            totalDelivered, totalRetried,
+            totalFailed, _awaitingAck.Count, PendingReminders.TimeUntilNext);
 
         TryScheduleFetchReminders();
     }

--- a/src/Akka.Reminders/ReminderScheduler.cs
+++ b/src/Akka.Reminders/ReminderScheduler.cs
@@ -44,14 +44,22 @@ public sealed record ReminderSettings
 
     /// <summary>
     /// Maximum number of delivery attempts before a reminder is marked as permanently failed.
+    /// Applies to both infrastructure failures (shard region not found) and ack timeouts.
     /// </summary>
-    public int MaxDeliveryAttempts { get; init; } = 3;
+    public int MaxDeliveryAttempts { get; init; } = 10;
 
     /// <summary>
     /// Base delay for exponential backoff when retrying failed reminders.
-    /// Actual delay = RetryBackoffBase * (2 ^ attemptCount)
+    /// Actual delay = min(RetryBackoffBase * (2 ^ attemptCount), MaxRetryBackoff)
+    /// Applies to both infrastructure failures (shard region not found) and ack timeouts.
     /// </summary>
-    public TimeSpan RetryBackoffBase { get; init; } = TimeSpan.FromSeconds(30);
+    public TimeSpan RetryBackoffBase { get; init; } = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Maximum backoff delay between retry attempts. Prevents exponential backoff from
+    /// growing to absurdly long intervals at high attempt counts.
+    /// </summary>
+    public TimeSpan MaxRetryBackoff { get; init; } = TimeSpan.FromMinutes(10);
 
     /// <summary>
     /// How long to wait for an acknowledgement after delivering a reminder before retrying.
@@ -485,12 +493,14 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
 
                     if (timedOutReminder.AttemptCount + 1 < Settings.MaxDeliveryAttempts)
                     {
-                        // Schedule a retry with exponential backoff
-                        var backoffSeconds =
-                            Settings.RetryBackoffBase.TotalSeconds * Math.Pow(2, timedOutReminder.AttemptCount);
+                        // Schedule a retry with capped exponential backoff
+                        var backoff = TimeSpan.FromSeconds(
+                            Math.Min(
+                                Settings.RetryBackoffBase.TotalSeconds * Math.Pow(2, timedOutReminder.AttemptCount),
+                                Settings.MaxRetryBackoff.TotalSeconds));
                         var retryReminder = timedOutReminder with
                         {
-                            When = now.Add(TimeSpan.FromSeconds(backoffSeconds)),
+                            When = now.Add(backoff),
                             AttemptCount = timedOutReminder.AttemptCount + 1,
                             LastFailureReason = "Ack timeout"
                         };
@@ -658,11 +668,13 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
 
                         if (reminder.AttemptCount + 1 < Settings.MaxDeliveryAttempts)
                         {
-                            var backoffSeconds =
-                                Settings.RetryBackoffBase.TotalSeconds * Math.Pow(2, reminder.AttemptCount);
+                            var backoff = TimeSpan.FromSeconds(
+                                Math.Min(
+                                    Settings.RetryBackoffBase.TotalSeconds * Math.Pow(2, reminder.AttemptCount),
+                                    Settings.MaxRetryBackoff.TotalSeconds));
                             var retryReminder = reminder with
                             {
-                                When = TimeProvider.Now.Add(TimeSpan.FromSeconds(backoffSeconds)),
+                                When = TimeProvider.Now.Add(backoff),
                                 AttemptCount = reminder.AttemptCount + 1,
                                 LastFailureReason = $"ShardRegion [{reminder.Entity.ShardRegionName}] not found"
                             };

--- a/src/Akka.Reminders/ReminderScheduler.cs
+++ b/src/Akka.Reminders/ReminderScheduler.cs
@@ -254,7 +254,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         ReminderEntity entity,
         ReminderKey key,
         DateTimeOffset dueTimeUtc)
-        => (entity, key, dueTimeUtc.ToUniversalTime());
+        => (entity, key, dueTimeUtc);
 
     private void ScheduleBufferedAckFlush()
     {
@@ -273,8 +273,6 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
 
     private void ScheduleAckTimeoutCheck(DateTimeOffset ackDeadlineUtc)
     {
-        ackDeadlineUtc = ackDeadlineUtc.ToUniversalTime();
-
         if (_nextAckTimeoutAt.HasValue && _nextAckTimeoutAt.Value <= ackDeadlineUtc)
             return;
 
@@ -290,7 +288,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
     private void TrackAckDeadlines(IEnumerable<AwaitingAckReminder> reminders)
     {
         var nextDeadline = reminders
-            .Select(r => r.AckDeadline.ToUniversalTime())
+            .Select(r => r.AckDeadline)
             .DefaultIfEmpty(DateTimeOffset.MaxValue)
             .Min();
 
@@ -756,8 +754,6 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         TimeSpan? repeatInterval,
         TimeSpan? maxDeliveryWindow)
     {
-        dueTimeUtc = dueTimeUtc.ToUniversalTime();
-
         DateTimeOffset? deadline = null;
         if (maxDeliveryWindow.HasValue)
             deadline = dueTimeUtc.Add(maxDeliveryWindow.Value);

--- a/src/Akka.Reminders/ReminderScheduler.cs
+++ b/src/Akka.Reminders/ReminderScheduler.cs
@@ -1,4 +1,7 @@
-﻿using Akka.Actor;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Akka.Actor;
 using Akka.Reminders.Sharding;
 using Akka.Reminders.Storage;
 
@@ -124,13 +127,8 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
     /// </summary>
     private bool _writeCircuitOpen;
 
-    /// <summary>
-    /// Tracks reminders that have been delivered to their target shard region but have not yet
-    /// been acknowledged. Keyed by (Entity, Key). Each entry stores the original reminder and
-    /// the absolute deadline by which an ack must arrive before the reminder is retried or
-    /// permanently failed.
-    /// </summary>
-    private readonly Dictionary<(ReminderEntity Entity, ReminderKey Key), (ScheduledReminder Reminder, DateTimeOffset AckDeadline)> _awaitingAck = new();
+    private bool _processingReminders;
+    private bool _processingAckTimeouts;
 
     private readonly ILoggingAdapter _log = Context.GetLogger();
 
@@ -157,6 +155,15 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         }
     }
 
+    private sealed class FetchRemindersCompleted
+    {
+        public static readonly FetchRemindersCompleted Instance = new();
+
+        private FetchRemindersCompleted()
+        {
+        }
+    }
+
     /// <summary>
     /// Time to prune completed reminders
     /// </summary>
@@ -170,8 +177,8 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
     }
 
     /// <summary>
-    /// Periodic timer message that triggers a scan of <see cref="_awaitingAck"/> to find
-    /// reminders whose ack deadline has elapsed and either retry or permanently fail them.
+    /// Periodic timer message that triggers a storage-backed scan for reminders whose ack deadline
+    /// has elapsed and either retries or permanently completes them.
     /// </summary>
     private sealed class CheckAckTimeouts
     {
@@ -182,15 +189,11 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         }
     }
 
-    /// <summary>
-    /// One-shot message sent during startup to reset any AwaitingAck reminders
-    /// left by a previous scheduler instance back to Pending.
-    /// </summary>
-    private sealed class RecoverAwaitingAck
+    private sealed class CheckAckTimeoutsCompleted
     {
-        public static readonly RecoverAwaitingAck Instance = new();
+        public static readonly CheckAckTimeoutsCompleted Instance = new();
 
-        private RecoverAwaitingAck()
+        private CheckAckTimeoutsCompleted()
         {
         }
     }
@@ -224,10 +227,6 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 Stash.UnstashAll(); // Process any messages that arrived during initialization
                 TryScheduleFetchReminders();
                 Timers.Cancel(RestartBackoffTimer.Instance); // if needed
-
-                // Recover reminders left in AwaitingAck by a previous scheduler instance.
-                // Scheduled as a message so it doesn't block the mailbox during startup.
-                Self.Tell(RecoverAwaitingAck.Instance);
                 break;
             case Status.Failure failure:
                 _log.Error(failure.Cause, "Failed to load reminder overview from storage - restarting...");
@@ -252,17 +251,34 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         {
             case FetchReminders:
             {
-                // process reminders
-                RunTask(() => ProcessReminders(TimeProvider.Now + Settings.MaxSlippage));
+                if (_processingReminders)
+                    break;
+
+                _processingReminders = true;
+                RunTask(async () =>
+                {
+                    try
+                    {
+                        await ExpireRemindersAsync(TimeProvider.Now);
+                        await ProcessReminders(TimeProvider.Now + Settings.MaxSlippage);
+                    }
+                    finally
+                    {
+                        Self.Tell(FetchRemindersCompleted.Instance);
+                    }
+                });
                 break;
             }
+            case FetchRemindersCompleted:
+                _processingReminders = false;
+                break;
             case ReminderProtocol.ScheduleReminder scheduleSingle:
             {
                 _log.Debug("Scheduling reminder {0}", scheduleSingle);
                 RunTask(async () =>
                 {
                     using var cts = new CancellationTokenSource(Settings.StorageTimeout);
-                    var reminder = scheduleSingle.ToScheduledReminder();
+                    var reminder = CreateScheduledReminder(scheduleSingle);
                     try
                     {
                         // validate that the ShardRegion exists
@@ -283,15 +299,8 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                         if (r.ResponseCode != ReminderScheduleResponseCode.Success)
                             return;
 
-                        // update scheduling state if we were successful
-                        var (newOverview, hasNewerDate) = PendingReminders!.Apply(reminder, TimeProvider.Now);
-                        PendingReminders = newOverview;
-
-                        if (hasNewerDate)
-                        {
-                            _log.Debug("New earlier reminder due date: {0}", newOverview.TimeUntilNext);
-                            TryScheduleFetchReminders();
-                        }
+                        await ReloadPendingOverviewAsync();
+                        TryScheduleFetchReminders();
                     }
                     catch (Exception ex)
                     {
@@ -314,10 +323,8 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                             await Storage.CancelReminderAsync(cancel.Entity, cancel.Key, cts.Token);
                         Sender.Tell(cancellationResult, ActorRefs.NoSender);
 
-                        PendingReminders = PendingReminders with
-                        {
-                            TotalPendingReminders = PendingReminders.TotalPendingReminders - 1
-                        };
+                        await ReloadPendingOverviewAsync();
+                        TryScheduleFetchReminders();
                     }
                     catch (Exception ex)
                     {
@@ -341,11 +348,8 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                             await Storage.CancelAllRemindersForEntityAsync(cancelAll.Entity, cts.Token);
                         Sender.Tell(cancellationResult, ActorRefs.NoSender);
 
-                        PendingReminders = PendingReminders with
-                        {
-                            TotalPendingReminders = PendingReminders.TotalPendingReminders -
-                                                    cancellationResult.Keys.Count
-                        };
+                        await ReloadPendingOverviewAsync();
+                        TryScheduleFetchReminders();
                     }
                     catch (Exception ex)
                     {
@@ -410,209 +414,77 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
             }
             case ReminderProtocol.ReminderAck ack:
             {
-                _log.Debug("Received ReminderAck for [{0}] / [{1}]", ack.Entity, ack.Key);
+                _log.Debug("Received ReminderAck for [{0}] / [{1}] due at [{2}]", ack.Entity, ack.Key, ack.DueTimeUtc);
                 var ackSender = Sender;
-                var lookupKey = (ack.Entity, ack.Key);
-
-                if (!_awaitingAck.TryGetValue(lookupKey, out var entry))
-                {
-                    // Late or duplicate ack — harmless, nothing to do
-                    _log.Debug("ReminderAck for [{0}] / [{1}] not found in awaiting-ack set (late or duplicate)",
-                        ack.Entity, ack.Key);
-                    ackSender.Tell(new ReminderProtocol.ReminderAckResponse(
-                        ack.Entity, ack.Key, ReminderAckResponseCode.NotFound), ActorRefs.NoSender);
-                    break;
-                }
-
-                // Optimistically remove — will re-add on storage failure so the timeout checker can retry
-                _awaitingAck.Remove(lookupKey);
-
-                var ackedReminder = entry.Reminder;
-                var originalEntry = entry; // captured for re-add on failure
 
                 RunTask(async () =>
                 {
                     try
                     {
-                        if (ackedReminder.RepeatInterval.HasValue)
+                        using var ackCts = new CancellationTokenSource(Settings.StorageTimeout);
+                        var ackResult = await Storage.AcknowledgeReminderAsync(
+                            ack.Entity,
+                            ack.Key,
+                            ack.DueTimeUtc,
+                            TimeProvider.Now,
+                            ackCts.Token);
+
+                        if (ackResult.Success)
                         {
-                            // Recurring reminder: schedule the next occurrence.
-                            // Anchor to the original When so repeated acks cannot drift the schedule.
-                            // ScheduleReminderAsync clears any lingering AwaitingAck state for the key.
-                            var nextOccurrence = ackedReminder with
-                            {
-                                When = ackedReminder.When.Add(ackedReminder.RepeatInterval.Value),
-                                AttemptCount = 0,
-                                LastFailureReason = null
-                            };
-                            using var scheduleCts = new CancellationTokenSource(Settings.StorageTimeout);
-                            var result = await Storage.ScheduleReminderAsync(nextOccurrence, scheduleCts.Token);
-                            if (result.ResponseCode != ReminderScheduleResponseCode.Success)
-                            {
-                                _log.Error(
-                                    "Failed to schedule next occurrence of recurring reminder [{0}] / [{1}]: {2}",
-                                    ackedReminder.Entity, ackedReminder.Key, result.Message ?? "Unknown error");
-                            }
-                            else
-                            {
-                                _log.Info("Scheduled next occurrence of recurring reminder [{0}] / [{1}] at {2}",
-                                    ackedReminder.Entity, ackedReminder.Key, nextOccurrence.When);
-                                var (newOverview, hasNewerDate) =
-                                    PendingReminders.Apply(nextOccurrence, TimeProvider.Now);
-                                PendingReminders = newOverview;
-                                if (hasNewerDate)
-                                    TryScheduleFetchReminders();
-                            }
+                            ackSender.Tell(new ReminderProtocol.ReminderAckResponse(
+                                ack.Entity,
+                                ack.Key,
+                                ack.DueTimeUtc,
+                                ReminderAckResponseCode.Success), ActorRefs.NoSender);
                         }
                         else
                         {
-                            // One-time reminder: mark as delivered and clear AwaitingAck state.
-                            var completed = new CompletedReminder(
-                                ackedReminder.Entity, ackedReminder.Key,
-                                TimeProvider.Now, ReminderCompletionStatus.Delivered);
-                            using var markCts = new CancellationTokenSource(Settings.StorageTimeout);
-                            var markResult = await Storage.MarkRemindersAsCompletedAsync([completed], markCts.Token);
-                            if (!markResult)
-                            {
-                                _log.Error(
-                                    "MarkRemindersAsCompletedAsync returned false for acked reminder [{0}] / [{1}]",
-                                    ackedReminder.Entity, ackedReminder.Key);
-                            }
+                            ackSender.Tell(new ReminderProtocol.ReminderAckResponse(
+                                ack.Entity,
+                                ack.Key,
+                                ack.DueTimeUtc,
+                                ReminderAckResponseCode.NotFound), ActorRefs.NoSender);
                         }
-
-                        ackSender.Tell(new ReminderProtocol.ReminderAckResponse(
-                            ack.Entity, ack.Key, ReminderAckResponseCode.Success), ActorRefs.NoSender);
                     }
                     catch (Exception ex)
                     {
                         _log.Error(ex,
-                            "Error processing ReminderAck for [{0}] / [{1}] — re-adding to awaiting-ack for retry",
-                            ack.Entity, ack.Key);
-                        // Re-add with the original deadline so the timeout checker will eventually retry
-                        _awaitingAck[lookupKey] = originalEntry;
+                            "Error processing ReminderAck for [{0}] / [{1}] / [{2}]",
+                            ack.Entity, ack.Key, ack.DueTimeUtc);
                         ackSender.Tell(new ReminderProtocol.ReminderAckResponse(
-                            ack.Entity, ack.Key, ReminderAckResponseCode.Error, ex.Message),
+                            ack.Entity,
+                            ack.Key,
+                            ack.DueTimeUtc,
+                            ReminderAckResponseCode.Error,
+                            ex.Message),
                             ActorRefs.NoSender);
-                    }
-                });
-                break;
-            }
-            case RecoverAwaitingAck:
-            {
-                // Reset any AwaitingAck reminders from a previous scheduler instance back to Pending.
-                // The in-memory _awaitingAck dict is always empty at startup, so any row still
-                // marked AwaitingAck in the DB would be permanently stuck without this reset.
-                RunTask(async () =>
-                {
-                    try
-                    {
-                        using var cts = new CancellationTokenSource(Settings.StorageTimeout);
-                        var resetCount = await Storage.ResetAwaitingAckToPendingAsync(cts.Token);
-                        if (resetCount > 0)
-                        {
-                            _log.Warning(
-                                "Reset [{0}] AwaitingAck reminder(s) from previous scheduler instance back to Pending",
-                                resetCount);
-                            // Refresh overview since we just made more reminders Pending
-                            using var overviewCts = new CancellationTokenSource(Settings.StorageTimeout);
-                            PendingReminders = await Storage.GetRemindersOverviewAsync(TimeProvider.Now, overviewCts.Token);
-                            TryScheduleFetchReminders();
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        _log.Error(ex,
-                            "Failed to reset AwaitingAck reminders to Pending on startup — " +
-                            "they will be recovered on the next scheduler restart");
                     }
                 });
                 break;
             }
             case CheckAckTimeouts:
             {
-                var now = TimeProvider.Now;
-                var timedOut = _awaitingAck
-                    .Where(kvp => kvp.Value.AckDeadline <= now)
-                    .ToList();
-
-                if (timedOut.Count == 0)
+                if (_processingAckTimeouts)
                     break;
 
-                _log.Debug("Ack-timeout scan found [{0}] timed-out reminder(s)", timedOut.Count);
-
-                foreach (var kvp in timedOut)
+                _processingAckTimeouts = true;
+                RunTask(async () =>
                 {
-                    _awaitingAck.Remove(kvp.Key);
-                    var timedOutReminder = kvp.Value.Reminder;
-
-                    if (timedOutReminder.AttemptCount + 1 < Settings.MaxDeliveryAttempts)
+                    try
                     {
-                        // Schedule a retry with capped exponential backoff
-                        var backoff = TimeSpan.FromSeconds(
-                            Math.Min(
-                                Settings.RetryBackoffBase.TotalSeconds * Math.Pow(2, timedOutReminder.AttemptCount),
-                                Settings.MaxRetryBackoff.TotalSeconds));
-                        var retryReminder = timedOutReminder with
-                        {
-                            When = now.Add(backoff),
-                            AttemptCount = timedOutReminder.AttemptCount + 1,
-                            LastFailureReason = "Ack timeout"
-                        };
-
-                        _log.Warning(
-                            "Ack timeout for reminder [{0}] / [{1}] (attempt {2} of {3}). Retrying at {4}.",
-                            timedOutReminder.Entity, timedOutReminder.Key,
-                            retryReminder.AttemptCount, Settings.MaxDeliveryAttempts,
-                            retryReminder.When);
-
-                        RunTask(async () =>
-                        {
-                            try
-                            {
-                                using var retryCts = new CancellationTokenSource(Settings.StorageTimeout);
-                                await Storage.ScheduleReminderAsync(retryReminder, retryCts.Token);
-                                var (newOverview, hasNewerDate) =
-                                    PendingReminders.Apply(retryReminder, TimeProvider.Now);
-                                PendingReminders = newOverview;
-                                if (hasNewerDate)
-                                    TryScheduleFetchReminders();
-                            }
-                            catch (Exception ex)
-                            {
-                                _log.Error(ex,
-                                    "Failed to schedule ack-timeout retry for reminder [{0}] / [{1}]",
-                                    retryReminder.Entity, retryReminder.Key);
-                            }
-                        });
+                        await ExpireRemindersAsync(TimeProvider.Now);
+                        await ProcessAckTimeouts();
                     }
-                    else
+                    finally
                     {
-                        _log.Error(
-                            "Reminder [{0}] / [{1}] exceeded max delivery attempts ({2}) after ack timeout. Marking as permanently failed.",
-                            timedOutReminder.Entity, timedOutReminder.Key, Settings.MaxDeliveryAttempts);
-
-                        RunTask(async () =>
-                        {
-                            try
-                            {
-                                var failed = new CompletedReminder(
-                                    timedOutReminder.Entity, timedOutReminder.Key,
-                                    TimeProvider.Now, ReminderCompletionStatus.Failed);
-                                using var failCts = new CancellationTokenSource(Settings.StorageTimeout);
-                                await Storage.MarkRemindersAsCompletedAsync([failed], failCts.Token);
-                            }
-                            catch (Exception ex)
-                            {
-                                _log.Error(ex,
-                                    "Failed to mark ack-timeout reminder [{0}] / [{1}] as permanently failed",
-                                    timedOutReminder.Entity, timedOutReminder.Key);
-                            }
-                        });
+                        Self.Tell(CheckAckTimeoutsCompleted.Instance);
                     }
-                }
-
+                });
                 break;
             }
+            case CheckAckTimeoutsCompleted:
+                _processingAckTimeouts = false;
+                break;
             default:
                 Unhandled(message);
                 break;
@@ -641,10 +513,39 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         _log.Info("Scheduled ack-timeout check every {0}", Settings.AckTimeoutCheckInterval);
     }
 
-    private Task LoadReminderOverview()
+    private async Task ReloadPendingOverviewAsync()
     {
         using var cts = new CancellationTokenSource(Settings.StorageTimeout);
-        var reminders = Storage.GetRemindersOverviewAsync(TimeProvider.Now, cts.Token);
+        PendingReminders = await Storage.GetRemindersOverviewAsync(TimeProvider.Now, cts.Token);
+    }
+
+    private async Task ExpireRemindersAsync(DateTimeOffset now)
+    {
+        try
+        {
+            using var cts = new CancellationTokenSource(Settings.StorageTimeout);
+            var expired = await Storage.ExpireRemindersAsync(now, cts.Token);
+            if (expired > 0)
+            {
+                _log.Info("Marked [{0}] expired reminder occurrence(s) as complete", expired);
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "Failed to expire stale reminder occurrences; continuing with deadline-filtered reads");
+        }
+    }
+
+    private Task LoadReminderOverview()
+    {
+        async Task<ReminderOverview> LoadAsync()
+        {
+            await ExpireRemindersAsync(TimeProvider.Now);
+            using var cts = new CancellationTokenSource(Settings.StorageTimeout);
+            return await Storage.GetRemindersOverviewAsync(TimeProvider.Now, cts.Token);
+        }
+
+        var reminders = LoadAsync();
         return reminders.PipeTo(Self, success: overview => overview, failure: ex => new Status.Failure(ex));
     }
 
@@ -655,13 +556,228 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
     /// Ensures both local and remote delivery produce the strongly-typed generic envelope
     /// so that <c>Receive&lt;ReminderEnvelope&lt;T&gt;&gt;</c> handlers match correctly.
     /// </summary>
-    private static ReminderEnvelope CreateTypedEnvelope(ReminderEntity entity, ReminderKey key, object message)
+    private static ReminderEnvelope CreateTypedEnvelope(
+        ReminderEntity entity,
+        ReminderKey key,
+        DateTimeOffset dueTimeUtc,
+        ReminderDeadline deadline,
+        object message)
     {
         var messageType = message.GetType();
         var closedType = OpenGenericEnvelopeType.MakeGenericType(messageType);
-        return (ReminderEnvelope)(Activator.CreateInstance(closedType, entity, key, message)
+        return (ReminderEnvelope)(Activator.CreateInstance(closedType, entity, key, dueTimeUtc, deadline, message)
             ?? throw new InvalidOperationException(
                 $"Failed to create {closedType.FullName} for message type {messageType.FullName}"));
+    }
+
+    private static DateTimeOffset? ComputeDeliveryDeadlineUtc(
+        DateTimeOffset dueTimeUtc,
+        TimeSpan? repeatInterval,
+        TimeSpan? maxDeliveryWindow)
+    {
+        dueTimeUtc = dueTimeUtc.ToUniversalTime();
+
+        DateTimeOffset? deadline = null;
+        if (maxDeliveryWindow.HasValue)
+            deadline = dueTimeUtc.Add(maxDeliveryWindow.Value);
+
+        if (repeatInterval.HasValue)
+        {
+            var nextDue = dueTimeUtc.Add(repeatInterval.Value);
+            deadline = deadline.HasValue && deadline.Value < nextDue ? deadline.Value : nextDue;
+        }
+
+        return deadline;
+    }
+
+    private ScheduledReminder CreateScheduledReminder(ReminderProtocol.ScheduleReminder scheduleReminder)
+    {
+        var dueTimeUtc = scheduleReminder.When.ToUniversalTime();
+        return new ScheduledReminder(
+            scheduleReminder.Entity,
+            scheduleReminder.Key,
+            dueTimeUtc,
+            scheduleReminder.Message,
+            scheduleReminder.RepeatInterval,
+            MaxDeliveryWindow: scheduleReminder.MaxDeliveryWindow,
+            DeliveryDeadlineUtc: ComputeDeliveryDeadlineUtc(
+                dueTimeUtc,
+                scheduleReminder.RepeatInterval,
+                scheduleReminder.MaxDeliveryWindow),
+            OccurrenceDueTimeUtc: dueTimeUtc);
+    }
+
+    private ScheduledReminder CreateNextRecurringOccurrence(ScheduledReminder reminder)
+    {
+        if (!reminder.RepeatInterval.HasValue)
+            throw new InvalidOperationException("Cannot create next recurring occurrence for a non-recurring reminder.");
+
+        var nextDue = reminder.DueTimeUtc.Add(reminder.RepeatInterval.Value);
+        return reminder with
+        {
+            When = nextDue,
+            AttemptCount = 0,
+            LastFailureReason = null,
+            DeliveryDeadlineUtc = ComputeDeliveryDeadlineUtc(nextDue, reminder.RepeatInterval, reminder.MaxDeliveryWindow),
+            OccurrenceDueTimeUtc = nextDue
+        };
+    }
+
+    private bool TryCreateRetryReminder(
+        ScheduledReminder reminder,
+        DateTimeOffset now,
+        string failureReason,
+        out ScheduledReminder retryReminder,
+        out ReminderCompletionStatus terminalStatus)
+    {
+        retryReminder = reminder;
+
+        if (reminder.DeliveryDeadlineUtc.HasValue && reminder.DeliveryDeadlineUtc.Value <= now)
+        {
+            terminalStatus = ReminderCompletionStatus.Expired;
+            return false;
+        }
+
+        if (reminder.AttemptCount + 1 >= Settings.MaxDeliveryAttempts)
+        {
+            terminalStatus = ReminderCompletionStatus.Failed;
+            return false;
+        }
+
+        var backoff = TimeSpan.FromSeconds(
+            Math.Min(
+                Settings.RetryBackoffBase.TotalSeconds * Math.Pow(2, reminder.AttemptCount),
+                Settings.MaxRetryBackoff.TotalSeconds));
+        var retryAt = now.Add(backoff);
+
+        if (reminder.DeliveryDeadlineUtc.HasValue && retryAt >= reminder.DeliveryDeadlineUtc.Value)
+        {
+            terminalStatus = ReminderCompletionStatus.Expired;
+            return false;
+        }
+
+        retryReminder = reminder with
+        {
+            When = retryAt,
+            AttemptCount = reminder.AttemptCount + 1,
+            LastFailureReason = failureReason
+        };
+        terminalStatus = ReminderCompletionStatus.Pending;
+        return true;
+    }
+
+    private async Task ProcessAckTimeouts()
+    {
+        var totalRetried = 0;
+        var totalFailed = 0;
+        var totalExpired = 0;
+
+        while (true)
+        {
+            IReadOnlyList<ScheduledReminder> timedOut;
+            try
+            {
+                using var readCts = new CancellationTokenSource(Settings.StorageTimeout);
+                timedOut = await Storage.GetTimedOutAckRemindersAsync(
+                    TimeProvider.Now,
+                    new ReminderBatchSize(Settings.MaxBatchSize),
+                    readCts.Token);
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex, "Failed to read timed-out awaiting-ack reminders from storage");
+                break;
+            }
+
+            if (timedOut.Count == 0)
+                break;
+
+            var occurrencesToUpsert = new List<ScheduledReminder>();
+            var terminalReminders = new List<CompletedReminder>();
+            var now = TimeProvider.Now;
+
+            foreach (var reminder in timedOut)
+            {
+                if (TryCreateRetryReminder(reminder, now, "Ack timeout", out var retryReminder, out var terminalStatus))
+                {
+                    occurrencesToUpsert.Add(retryReminder);
+                    totalRetried += 1;
+                }
+                else
+                {
+                    terminalReminders.Add(new CompletedReminder(
+                        reminder.Entity,
+                        reminder.Key,
+                        reminder.DueTimeUtc,
+                        now,
+                        terminalStatus));
+
+                    if (terminalStatus == ReminderCompletionStatus.Expired)
+                        totalExpired += 1;
+                    else
+                        totalFailed += 1;
+                }
+            }
+
+            var writeFailed = false;
+
+            if (occurrencesToUpsert.Count > 0)
+            {
+                try
+                {
+                    using var upsertCts = new CancellationTokenSource(Settings.StorageTimeout);
+                    var upsertResult = await Storage.UpsertReminderOccurrencesAsync(occurrencesToUpsert, upsertCts.Token);
+                    if (!upsertResult)
+                        writeFailed = true;
+                }
+                catch (Exception ex)
+                {
+                    _log.Error(ex, "Failed to upsert [{0}] ack-timeout retry reminder(s)", occurrencesToUpsert.Count);
+                    writeFailed = true;
+                }
+            }
+
+            if (!writeFailed && terminalReminders.Count > 0)
+            {
+                try
+                {
+                    using var markCts = new CancellationTokenSource(Settings.StorageTimeout);
+                    var markResult = await Storage.MarkRemindersAsCompletedAsync(terminalReminders, markCts.Token);
+                    if (!markResult)
+                        writeFailed = true;
+                }
+                catch (Exception ex)
+                {
+                    _log.Error(ex, "Failed to mark [{0}] timed-out reminder(s) as terminal", terminalReminders.Count);
+                    writeFailed = true;
+                }
+            }
+
+            if (writeFailed)
+            {
+                _writeCircuitOpen = true;
+                _log.Warning("Write circuit OPEN — ack-timeout processing encountered storage write failures.");
+                break;
+            }
+
+            if (timedOut.Count < Settings.MaxBatchSize)
+                break;
+        }
+
+        if (totalRetried > 0 || totalFailed > 0 || totalExpired > 0)
+        {
+            await ReloadPendingOverviewAsync();
+            TryScheduleFetchReminders();
+        }
+
+        if (totalRetried > 0 || totalFailed > 0 || totalExpired > 0)
+        {
+            _log.Info(
+                "Ack-timeout processing retried [{0}] reminder occurrence(s), failed [{1}], expired [{2}]",
+                totalRetried,
+                totalFailed,
+                totalExpired);
+        }
     }
 
     private async Task ProcessReminders(DateTimeOffset untilDeadline)
@@ -669,6 +785,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         var totalDelivered = 0;
         var totalRetried = 0;
         var totalFailed = 0;
+        var totalExpired = 0;
 
         // When the write circuit is open, probe with a single reminder to test
         // write availability before resuming full-batch processing. This limits
@@ -719,138 +836,140 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 // by (Status, When) efficiently.
                 var completedAt = TimeProvider.Now;
 
-                // Phase 2: Deliver reminders and categorize results.
-                // Successfully delivered reminders are placed in _awaitingAck; completion
-                // and recurring rescheduling happen only after the target entity sends a
-                // ReminderAck back. Infrastructure failures (shard region missing) still
-                // go through the immediate retry / permanent-fail path.
-                var failedRemindersToRetry = new List<ScheduledReminder>();
-                var permanentlyFailedReminders = new List<CompletedReminder>();
-                var deliveredReminders = new List<AwaitingAckReminder>();
+                var occurrencesToUpsert = new List<ScheduledReminder>();
+                var terminalReminders = new List<CompletedReminder>();
+                var remindersToAwaitAck = new List<AwaitingAckReminder>();
+                var deliveries = new List<(IActorRef ShardRegion, ScheduledReminder Reminder)>();
 
                 foreach (var reminder in chunk)
                 {
+                    if (reminder.DeliveryDeadlineUtc.HasValue && reminder.DeliveryDeadlineUtc.Value <= completedAt)
+                    {
+                        terminalReminders.Add(new CompletedReminder(
+                            reminder.Entity,
+                            reminder.Key,
+                            reminder.DueTimeUtc,
+                            completedAt,
+                            ReminderCompletionStatus.Expired));
+                        totalExpired += 1;
+                        continue;
+                    }
+
                     var shardRegion = ShardRegionResolver.TryResolve(reminder.Entity);
                     if (shardRegion is null)
                     {
                         _log.Warning("Reminder {0} could not be resolved to a ShardRegion. Attempt {1} of {2}",
                             reminder, reminder.AttemptCount + 1, Settings.MaxDeliveryAttempts);
 
-                        if (reminder.AttemptCount + 1 < Settings.MaxDeliveryAttempts)
+                        if (TryCreateRetryReminder(
+                                reminder,
+                                TimeProvider.Now,
+                                $"ShardRegion [{reminder.Entity.ShardRegionName}] not found",
+                                out var retryReminder,
+                                out var terminalStatus))
                         {
-                            var backoff = TimeSpan.FromSeconds(
-                                Math.Min(
-                                    Settings.RetryBackoffBase.TotalSeconds * Math.Pow(2, reminder.AttemptCount),
-                                    Settings.MaxRetryBackoff.TotalSeconds));
-                            var retryReminder = reminder with
-                            {
-                                When = TimeProvider.Now.Add(backoff),
-                                AttemptCount = reminder.AttemptCount + 1,
-                                LastFailureReason = $"ShardRegion [{reminder.Entity.ShardRegionName}] not found"
-                            };
-                            failedRemindersToRetry.Add(retryReminder);
+                            occurrencesToUpsert.Add(retryReminder);
                             _log.Info("Scheduling retry for reminder {0} at {1}", reminder.Key, retryReminder.When);
+                            totalRetried += 1;
                         }
                         else
                         {
-                            _log.Error(
-                                "Reminder {0} exceeded max delivery attempts ({1}). Marking as permanently failed.",
-                                reminder.Key, Settings.MaxDeliveryAttempts);
-                            permanentlyFailedReminders.Add(new CompletedReminder(reminder.Entity, reminder.Key,
-                                completedAt, ReminderCompletionStatus.Failed));
+                            terminalReminders.Add(new CompletedReminder(
+                                reminder.Entity,
+                                reminder.Key,
+                                reminder.DueTimeUtc,
+                                completedAt,
+                                terminalStatus));
+
+                            if (terminalStatus == ReminderCompletionStatus.Expired)
+                                totalExpired += 1;
+                            else
+                                totalFailed += 1;
                         }
                     }
                     else
                     {
-                        _log.Debug("Sending reminder {0} to {1}", reminder, shardRegion);
-                        var envelope = CreateTypedEnvelope(reminder.Entity, reminder.Key, reminder.Message);
-                        ShardRegionResolver.DeliverReminder(reminder.Entity, envelope, Self);
-
                         var ackDeadline = TimeProvider.Now.Add(Settings.AckTimeout);
-                        _awaitingAck[(reminder.Entity, reminder.Key)] = (reminder, ackDeadline);
-                        deliveredReminders.Add(new AwaitingAckReminder(
-                            reminder.Entity, reminder.Key, completedAt, ackDeadline));
 
-                        totalDelivered += 1;
+                        if (reminder.RepeatInterval.HasValue)
+                        {
+                            occurrencesToUpsert.Add(CreateNextRecurringOccurrence(reminder));
+                        }
+
+                        remindersToAwaitAck.Add(new AwaitingAckReminder(
+                            reminder.Entity,
+                            reminder.Key,
+                            reminder.DueTimeUtc,
+                            completedAt,
+                            ackDeadline));
+                        deliveries.Add((shardRegion, reminder));
                     }
                 }
 
-                // Phase 2.5: Persist AwaitingAck state for successfully delivered reminders.
-                // This prevents re-delivery on the next fetch and enables the circuit breaker
-                // to detect storage failures in the delivery hot path.
                 var writeFailed = false;
-                if (deliveredReminders.Count > 0)
+
+                if (occurrencesToUpsert.Count > 0)
                 {
                     try
                     {
-                        using var ackCts = new CancellationTokenSource(Settings.StorageTimeout);
-                        var ackResult = await Storage.MarkRemindersAsAwaitingAckAsync(deliveredReminders, ackCts.Token);
-                        if (!ackResult)
+                        using var upsertCts = new CancellationTokenSource(Settings.StorageTimeout);
+                        var upsertResult = await Storage.UpsertReminderOccurrencesAsync(occurrencesToUpsert, upsertCts.Token);
+                        if (!upsertResult)
                         {
                             _log.Error(
-                                "MarkRemindersAsAwaitingAckAsync returned false for [{0}] delivered reminders",
-                                deliveredReminders.Count);
+                                "UpsertReminderOccurrencesAsync returned false for [{0}] reminder occurrence(s)",
+                                occurrencesToUpsert.Count);
                             writeFailed = true;
                         }
                     }
                     catch (Exception ex)
                     {
                         _log.Error(ex,
-                            "Failed to mark [{0}] reminders as awaiting ack",
-                            deliveredReminders.Count);
+                            "Failed to upsert [{0}] reminder occurrence(s)",
+                            occurrencesToUpsert.Count);
                         writeFailed = true;
                     }
                 }
 
-                // Phase 3: Mark permanently failed reminders as complete in storage.
-                // Delivered reminders are NOT marked here — that happens in the ReminderAck handler.
-                if (!writeFailed && permanentlyFailedReminders.Count > 0)
+                if (!writeFailed && terminalReminders.Count > 0)
                 {
                     try
                     {
                         using var markCts = new CancellationTokenSource(Settings.StorageTimeout);
-                        var markResult =
-                            await Storage.MarkRemindersAsCompletedAsync(permanentlyFailedReminders, markCts.Token);
+                        var markResult = await Storage.MarkRemindersAsCompletedAsync(terminalReminders, markCts.Token);
                         if (!markResult)
                         {
                             _log.Error(
-                                "MarkRemindersAsCompletedAsync returned false for [{0}] permanently-failed reminders",
-                                permanentlyFailedReminders.Count);
+                                "MarkRemindersAsCompletedAsync returned false for [{0}] terminal reminder occurrence(s)",
+                                terminalReminders.Count);
                             writeFailed = true;
                         }
                     }
                     catch (Exception ex)
                     {
                         _log.Error(ex,
-                            "Failed to mark [{0}] reminders as permanently failed",
-                            permanentlyFailedReminders.Count);
+                            "Failed to mark [{0}] reminder occurrence(s) as terminal",
+                            terminalReminders.Count);
                         writeFailed = true;
                     }
                 }
 
-                // Phase 4: Schedule retries for infrastructure-failed reminders
-                if (!writeFailed)
+                if (!writeFailed && remindersToAwaitAck.Count > 0)
                 {
                     try
                     {
-                        foreach (var retryReminder in failedRemindersToRetry)
-                        {
-                            using var retryCts = new CancellationTokenSource(Settings.StorageTimeout);
-                            await Storage.ScheduleReminderAsync(retryReminder, retryCts.Token);
-                        }
+                        using var awaitAckCts = new CancellationTokenSource(Settings.StorageTimeout);
+                        var awaitAckResult = await Storage.MarkRemindersAsAwaitingAckAsync(remindersToAwaitAck, awaitAckCts.Token);
+                        if (!awaitAckResult)
+                            writeFailed = true;
                     }
                     catch (Exception ex)
                     {
-                        _log.Error(ex, "Failed to schedule [{0}] retry reminders", failedRemindersToRetry.Count);
+                        _log.Error(ex, "Failed to mark [{0}] reminder occurrence(s) as awaiting ack", remindersToAwaitAck.Count);
                         writeFailed = true;
                     }
                 }
 
-                totalRetried += failedRemindersToRetry.Count;
-                totalFailed += permanentlyFailedReminders.Count;
-
-                // If any write failed, open the circuit breaker and stop processing.
-                // The next timer tick will probe with a single reminder before resuming.
                 if (writeFailed)
                 {
                     _writeCircuitOpen = true;
@@ -862,13 +981,29 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                     break;
                 }
 
-                // Write probe succeeded — close the circuit and resume full batches
                 if (_writeCircuitOpen)
                 {
                     _writeCircuitOpen = false;
                     effectiveBatchSize = Settings.MaxBatchSize;
                     recoveredFromProbe = true;
                     _log.Info("Write circuit CLOSED — database writes recovered, resuming full-batch processing");
+                }
+
+                foreach (var delivery in deliveries)
+                {
+                    _log.Debug("Sending reminder occurrence [{0}] / [{1}] due at [{2}] to [{3}]",
+                        delivery.Reminder.Entity,
+                        delivery.Reminder.Key,
+                        delivery.Reminder.DueTimeUtc,
+                        delivery.ShardRegion);
+                    var envelope = CreateTypedEnvelope(
+                        delivery.Reminder.Entity,
+                        delivery.Reminder.Key,
+                        delivery.Reminder.DueTimeUtc,
+                        delivery.Reminder.Deadline,
+                        delivery.Reminder.Message);
+                    ShardRegionResolver.DeliverReminder(delivery.Reminder.Entity, envelope, Self);
+                    totalDelivered += 1;
                 }
             }
 
@@ -897,9 +1032,12 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         }
 
         _log.Info(
-            "Successfully delivered [{0}] reminders (awaiting ack); retrying [{1}] infrastructure-failed reminders; permanently failed [{2}] reminders. Awaiting ack: [{3}]. Next reminder due: {4}",
-            totalDelivered, totalRetried,
-            totalFailed, _awaitingAck.Count, PendingReminders.TimeUntilNext);
+            "Successfully delivered [{0}] reminder occurrence(s); retrying [{1}] infrastructure-failed occurrence(s); permanently failed [{2}] occurrence(s); expired [{3}] occurrence(s). Next reminder due: {4}",
+            totalDelivered,
+            totalRetried,
+            totalFailed,
+            totalExpired,
+            PendingReminders.TimeUntilNext);
 
         TryScheduleFetchReminders();
     }

--- a/src/Akka.Reminders/ReminderScheduler.cs
+++ b/src/Akka.Reminders/ReminderScheduler.cs
@@ -182,6 +182,19 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         }
     }
 
+    /// <summary>
+    /// One-shot message sent during startup to reset any AwaitingAck reminders
+    /// left by a previous scheduler instance back to Pending.
+    /// </summary>
+    private sealed class RecoverAwaitingAck
+    {
+        public static readonly RecoverAwaitingAck Instance = new();
+
+        private RecoverAwaitingAck()
+        {
+        }
+    }
+
     private void TryScheduleFetchReminders()
     {
         if (PendingReminders?.TotalPendingReminders > 0)
@@ -213,27 +226,8 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 Timers.Cancel(RestartBackoffTimer.Instance); // if needed
 
                 // Recover reminders left in AwaitingAck by a previous scheduler instance.
-                // The in-memory _awaitingAck dict is always empty at startup, so any row
-                // still marked AwaitingAck in the DB would be permanently stuck without this reset.
-                // Non-fatal: if the reset fails those reminders will be recovered on next restart.
-                RunTask(async () =>
-                {
-                    try
-                    {
-                        using var cts = new CancellationTokenSource(Settings.StorageTimeout);
-                        var resetCount = await Storage.ResetAwaitingAckToPendingAsync(cts.Token);
-                        if (resetCount > 0)
-                            _log.Warning(
-                                "Reset [{0}] AwaitingAck reminder(s) from previous scheduler instance back to Pending",
-                                resetCount);
-                    }
-                    catch (Exception ex)
-                    {
-                        _log.Error(ex,
-                            "Failed to reset AwaitingAck reminders to Pending on startup — " +
-                            "they will be recovered on the next scheduler restart");
-                    }
-                });
+                // Scheduled as a message so it doesn't block the mailbox during startup.
+                Self.Tell(RecoverAwaitingAck.Instance);
                 break;
             case Status.Failure failure:
                 _log.Error(failure.Cause, "Failed to load reminder overview from storage - restarting...");
@@ -499,6 +493,37 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                         ackSender.Tell(new ReminderProtocol.ReminderAckResponse(
                             ack.Entity, ack.Key, ReminderAckResponseCode.Error, ex.Message),
                             ActorRefs.NoSender);
+                    }
+                });
+                break;
+            }
+            case RecoverAwaitingAck:
+            {
+                // Reset any AwaitingAck reminders from a previous scheduler instance back to Pending.
+                // The in-memory _awaitingAck dict is always empty at startup, so any row still
+                // marked AwaitingAck in the DB would be permanently stuck without this reset.
+                RunTask(async () =>
+                {
+                    try
+                    {
+                        using var cts = new CancellationTokenSource(Settings.StorageTimeout);
+                        var resetCount = await Storage.ResetAwaitingAckToPendingAsync(cts.Token);
+                        if (resetCount > 0)
+                        {
+                            _log.Warning(
+                                "Reset [{0}] AwaitingAck reminder(s) from previous scheduler instance back to Pending",
+                                resetCount);
+                            // Refresh overview since we just made more reminders Pending
+                            using var overviewCts = new CancellationTokenSource(Settings.StorageTimeout);
+                            PendingReminders = await Storage.GetRemindersOverviewAsync(TimeProvider.Now, overviewCts.Token);
+                            TryScheduleFetchReminders();
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _log.Error(ex,
+                            "Failed to reset AwaitingAck reminders to Pending on startup — " +
+                            "they will be recovered on the next scheduler restart");
                     }
                 });
                 break;

--- a/src/Akka.Reminders/ReminderScheduler.cs
+++ b/src/Akka.Reminders/ReminderScheduler.cs
@@ -280,7 +280,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         if (_nextAckTimeoutAt.HasValue && _nextAckTimeoutAt.Value <= ackDeadlineUtc)
             return;
 
-        _nextAckTimeoutCheck?.Cancel();
+        CancelAckTimeoutCheck();
         _nextAckTimeoutAt = ackDeadlineUtc;
 
         var delay = ackDeadlineUtc - TimeProvider.Now;

--- a/src/Akka.Reminders/ReminderScheduler.cs
+++ b/src/Akka.Reminders/ReminderScheduler.cs
@@ -594,6 +594,22 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         return reminders.PipeTo(Self, success: overview => overview, failure: ex => new Status.Failure(ex));
     }
 
+    private static readonly Type OpenGenericEnvelopeType = typeof(ReminderEnvelope<>);
+
+    /// <summary>
+    /// Constructs a <see cref="ReminderEnvelope{T}"/> using the runtime type of the message.
+    /// Ensures both local and remote delivery produce the strongly-typed generic envelope
+    /// so that <c>Receive&lt;ReminderEnvelope&lt;T&gt;&gt;</c> handlers match correctly.
+    /// </summary>
+    private static ReminderEnvelope CreateTypedEnvelope(ReminderEntity entity, ReminderKey key, object message)
+    {
+        var messageType = message.GetType();
+        var closedType = OpenGenericEnvelopeType.MakeGenericType(messageType);
+        return (ReminderEnvelope)(Activator.CreateInstance(closedType, entity, key, message)
+            ?? throw new InvalidOperationException(
+                $"Failed to create {closedType.FullName} for message type {messageType.FullName}"));
+    }
+
     private async Task ProcessReminders(DateTimeOffset untilDeadline)
     {
         var totalDelivered = 0;
@@ -693,7 +709,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                     else
                     {
                         _log.Debug("Sending reminder {0} to {1}", reminder, shardRegion);
-                        var envelope = new ReminderEnvelope(reminder.Entity, reminder.Key, reminder.Message);
+                        var envelope = CreateTypedEnvelope(reminder.Entity, reminder.Key, reminder.Message);
                         ShardRegionResolver.DeliverReminder(reminder.Entity, envelope, Self);
 
                         var ackDeadline = TimeProvider.Now.Add(Settings.AckTimeout);

--- a/src/Akka.Reminders/ReminderScheduler.cs
+++ b/src/Akka.Reminders/ReminderScheduler.cs
@@ -211,6 +211,29 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 Stash.UnstashAll(); // Process any messages that arrived during initialization
                 TryScheduleFetchReminders();
                 Timers.Cancel(RestartBackoffTimer.Instance); // if needed
+
+                // Recover reminders left in AwaitingAck by a previous scheduler instance.
+                // The in-memory _awaitingAck dict is always empty at startup, so any row
+                // still marked AwaitingAck in the DB would be permanently stuck without this reset.
+                // Non-fatal: if the reset fails those reminders will be recovered on next restart.
+                RunTask(async () =>
+                {
+                    try
+                    {
+                        using var cts = new CancellationTokenSource(Settings.StorageTimeout);
+                        var resetCount = await Storage.ResetAwaitingAckToPendingAsync(cts.Token);
+                        if (resetCount > 0)
+                            _log.Warning(
+                                "Reset [{0}] AwaitingAck reminder(s) from previous scheduler instance back to Pending",
+                                resetCount);
+                    }
+                    catch (Exception ex)
+                    {
+                        _log.Error(ex,
+                            "Failed to reset AwaitingAck reminders to Pending on startup — " +
+                            "they will be recovered on the next scheduler restart");
+                    }
+                });
                 break;
             case Status.Failure failure:
                 _log.Error(failure.Cause, "Failed to load reminder overview from storage - restarting...");
@@ -407,9 +430,11 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                     break;
                 }
 
+                // Optimistically remove — will re-add on storage failure so the timeout checker can retry
                 _awaitingAck.Remove(lookupKey);
 
                 var ackedReminder = entry.Reminder;
+                var originalEntry = entry; // captured for re-add on failure
 
                 RunTask(async () =>
                 {
@@ -418,10 +443,11 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                         if (ackedReminder.RepeatInterval.HasValue)
                         {
                             // Recurring reminder: schedule the next occurrence.
+                            // Anchor to the original When so repeated acks cannot drift the schedule.
                             // ScheduleReminderAsync clears any lingering AwaitingAck state for the key.
                             var nextOccurrence = ackedReminder with
                             {
-                                When = TimeProvider.Now.Add(ackedReminder.RepeatInterval.Value),
+                                When = ackedReminder.When.Add(ackedReminder.RepeatInterval.Value),
                                 AttemptCount = 0,
                                 LastFailureReason = null
                             };
@@ -465,8 +491,11 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                     }
                     catch (Exception ex)
                     {
-                        _log.Error(ex, "Error processing ReminderAck for [{0}] / [{1}]",
+                        _log.Error(ex,
+                            "Error processing ReminderAck for [{0}] / [{1}] — re-adding to awaiting-ack for retry",
                             ack.Entity, ack.Key);
+                        // Re-add with the original deadline so the timeout checker will eventually retry
+                        _awaitingAck[lookupKey] = originalEntry;
                         ackSender.Tell(new ReminderProtocol.ReminderAckResponse(
                             ack.Entity, ack.Key, ReminderAckResponseCode.Error, ex.Message),
                             ActorRefs.NoSender);

--- a/src/Akka.Reminders/ReminderScheduler.cs
+++ b/src/Akka.Reminders/ReminderScheduler.cs
@@ -133,7 +133,6 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
     private bool _processingReminders;
     private bool _processingAckTimeouts;
     private bool _ackFlushScheduled;
-    private ICancelable? _nextAckTimeoutCheck;
     private DateTimeOffset? _nextAckTimeoutAt;
 
     private readonly Dictionary<(ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc), BufferedAckWrite>
@@ -268,8 +267,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
 
     private void CancelAckTimeoutCheck()
     {
-        _nextAckTimeoutCheck?.Cancel();
-        _nextAckTimeoutCheck = null;
+        Timers.Cancel(CheckAckTimeouts.Instance);
         _nextAckTimeoutAt = null;
     }
 
@@ -280,18 +278,13 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         if (_nextAckTimeoutAt.HasValue && _nextAckTimeoutAt.Value <= ackDeadlineUtc)
             return;
 
-        CancelAckTimeoutCheck();
         _nextAckTimeoutAt = ackDeadlineUtc;
 
         var delay = ackDeadlineUtc - TimeProvider.Now;
         if (delay < TimeSpan.Zero)
             delay = TimeSpan.Zero;
 
-        _nextAckTimeoutCheck = Context.System.Scheduler.ScheduleTellOnceCancelable(
-            delay,
-            Self,
-            CheckAckTimeouts.Instance,
-            Self);
+        Timers.StartSingleTimer(CheckAckTimeouts.Instance, CheckAckTimeouts.Instance, delay);
     }
 
     private void TrackAckDeadlines(IEnumerable<AwaitingAckReminder> reminders)
@@ -645,7 +638,6 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 if (_processingAckTimeouts)
                     break;
 
-                _nextAckTimeoutCheck = null;
                 _nextAckTimeoutAt = null;
 
                 _processingAckTimeouts = true;
@@ -689,7 +681,7 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
 
     protected override void PostStop()
     {
-        CancelAckTimeoutCheck();
+        // IWithTimers cancels all timers automatically on stop.
         base.PostStop();
     }
 

--- a/src/Akka.Reminders/ReminderScheduler.cs
+++ b/src/Akka.Reminders/ReminderScheduler.cs
@@ -130,11 +130,37 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
     /// </summary>
     private bool _writeCircuitOpen;
 
+    /// <summary>
+    /// Guards against re-entrant FetchReminders processing. RunTask suspends the mailbox,
+    /// but the timer could fire again before FetchRemindersCompleted is processed.
+    /// </summary>
     private bool _processingReminders;
+
+    /// <summary>
+    /// Same guard for CheckAckTimeouts — prevents overlapping ack-timeout scans.
+    /// </summary>
     private bool _processingAckTimeouts;
+
+    /// <summary>
+    /// Debounce flag for ack flush scheduling. Multiple ReminderAck messages can arrive
+    /// while the actor is processing other work; this flag ensures only one
+    /// FlushBufferedAcks self-message is queued at a time.
+    /// </summary>
     private bool _ackFlushScheduled;
+
+    /// <summary>
+    /// Tracks the currently scheduled ack-timeout deadline so we can avoid rescheduling
+    /// the timer when a later deadline arrives. Only replaced when an earlier deadline
+    /// is found.
+    /// </summary>
     private DateTimeOffset? _nextAckTimeoutAt;
 
+    /// <summary>
+    /// In-memory buffer for incoming acks. Acks are NOT written to storage immediately —
+    /// they accumulate here and are flushed in batches via FlushBufferedAcksAsync.
+    /// Keyed by occurrence identity so duplicate acks for the same occurrence are
+    /// coalesced (additional senders are appended to the existing entry's ReplyTo list).
+    /// </summary>
     private readonly Dictionary<(ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc), BufferedAckWrite>
         _bufferedAcknowledgements = new();
 
@@ -256,6 +282,11 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         DateTimeOffset dueTimeUtc)
         => (entity, key, dueTimeUtc);
 
+    /// <summary>
+    /// Schedules a FlushBufferedAcks message to self if one isn't already pending.
+    /// Uses Self.Tell (not a timer) so the flush happens on the next mailbox dispatch —
+    /// essentially "as soon as possible" without blocking the current message handler.
+    /// </summary>
     private void ScheduleBufferedAckFlush()
     {
         if (_ackFlushScheduled || _bufferedAcknowledgements.Count == 0)
@@ -271,8 +302,15 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         _nextAckTimeoutAt = null;
     }
 
+    /// <summary>
+    /// Schedules a CheckAckTimeouts timer at the given deadline, but only if it's
+    /// earlier than any currently scheduled check. This ensures the ack-timeout checker
+    /// fires at the earliest possible deadline across all AwaitingAck reminders.
+    /// StartSingleTimer with the same key automatically cancels any prior timer.
+    /// </summary>
     private void ScheduleAckTimeoutCheck(DateTimeOffset ackDeadlineUtc)
     {
+        // Already have an earlier or equal deadline scheduled — no need to reschedule.
         if (_nextAckTimeoutAt.HasValue && _nextAckTimeoutAt.Value <= ackDeadlineUtc)
             return;
 
@@ -315,6 +353,13 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
             _ => ReminderAckResponseCode.Error
         };
 
+    /// <summary>
+    /// Drains the ack buffer in batches, writing each batch to storage via
+    /// AcknowledgeRemindersAsync. On success, marks the occurrence as Delivered
+    /// and refreshes the ack-timeout schedule. On failure, replies Error to all
+    /// buffered senders — the occurrence stays AwaitingAck and will be retried
+    /// after the ack timeout fires.
+    /// </summary>
     private async Task FlushBufferedAcksAsync()
     {
         var shouldRefreshAckTimeoutSchedule = false;
@@ -325,6 +370,9 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 .Take(Settings.AckFlushBatchSize)
                 .ToList();
 
+            // Remove from the buffer before writing — if the write fails, the entries
+            // are gone. This is safe because the occurrence stays AwaitingAck in storage
+            // and the ack-timeout checker will handle it on the next scan.
             foreach (var entry in batch)
                 _bufferedAcknowledgements.Remove(entry.Key);
 
@@ -425,6 +473,12 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         }
     }
 
+    /// <summary>
+    /// Main behavior after initialization. Handles scheduling commands, delivery ticks,
+    /// ack processing, and ack-timeout scanning. All I/O-bound work uses RunTask to
+    /// avoid blocking the dispatcher thread — the mailbox is suspended until each
+    /// RunTask completes.
+    /// </summary>
     private void Scheduling(object message)
     {
         switch (message)
@@ -435,6 +489,10 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                     break;
 
                 _processingReminders = true;
+                // Each tick: flush any pending acks first (so the fetch sees up-to-date
+                // storage state), then expire stale reminders, then process due reminders.
+                // MaxSlippage causes the scheduler to fetch slightly ahead of the current
+                // time, avoiding a re-schedule for reminders about to become due.
                 RunTask(async () =>
                 {
                     try
@@ -603,6 +661,9 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 });
                 break;
             }
+            // Acks are buffered in memory and flushed in batches, not written per-ack.
+            // If multiple acks arrive for the same occurrence (duplicate delivery),
+            // they're coalesced — all senders get the same response when the batch flushes.
             case ReminderProtocol.ReminderAck ack:
             {
                 _log.Debug("Received ReminderAck for [{0}] / [{1}] due at [{2}]", ack.Entity, ack.Key, ack.DueTimeUtc);
@@ -610,6 +671,8 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 var occurrenceKey = ToOccurrenceKey(ack.Entity, ack.Key, ack.DueTimeUtc);
                 if (_bufferedAcknowledgements.TryGetValue(occurrenceKey, out var bufferedAck))
                 {
+                    // Duplicate ack for an occurrence already in the buffer — just
+                    // append the sender so they get the response when it flushes.
                     bufferedAck.AddReplyTo(ackSender);
                 }
                 else
@@ -631,6 +694,11 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 RunTask(FlushBufferedAcksAsync);
                 break;
             }
+            // Fired by a deadline-driven one-shot timer (not periodic). Scans storage
+            // for AwaitingAck rows whose ack deadline has elapsed, and either retries
+            // them (back to Pending with backoff) or marks them terminal (Failed/Expired).
+            // Flushes buffered acks first so we don't retry an occurrence that was
+            // actually acked but not yet flushed.
             case CheckAckTimeouts:
             {
                 if (_processingAckTimeouts)
@@ -749,6 +817,15 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 $"Failed to create {closedType.FullName} for message type {messageType.FullName}"));
     }
 
+    /// <summary>
+    /// Computes the absolute UTC deadline for a reminder occurrence.
+    ///
+    /// Rules:
+    /// - No window, no repeat: null (infinite — retries until MaxDeliveryAttempts).
+    /// - Window set: due + window.
+    /// - Recurring: clamped to the next occurrence's due time (latest-only semantics).
+    /// - Both: min(due + window, next due).
+    /// </summary>
     private static DateTimeOffset? ComputeDeliveryDeadlineUtc(
         DateTimeOffset dueTimeUtc,
         TimeSpan? repeatInterval,
@@ -784,6 +861,11 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
             OccurrenceDueTimeUtc: dueTimeUtc);
     }
 
+    /// <summary>
+    /// Creates the next occurrence for a recurring reminder. Both when_utc and due_time_utc
+    /// advance by RepeatInterval — this is a NEW row with a new occurrence identity,
+    /// not a mutation of the current one. AttemptCount resets to 0 for the fresh occurrence.
+    /// </summary>
     private ScheduledReminder CreateNextRecurringOccurrence(ScheduledReminder reminder)
     {
         if (!reminder.RepeatInterval.HasValue)
@@ -800,6 +882,15 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
         };
     }
 
+    /// <summary>
+    /// Attempts to create a retry for a failed reminder delivery. Returns false when
+    /// the reminder has exhausted its retry budget (MaxDeliveryAttempts) or its
+    /// delivery deadline has passed — in those cases, the caller should mark it terminal.
+    ///
+    /// The retry uses exponential backoff: when_utc is pushed forward by
+    /// RetryBackoffBase * 2^AttemptCount (capped by MaxRetryBackoff). The DueTimeUtc
+    /// (occurrence identity) stays fixed so the ack still matches the original occurrence.
+    /// </summary>
     private bool TryCreateRetryReminder(
         ScheduledReminder reminder,
         DateTimeOffset now,
@@ -809,12 +900,14 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
     {
         retryReminder = reminder;
 
+        // Deadline passed — no point retrying.
         if (reminder.DeliveryDeadlineUtc.HasValue && reminder.DeliveryDeadlineUtc.Value <= now)
         {
             terminalStatus = ReminderCompletionStatus.Expired;
             return false;
         }
 
+        // Used all attempts.
         if (reminder.AttemptCount + 1 >= Settings.MaxDeliveryAttempts)
         {
             terminalStatus = ReminderCompletionStatus.Failed;
@@ -827,12 +920,15 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                 Settings.MaxRetryBackoff.TotalSeconds));
         var retryAt = now.Add(backoff);
 
+        // Backoff would land after the deadline — expire instead of scheduling a doomed retry.
         if (reminder.DeliveryDeadlineUtc.HasValue && retryAt >= reminder.DeliveryDeadlineUtc.Value)
         {
             terminalStatus = ReminderCompletionStatus.Expired;
             return false;
         }
 
+        // Push when_utc forward (changes the fetch time) but keep DueTimeUtc fixed
+        // (preserves the occurrence identity for ack matching).
         retryReminder = reminder with
         {
             When = retryAt,
@@ -1069,11 +1165,17 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                     {
                         var ackDeadline = TimeProvider.Now.Add(Settings.AckTimeout);
 
+                        // For recurring reminders, pre-create the next occurrence NOW
+                        // (before delivery) so it's persisted in the same commit batch.
+                        // This means the next occurrence exists in storage even if the
+                        // scheduler crashes after delivery — no occurrences are lost.
                         if (reminder.RepeatInterval.HasValue)
                         {
                             occurrencesToUpsert.Add(CreateNextRecurringOccurrence(reminder));
                         }
 
+                        // Move the current occurrence to AwaitingAck. It stays there
+                        // until the entity acks it or the ack deadline elapses.
                         remindersToAwaitAck.Add(new AwaitingAckReminder(
                             reminder.Entity,
                             reminder.Key,
@@ -1084,6 +1186,9 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                     }
                 }
 
+                // Phase 3: Commit all mutations in a single atomic batch BEFORE delivery.
+                // This is the key correctness boundary — if the write fails, nothing is
+                // delivered, so there are zero duplicate deliveries on first failure.
                 var writeFailed = false;
                 var mutationBatch = new ReminderMutationBatch(
                     occurrencesToUpsert,
@@ -1122,6 +1227,9 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                     break;
                 }
 
+                // Update the in-memory overview incrementally from upserted reminders
+                // (next recurring occurrences, retries). Avoids an extra storage query
+                // per chunk — the overview is only reloaded from storage on failure.
                 if (occurrencesToUpsert.Count > 0)
                 {
                     foreach (var pendingReminder in occurrencesToUpsert)
@@ -1141,6 +1249,9 @@ internal sealed class ReminderScheduler : UntypedActor, IWithTimers, IWithStash
                     _log.Info("Write circuit CLOSED — database writes recovered, resuming full-batch processing");
                 }
 
+                // Phase 4: Deliver AFTER the commit succeeds. If we get here, storage
+                // has the AwaitingAck state persisted, so a crash after delivery is safe —
+                // the ack-timeout checker will find the unacked occurrence and retry it.
                 foreach (var delivery in deliveries)
                 {
                     _log.Debug("Sending reminder occurrence [{0}] / [{1}] due at [{2}] to [{3}]",

--- a/src/Akka.Reminders/Serialization/ReminderSerializer.cs
+++ b/src/Akka.Reminders/Serialization/ReminderSerializer.cs
@@ -38,7 +38,7 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
     }
 
     private Akka.Serialization.Serialization SerializationSystem
-        => _serialization ??= Akka.Serialization.Serialization.For(_system);
+        => _serialization ??= _system.Serialization;
 
     /// <inheritdoc />
     public override int Identifier => 22550;

--- a/src/Akka.Reminders/Serialization/ReminderSerializer.cs
+++ b/src/Akka.Reminders/Serialization/ReminderSerializer.cs
@@ -24,15 +24,21 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
 
     private static readonly Type ReminderEnvelopeOpenGenericType = typeof(ReminderEnvelope<>);
 
-    private readonly Akka.Serialization.Serialization _serialization;
+    private readonly ExtendedActorSystem _system;
+    private Akka.Serialization.Serialization? _serialization;
 
     /// <summary>
     /// Creates a new <see cref="ReminderSerializer"/> bound to the given actor system.
     /// </summary>
     public ReminderSerializer(ExtendedActorSystem system) : base(system)
     {
-        _serialization = new Akka.Serialization.Serialization(system);
+        _system = system;
+        // Lazy — we cannot create a new Serialization instance here because that would
+        // re-instantiate all registered serializers including this one, causing a stack overflow.
     }
+
+    private Akka.Serialization.Serialization SerializationSystem
+        => _serialization ??= Akka.Serialization.Serialization.For(_system);
 
     /// <inheritdoc />
     public override int Identifier => 22550;
@@ -77,7 +83,7 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
         writer.Write(envelope.Key.Name);
 
         // Delegate inner message serialization to Akka's serialization infrastructure
-        var innerSerializer = _serialization.FindSerializerFor(envelope.Message);
+        var innerSerializer = SerializationSystem.FindSerializerFor(envelope.Message);
         var innerManifest = Akka.Serialization.Serialization.ManifestFor(innerSerializer, envelope.Message);
         var innerBytes = innerSerializer.ToBinary(envelope.Message);
 
@@ -107,7 +113,7 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
         var innerLength = reader.ReadInt32();
         var innerBytes = reader.ReadBytes(innerLength);
 
-        var innerMessage = _serialization.Deserialize(innerBytes, innerSerializerId, innerManifest);
+        var innerMessage = SerializationSystem.Deserialize(innerBytes, innerSerializerId, innerManifest);
 
         // Construct ReminderEnvelope<T> using the runtime type of the deserialized message
         var messageType = innerMessage.GetType();

--- a/src/Akka.Reminders/Serialization/ReminderSerializer.cs
+++ b/src/Akka.Reminders/Serialization/ReminderSerializer.cs
@@ -5,9 +5,9 @@ using Akka.Serialization;
 namespace Akka.Reminders.Serialization;
 
 /// <summary>
-/// Custom Akka serializer for <see cref="ReminderEnvelope"/>, <see cref="ReminderProtocol.ReminderAck"/>,
-/// and <see cref="ReminderProtocol.ReminderAckResponse"/>. Handles cross-node serialization for
-/// Akka.Remote and Akka.Cluster deployments.
+/// Custom Akka serializer for all <see cref="IReminderWireMessage"/> types. Handles cross-node
+/// serialization for Akka.Remote and Akka.Cluster deployments. Registered via
+/// <c>WithCustomSerializer</c> in <see cref="AkkaHostingExtensions"/>.
 /// </summary>
 /// <remarks>
 /// <para>

--- a/src/Akka.Reminders/Serialization/ReminderSerializer.cs
+++ b/src/Akka.Reminders/Serialization/ReminderSerializer.cs
@@ -82,6 +82,10 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
         // Write key field
         writer.Write(envelope.Key.Name);
 
+        // Write occurrence metadata
+        writer.Write(envelope.DueTimeUtc.UtcTicks);
+        writer.Write(envelope.Deadline.UtcDateTime.UtcTicks);
+
         // Delegate inner message serialization to Akka's serialization infrastructure
         var innerSerializer = SerializationSystem.FindSerializerFor(envelope.Message);
         var innerManifest = Akka.Serialization.Serialization.ManifestFor(innerSerializer, envelope.Message);
@@ -108,6 +112,9 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
         var keyName = reader.ReadString();
         var key = new ReminderKey(keyName);
 
+        var dueTimeUtc = new DateTimeOffset(reader.ReadInt64(), TimeSpan.Zero);
+        var deadline = new ReminderDeadline(new DateTimeOffset(reader.ReadInt64(), TimeSpan.Zero));
+
         var innerSerializerId = reader.ReadInt32();
         var innerManifest = reader.ReadString();
         var innerLength = reader.ReadInt32();
@@ -118,7 +125,7 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
         // Construct ReminderEnvelope<T> using the runtime type of the deserialized message
         var messageType = innerMessage.GetType();
         var closedGenericType = ReminderEnvelopeOpenGenericType.MakeGenericType(messageType);
-        var envelope = Activator.CreateInstance(closedGenericType, entity, key, innerMessage)
+        var envelope = Activator.CreateInstance(closedGenericType, entity, key, dueTimeUtc, deadline, innerMessage)
             ?? throw new InvalidOperationException(
                 $"Failed to create {closedGenericType.FullName} via Activator.CreateInstance.");
 
@@ -133,6 +140,7 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
         writer.Write(ack.Entity.ShardRegionName);
         writer.Write(ack.Entity.EntityId);
         writer.Write(ack.Key.Name);
+        writer.Write(ack.DueTimeUtc.UtcTicks);
 
         writer.Flush();
         return stream.ToArray();
@@ -146,10 +154,12 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
         var shardRegionName = reader.ReadString();
         var entityId = reader.ReadString();
         var keyName = reader.ReadString();
+        var dueTimeUtc = new DateTimeOffset(reader.ReadInt64(), TimeSpan.Zero);
 
         return new ReminderProtocol.ReminderAck(
             new ReminderEntity(shardRegionName, entityId),
-            new ReminderKey(keyName));
+            new ReminderKey(keyName),
+            dueTimeUtc);
     }
 
     private static byte[] SerializeReminderAckResponse(ReminderProtocol.ReminderAckResponse response)
@@ -160,6 +170,7 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
         writer.Write(response.Entity.ShardRegionName);
         writer.Write(response.Entity.EntityId);
         writer.Write(response.Key.Name);
+        writer.Write(response.DueTimeUtc.UtcTicks);
         writer.Write((int)response.ResponseCode);
         writer.Write(response.Message ?? string.Empty);
 
@@ -175,12 +186,14 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
         var shardRegionName = reader.ReadString();
         var entityId = reader.ReadString();
         var keyName = reader.ReadString();
+        var dueTimeUtc = new DateTimeOffset(reader.ReadInt64(), TimeSpan.Zero);
         var responseCode = (ReminderAckResponseCode)reader.ReadInt32();
         var message = reader.ReadString();
 
         return new ReminderProtocol.ReminderAckResponse(
             new ReminderEntity(shardRegionName, entityId),
             new ReminderKey(keyName),
+            dueTimeUtc,
             responseCode,
             string.IsNullOrEmpty(message) ? null : message);
     }

--- a/src/Akka.Reminders/Serialization/ReminderSerializer.cs
+++ b/src/Akka.Reminders/Serialization/ReminderSerializer.cs
@@ -1,0 +1,181 @@
+using System.Text;
+using Akka.Actor;
+using Akka.Serialization;
+
+namespace Akka.Reminders.Serialization;
+
+/// <summary>
+/// Custom Akka serializer for <see cref="ReminderEnvelope"/>, <see cref="ReminderProtocol.ReminderAck"/>,
+/// and <see cref="ReminderProtocol.ReminderAckResponse"/>. Handles cross-node serialization for
+/// Akka.Remote and Akka.Cluster deployments.
+/// </summary>
+/// <remarks>
+/// The binary format for <see cref="ReminderEnvelope"/> writes the entity and key fields using
+/// length-prefixed UTF-8 strings, then delegates the inner message to Akka's existing serialization
+/// infrastructure (serializer id + manifest + payload). Deserialization reconstructs the strongly-typed
+/// <see cref="ReminderEnvelope{T}"/> by using the runtime type of the deserialized inner message via
+/// reflection to call <see cref="Type.MakeGenericType"/>.
+/// </remarks>
+public sealed class ReminderSerializer : SerializerWithStringManifest
+{
+    private const string ReminderEnvelopeManifest = "re";
+    private const string ReminderAckManifest = "ra";
+    private const string ReminderAckResponseManifest = "rar";
+
+    private static readonly Type ReminderEnvelopeOpenGenericType = typeof(ReminderEnvelope<>);
+
+    private readonly Akka.Serialization.Serialization _serialization;
+
+    /// <summary>
+    /// Creates a new <see cref="ReminderSerializer"/> bound to the given actor system.
+    /// </summary>
+    public ReminderSerializer(ExtendedActorSystem system) : base(system)
+    {
+        _serialization = new Akka.Serialization.Serialization(system);
+    }
+
+    /// <inheritdoc />
+    public override int Identifier => 22550;
+
+    /// <inheritdoc />
+    public override string Manifest(object o) => o switch
+    {
+        ReminderEnvelope => ReminderEnvelopeManifest,
+        ReminderProtocol.ReminderAck => ReminderAckManifest,
+        ReminderProtocol.ReminderAckResponse => ReminderAckResponseManifest,
+        _ => throw new ArgumentException($"{nameof(ReminderSerializer)} does not support serializing [{o.GetType().FullName}]", nameof(o))
+    };
+
+    /// <inheritdoc />
+    public override byte[] ToBinary(object obj) => obj switch
+    {
+        ReminderEnvelope envelope => SerializeReminderEnvelope(envelope),
+        ReminderProtocol.ReminderAck ack => SerializeReminderAck(ack),
+        ReminderProtocol.ReminderAckResponse ackResponse => SerializeReminderAckResponse(ackResponse),
+        _ => throw new ArgumentException($"{nameof(ReminderSerializer)} does not support serializing [{obj.GetType().FullName}]", nameof(obj))
+    };
+
+    /// <inheritdoc />
+    public override object FromBinary(byte[] bytes, string manifest) => manifest switch
+    {
+        ReminderEnvelopeManifest => DeserializeReminderEnvelope(bytes),
+        ReminderAckManifest => DeserializeReminderAck(bytes),
+        ReminderAckResponseManifest => DeserializeReminderAckResponse(bytes),
+        _ => throw new ArgumentException($"{nameof(ReminderSerializer)} does not recognize manifest [{manifest}]", nameof(manifest))
+    };
+
+    private byte[] SerializeReminderEnvelope(ReminderEnvelope envelope)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+
+        // Write entity fields
+        writer.Write(envelope.Entity.ShardRegionName);
+        writer.Write(envelope.Entity.EntityId);
+
+        // Write key field
+        writer.Write(envelope.Key.Name);
+
+        // Delegate inner message serialization to Akka's serialization infrastructure
+        var innerSerializer = _serialization.FindSerializerFor(envelope.Message);
+        var innerManifest = Akka.Serialization.Serialization.ManifestFor(innerSerializer, envelope.Message);
+        var innerBytes = innerSerializer.ToBinary(envelope.Message);
+
+        writer.Write(innerSerializer.Identifier);
+        writer.Write(innerManifest);
+        writer.Write(innerBytes.Length);
+        writer.Write(innerBytes);
+
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    private ReminderEnvelope DeserializeReminderEnvelope(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes);
+        using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+
+        var shardRegionName = reader.ReadString();
+        var entityId = reader.ReadString();
+        var entity = new ReminderEntity(shardRegionName, entityId);
+
+        var keyName = reader.ReadString();
+        var key = new ReminderKey(keyName);
+
+        var innerSerializerId = reader.ReadInt32();
+        var innerManifest = reader.ReadString();
+        var innerLength = reader.ReadInt32();
+        var innerBytes = reader.ReadBytes(innerLength);
+
+        var innerMessage = _serialization.Deserialize(innerBytes, innerSerializerId, innerManifest);
+
+        // Construct ReminderEnvelope<T> using the runtime type of the deserialized message
+        var messageType = innerMessage.GetType();
+        var closedGenericType = ReminderEnvelopeOpenGenericType.MakeGenericType(messageType);
+        var envelope = Activator.CreateInstance(closedGenericType, entity, key, innerMessage)
+            ?? throw new InvalidOperationException(
+                $"Failed to create {closedGenericType.FullName} via Activator.CreateInstance.");
+
+        return (ReminderEnvelope)envelope;
+    }
+
+    private static byte[] SerializeReminderAck(ReminderProtocol.ReminderAck ack)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+
+        writer.Write(ack.Entity.ShardRegionName);
+        writer.Write(ack.Entity.EntityId);
+        writer.Write(ack.Key.Name);
+
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    private static ReminderProtocol.ReminderAck DeserializeReminderAck(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes);
+        using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+
+        var shardRegionName = reader.ReadString();
+        var entityId = reader.ReadString();
+        var keyName = reader.ReadString();
+
+        return new ReminderProtocol.ReminderAck(
+            new ReminderEntity(shardRegionName, entityId),
+            new ReminderKey(keyName));
+    }
+
+    private static byte[] SerializeReminderAckResponse(ReminderProtocol.ReminderAckResponse response)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+
+        writer.Write(response.Entity.ShardRegionName);
+        writer.Write(response.Entity.EntityId);
+        writer.Write(response.Key.Name);
+        writer.Write((int)response.ResponseCode);
+        writer.Write(response.Message ?? string.Empty);
+
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    private static ReminderProtocol.ReminderAckResponse DeserializeReminderAckResponse(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes);
+        using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+
+        var shardRegionName = reader.ReadString();
+        var entityId = reader.ReadString();
+        var keyName = reader.ReadString();
+        var responseCode = (ReminderAckResponseCode)reader.ReadInt32();
+        var message = reader.ReadString();
+
+        return new ReminderProtocol.ReminderAckResponse(
+            new ReminderEntity(shardRegionName, entityId),
+            new ReminderKey(keyName),
+            responseCode,
+            string.IsNullOrEmpty(message) ? null : message);
+    }
+}

--- a/src/Akka.Reminders/Serialization/ReminderSerializer.cs
+++ b/src/Akka.Reminders/Serialization/ReminderSerializer.cs
@@ -10,11 +10,56 @@ namespace Akka.Reminders.Serialization;
 /// Akka.Remote and Akka.Cluster deployments.
 /// </summary>
 /// <remarks>
-/// The binary format for <see cref="ReminderEnvelope"/> writes the entity and key fields using
-/// length-prefixed UTF-8 strings, then delegates the inner message to Akka's existing serialization
-/// infrastructure (serializer id + manifest + payload). Deserialization reconstructs the strongly-typed
-/// <see cref="ReminderEnvelope{T}"/> by using the runtime type of the deserialized inner message via
-/// reflection to call <see cref="Type.MakeGenericType"/>.
+/// <para>
+/// Uses a hand-rolled binary format via <see cref="BinaryWriter"/>/<see cref="BinaryReader"/>.
+/// Strings are length-prefixed UTF-8 (BinaryWriter's default string encoding). Timestamps are
+/// stored as <c>Int64</c> UTC ticks. The inner message payload is delegated to Akka's own
+/// serialization infrastructure, so whatever serializer the user has configured for their
+/// message type handles that part.
+/// </para>
+///
+/// <para><b>Wire format: ReminderEnvelope (manifest "re")</b></para>
+/// <code>
+/// ┌──────────────────────────────────────────────────────────────┐
+/// │ ShardRegionName    : length-prefixed UTF-8 string           │
+/// │ EntityId           : length-prefixed UTF-8 string           │
+/// │ Key.Name           : length-prefixed UTF-8 string           │
+/// │ DueTimeUtc         : Int64 (UTC ticks)                      │
+/// │ Deadline           : Int64 (UTC ticks)                      │
+/// │ InnerSerializerId  : Int32 (Akka serializer identifier)     │
+/// │ InnerManifest      : length-prefixed UTF-8 string           │
+/// │ InnerPayloadLength : Int32                                  │
+/// │ InnerPayload       : byte[] (serialized by Akka)            │
+/// └──────────────────────────────────────────────────────────────┘
+/// </code>
+///
+/// <para><b>Wire format: ReminderAck (manifest "ra")</b></para>
+/// <code>
+/// ┌──────────────────────────────────────────────────────────────┐
+/// │ ShardRegionName    : length-prefixed UTF-8 string           │
+/// │ EntityId           : length-prefixed UTF-8 string           │
+/// │ Key.Name           : length-prefixed UTF-8 string           │
+/// │ DueTimeUtc         : Int64 (UTC ticks)                      │
+/// └──────────────────────────────────────────────────────────────┘
+/// </code>
+///
+/// <para><b>Wire format: ReminderAckResponse (manifest "rar")</b></para>
+/// <code>
+/// ┌──────────────────────────────────────────────────────────────┐
+/// │ ShardRegionName    : length-prefixed UTF-8 string           │
+/// │ EntityId           : length-prefixed UTF-8 string           │
+/// │ Key.Name           : length-prefixed UTF-8 string           │
+/// │ DueTimeUtc         : Int64 (UTC ticks)                      │
+/// │ ResponseCode       : Int32 (enum)                           │
+/// │ Message            : length-prefixed UTF-8 string (or "")   │
+/// └──────────────────────────────────────────────────────────────┘
+/// </code>
+///
+/// <para>
+/// Deserialization of <see cref="ReminderEnvelope"/> reconstructs the strongly-typed
+/// <see cref="ReminderEnvelope{T}"/> by using the runtime type of the deserialized inner
+/// message via reflection (<see cref="Type.MakeGenericType"/>).
+/// </para>
 /// </remarks>
 public sealed class ReminderSerializer : SerializerWithStringManifest
 {

--- a/src/Akka.Reminders/Sharding/IShardRegionResolver.cs
+++ b/src/Akka.Reminders/Sharding/IShardRegionResolver.cs
@@ -19,8 +19,7 @@ public interface IShardRegionResolver
     /// </summary>
     /// <param name="entity">The target entity for the reminder.</param>
     /// <param name="envelope">The reminder envelope containing the payload and metadata.</param>
-    /// <param name="sender">The actor reference to use as the sender of the message.</param>
-    public void DeliverReminder(ReminderEntity entity, ReminderEnvelope envelope, IActorRef sender);
+    public void DeliverReminder(ReminderEntity entity, ReminderEnvelope envelope);
 }
 
 /// <summary>
@@ -50,10 +49,10 @@ public sealed class DefaultShardRegionResolver : IShardRegionResolver
         return null;
     }
 
-    public void DeliverReminder(ReminderEntity entity, ReminderEnvelope envelope, IActorRef sender)
+    public void DeliverReminder(ReminderEntity entity, ReminderEnvelope envelope)
     {
         var shardRegion = TryResolve(entity);
-        shardRegion?.Tell(new ShardingEnvelope(entity.EntityId, envelope), sender);
+        shardRegion?.Tell(new ShardingEnvelope(entity.EntityId, envelope));
     }
 }
 
@@ -117,9 +116,9 @@ public sealed class TestShardRegionResolver : IShardRegionResolver
         return _shardRegions.GetValueOrDefault(entity.ShardRegionName);
     }
 
-    public void DeliverReminder(ReminderEntity entity, ReminderEnvelope envelope, IActorRef sender)
+    public void DeliverReminder(ReminderEntity entity, ReminderEnvelope envelope)
     {
         var actor = TryResolve(entity);
-        actor?.Tell(envelope, sender);
+        actor?.Tell(envelope);
     }
 }

--- a/src/Akka.Reminders/Sharding/IShardRegionResolver.cs
+++ b/src/Akka.Reminders/Sharding/IShardRegionResolver.cs
@@ -17,9 +17,10 @@ public interface IShardRegionResolver
     /// Delivers a reminder message to the target entity.
     /// Implementations handle the delivery mechanism (e.g., wrapping in ShardingEnvelope for cluster sharding).
     /// </summary>
-    /// <param name="entity">The target entity for the reminder</param>
-    /// <param name="message">The reminder message to deliver</param>
-    public void DeliverReminder(ReminderEntity entity, object message);
+    /// <param name="entity">The target entity for the reminder.</param>
+    /// <param name="envelope">The reminder envelope containing the payload and metadata.</param>
+    /// <param name="sender">The actor reference to use as the sender of the message.</param>
+    public void DeliverReminder(ReminderEntity entity, ReminderEnvelope envelope, IActorRef sender);
 }
 
 /// <summary>
@@ -49,13 +50,10 @@ public sealed class DefaultShardRegionResolver : IShardRegionResolver
         return null;
     }
 
-    public void DeliverReminder(ReminderEntity entity, object message)
+    public void DeliverReminder(ReminderEntity entity, ReminderEnvelope envelope, IActorRef sender)
     {
         var shardRegion = TryResolve(entity);
-        // Wrap message in ShardingEnvelope for cluster sharding
-        
-        // we don't want actors replying to the scheduler, so NoSender is used
-        shardRegion?.Tell(new ShardingEnvelope(entity.EntityId, message), ActorRefs.NoSender);
+        shardRegion?.Tell(new ShardingEnvelope(entity.EntityId, envelope), sender);
     }
 }
 
@@ -119,10 +117,9 @@ public sealed class TestShardRegionResolver : IShardRegionResolver
         return _shardRegions.GetValueOrDefault(entity.ShardRegionName);
     }
 
-    public void DeliverReminder(ReminderEntity entity, object message)
+    public void DeliverReminder(ReminderEntity entity, ReminderEnvelope envelope, IActorRef sender)
     {
         var actor = TryResolve(entity);
-        // Deliver message directly without wrapping - test actors handle raw messages
-        actor?.Tell(message, ActorRefs.NoSender);
+        actor?.Tell(envelope, sender);
     }
 }

--- a/src/Akka.Reminders/Sharding/IShardRegionResolver.cs
+++ b/src/Akka.Reminders/Sharding/IShardRegionResolver.cs
@@ -19,7 +19,8 @@ public interface IShardRegionResolver
     /// </summary>
     /// <param name="entity">The target entity for the reminder.</param>
     /// <param name="envelope">The reminder envelope containing the payload and metadata.</param>
-    public void DeliverReminder(ReminderEntity entity, ReminderEnvelope envelope);
+    /// <param name="sender">Optional sender actor reference. Defaults to <see cref="ActorRefs.NoSender"/>.</param>
+    public void DeliverReminder(ReminderEntity entity, ReminderEnvelope envelope, IActorRef? sender = null);
 }
 
 /// <summary>
@@ -49,10 +50,10 @@ public sealed class DefaultShardRegionResolver : IShardRegionResolver
         return null;
     }
 
-    public void DeliverReminder(ReminderEntity entity, ReminderEnvelope envelope)
+    public void DeliverReminder(ReminderEntity entity, ReminderEnvelope envelope, IActorRef? sender = null)
     {
         var shardRegion = TryResolve(entity);
-        shardRegion?.Tell(new ShardingEnvelope(entity.EntityId, envelope));
+        shardRegion?.Tell(new ShardingEnvelope(entity.EntityId, envelope), sender ?? ActorRefs.NoSender);
     }
 }
 
@@ -116,9 +117,9 @@ public sealed class TestShardRegionResolver : IShardRegionResolver
         return _shardRegions.GetValueOrDefault(entity.ShardRegionName);
     }
 
-    public void DeliverReminder(ReminderEntity entity, ReminderEnvelope envelope)
+    public void DeliverReminder(ReminderEntity entity, ReminderEnvelope envelope, IActorRef? sender = null)
     {
         var actor = TryResolve(entity);
-        actor?.Tell(envelope);
+        actor?.Tell(envelope, sender ?? ActorRefs.NoSender);
     }
 }

--- a/src/Akka.Reminders/Storage/IReminderStorage.cs
+++ b/src/Akka.Reminders/Storage/IReminderStorage.cs
@@ -120,11 +120,54 @@ public sealed record AwaitingAckReminder(
     DateTimeOffset AckDeadline);
 
 /// <summary>
+/// Batched mutation set applied by the scheduler inside a single storage commit.
+/// </summary>
+public sealed record ReminderMutationBatch(
+    IReadOnlyList<ScheduledReminder> PendingUpserts,
+    IReadOnlyList<CompletedReminder> CompletedReminders,
+    IReadOnlyList<AwaitingAckReminder> AwaitingAckReminders)
+{
+    public static ReminderMutationBatch Empty { get; } = new([], [], []);
+
+    public bool IsEmpty => PendingUpserts.Count == 0 && CompletedReminders.Count == 0 && AwaitingAckReminders.Count == 0;
+}
+
+/// <summary>
+/// Buffered acknowledgement write issued by the scheduler.
+/// </summary>
+public sealed record ReminderAcknowledgement(
+    ReminderEntity Entity,
+    ReminderKey Key,
+    DateTimeOffset DueTimeUtc,
+    DateTimeOffset AckedAt);
+
+/// <summary>
+/// Result status for a reminder acknowledgement write.
+/// </summary>
+public enum ReminderAckStorageStatus
+{
+    Success = 0,
+    NotFound = 1,
+    Error = 2
+}
+
+/// <summary>
 /// The result of acknowledging a reminder.
 /// </summary>
-/// <param name="Success">Whether the acknowledgement was successfully recorded.</param>
+/// <param name="Entity">Entity that owns the reminder occurrence.</param>
+/// <param name="Key">Reminder key.</param>
+/// <param name="DueTimeUtc">Occurrence identity.</param>
+/// <param name="Status">Ack write outcome.</param>
+/// <param name="ErrorMessage">Optional storage error details.</param>
 public sealed record AckResult(
-    bool Success);
+    ReminderEntity Entity,
+    ReminderKey Key,
+    DateTimeOffset DueTimeUtc,
+    ReminderAckStorageStatus Status,
+    string? ErrorMessage = null)
+{
+    public bool Success => Status == ReminderAckStorageStatus.Success;
+}
 
 /// <summary>
 /// Storage implementation for reminders.
@@ -133,6 +176,7 @@ public interface IReminderStorage
 {
     Task<ReminderProtocol.ReminderScheduled> ScheduleReminderAsync(ScheduledReminder reminder, CancellationToken ct = default);
     Task<bool> UpsertReminderOccurrencesAsync(IEnumerable<ScheduledReminder> reminders, CancellationToken ct = default);
+    Task<bool> CommitReminderMutationsAsync(ReminderMutationBatch mutationBatch, CancellationToken ct = default);
     Task<ReminderProtocol.RemindersCancelled> CancelReminderAsync(ReminderEntity entity, ReminderKey key, CancellationToken ct = default);
     
     Task<IReadOnlyList<ScheduledReminder>> GetRemindersForEntityAsync(ReminderEntity entity, int take = 10, int skip = 0, CancellationToken ct = default);
@@ -228,5 +272,9 @@ public interface IReminderStorage
         ReminderKey key,
         DateTimeOffset dueTimeUtc,
         DateTimeOffset ackedAt,
+        CancellationToken ct = default);
+
+    Task<IReadOnlyList<AckResult>> AcknowledgeRemindersAsync(
+        IEnumerable<ReminderAcknowledgement> acknowledgements,
         CancellationToken ct = default);
 }

--- a/src/Akka.Reminders/Storage/IReminderStorage.cs
+++ b/src/Akka.Reminders/Storage/IReminderStorage.cs
@@ -74,7 +74,13 @@ public enum ReminderCompletionStatus
     /// <summary>
     /// Reminder was explicitly cancelled by the user.
     /// </summary>
-    Cancelled = 3
+    Cancelled = 3,
+
+    /// <summary>
+    /// Reminder has been delivered but the recipient has not yet acknowledged it.
+    /// The reminder will be redelivered if the ack deadline passes without acknowledgement.
+    /// </summary>
+    AwaitingAck = 4
 }
 
 /// <summary>
@@ -85,6 +91,34 @@ public sealed record CompletedReminder(
     ReminderKey Key,
     DateTimeOffset When,
     ReminderCompletionStatus Status = ReminderCompletionStatus.Delivered);
+
+/// <summary>
+/// Tracks a reminder that has been delivered but is awaiting acknowledgement from the recipient.
+/// </summary>
+/// <param name="Entity">The entity that owns this reminder.</param>
+/// <param name="Key">The unique reminder key.</param>
+/// <param name="DeliveredAt">When the reminder was delivered to the recipient.</param>
+/// <param name="AckDeadline">The deadline by which the recipient must acknowledge the reminder.
+/// If this deadline passes without an ack, the reminder will be redelivered.</param>
+public sealed record AwaitingAckReminder(
+    ReminderEntity Entity,
+    ReminderKey Key,
+    DateTimeOffset DeliveredAt,
+    DateTimeOffset AckDeadline);
+
+/// <summary>
+/// The result of acknowledging a reminder.
+/// </summary>
+/// <param name="Success">Whether the acknowledgement was successfully recorded.</param>
+/// <param name="IsRecurring">Whether the acknowledged reminder was a recurring reminder.</param>
+/// <param name="OriginalReminder">
+/// For recurring reminders, the original reminder record so the caller can schedule the next occurrence.
+/// <c>null</c> for one-time reminders or when <paramref name="Success"/> is <c>false</c>.
+/// </param>
+public sealed record AckResult(
+    bool Success,
+    bool IsRecurring,
+    ScheduledReminder? OriginalReminder);
 
 /// <summary>
 /// Storage implementation for reminders.
@@ -135,4 +169,48 @@ public interface IReminderStorage
     /// <param name="ct"></param>
     /// <returns></returns>
     Task<bool> CleanUpCompletedRemindersAsync(DateTimeOffset olderThan, CancellationToken ct = default);
+
+    /// <summary>
+    /// Marks reminders as delivered but awaiting acknowledgement from the recipient.
+    /// Sets <c>completion_status = 'AwaitingAck'</c> and records the delivery and ack-deadline timestamps.
+    /// The reminder remains visible to due-reminder queries until it is either acknowledged or its
+    /// ack deadline expires and it is requeued.
+    /// </summary>
+    /// <param name="reminders">The reminders to transition into the awaiting-ack state.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns><c>true</c> if the update succeeded; <c>false</c> on storage error.</returns>
+    Task<bool> MarkRemindersAsAwaitingAckAsync(
+        IEnumerable<AwaitingAckReminder> reminders,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets reminders whose ack deadline has passed without acknowledgement.
+    /// These reminders should be redelivered to their target entities.
+    /// </summary>
+    /// <param name="now">The current time; reminders with <c>ack_deadline_utc &lt;= now</c> are returned.</param>
+    /// <param name="maxCount">Maximum number of timed-out reminders to return per call.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A list of reminders that must be redelivered.</returns>
+    Task<IReadOnlyList<ScheduledReminder>> GetTimedOutAckRemindersAsync(
+        DateTimeOffset now,
+        ReminderBatchSize maxCount,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Acknowledges a reminder, marking it as fully delivered.
+    /// For recurring reminders the original reminder record is returned so the caller can schedule the next occurrence.
+    /// </summary>
+    /// <param name="entity">The entity that owns the reminder.</param>
+    /// <param name="key">The unique reminder key.</param>
+    /// <param name="ackedAt">The time at which the ack was received.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// An <see cref="AckResult"/> with <c>Success = true</c> when the reminder was found and acknowledged;
+    /// <c>Success = false</c> when no matching awaiting-ack reminder was found.
+    /// </returns>
+    Task<AckResult> AcknowledgeReminderAsync(
+        ReminderEntity entity,
+        ReminderKey key,
+        DateTimeOffset ackedAt,
+        CancellationToken ct = default);
 }

--- a/src/Akka.Reminders/Storage/IReminderStorage.cs
+++ b/src/Akka.Reminders/Storage/IReminderStorage.cs
@@ -256,6 +256,12 @@ public interface IReminderStorage
         CancellationToken ct = default);
 
     /// <summary>
+    /// Gets the earliest acknowledgement deadline currently persisted in storage.
+    /// Returns <c>null</c> when there are no reminders awaiting acknowledgement.
+    /// </summary>
+    Task<DateTimeOffset?> GetNextAwaitingAckDeadlineAsync(CancellationToken ct = default);
+
+    /// <summary>
     /// Acknowledges a reminder, marking it as fully delivered.
     /// </summary>
     /// <param name="entity">The entity that owns the reminder.</param>

--- a/src/Akka.Reminders/Storage/IReminderStorage.cs
+++ b/src/Akka.Reminders/Storage/IReminderStorage.cs
@@ -1,4 +1,9 @@
-﻿namespace Akka.Reminders.Storage;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Akka.Reminders.Storage;
 
 public sealed record ReminderOverview
 {
@@ -80,7 +85,12 @@ public enum ReminderCompletionStatus
     /// Reminder has been delivered but the recipient has not yet acknowledged it.
     /// The reminder will be redelivered if the ack deadline passes without acknowledgement.
     /// </summary>
-    AwaitingAck = 4
+    AwaitingAck = 4,
+
+    /// <summary>
+    /// Reminder exceeded its delivery deadline and is no longer actionable.
+    /// </summary>
+    Expired = 5
 }
 
 /// <summary>
@@ -89,7 +99,8 @@ public enum ReminderCompletionStatus
 public sealed record CompletedReminder(
     ReminderEntity Entity,
     ReminderKey Key,
-    DateTimeOffset When,
+    DateTimeOffset DueTimeUtc,
+    DateTimeOffset CompletedAt,
     ReminderCompletionStatus Status = ReminderCompletionStatus.Delivered);
 
 /// <summary>
@@ -97,12 +108,14 @@ public sealed record CompletedReminder(
 /// </summary>
 /// <param name="Entity">The entity that owns this reminder.</param>
 /// <param name="Key">The unique reminder key.</param>
+/// <param name="DueTimeUtc">The original due time that identifies this reminder occurrence.</param>
 /// <param name="DeliveredAt">When the reminder was delivered to the recipient.</param>
 /// <param name="AckDeadline">The deadline by which the recipient must acknowledge the reminder.
 /// If this deadline passes without an ack, the reminder will be redelivered.</param>
 public sealed record AwaitingAckReminder(
     ReminderEntity Entity,
     ReminderKey Key,
+    DateTimeOffset DueTimeUtc,
     DateTimeOffset DeliveredAt,
     DateTimeOffset AckDeadline);
 
@@ -110,15 +123,8 @@ public sealed record AwaitingAckReminder(
 /// The result of acknowledging a reminder.
 /// </summary>
 /// <param name="Success">Whether the acknowledgement was successfully recorded.</param>
-/// <param name="IsRecurring">Whether the acknowledged reminder was a recurring reminder.</param>
-/// <param name="OriginalReminder">
-/// For recurring reminders, the original reminder record so the caller can schedule the next occurrence.
-/// <c>null</c> for one-time reminders or when <paramref name="Success"/> is <c>false</c>.
-/// </param>
 public sealed record AckResult(
-    bool Success,
-    bool IsRecurring,
-    ScheduledReminder? OriginalReminder);
+    bool Success);
 
 /// <summary>
 /// Storage implementation for reminders.
@@ -126,6 +132,7 @@ public sealed record AckResult(
 public interface IReminderStorage
 {
     Task<ReminderProtocol.ReminderScheduled> ScheduleReminderAsync(ScheduledReminder reminder, CancellationToken ct = default);
+    Task<bool> UpsertReminderOccurrencesAsync(IEnumerable<ScheduledReminder> reminders, CancellationToken ct = default);
     Task<ReminderProtocol.RemindersCancelled> CancelReminderAsync(ReminderEntity entity, ReminderKey key, CancellationToken ct = default);
     
     Task<IReadOnlyList<ScheduledReminder>> GetRemindersForEntityAsync(ReminderEntity entity, int take = 10, int skip = 0, CancellationToken ct = default);
@@ -171,6 +178,14 @@ public interface IReminderStorage
     Task<bool> CleanUpCompletedRemindersAsync(DateTimeOffset olderThan, CancellationToken ct = default);
 
     /// <summary>
+    /// Marks all active reminders whose delivery deadline has passed as expired.
+    /// </summary>
+    /// <param name="now">Current time used as the expiration cutoff.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The number of reminders transitioned to <see cref="ReminderCompletionStatus.Expired"/>.</returns>
+    Task<int> ExpireRemindersAsync(DateTimeOffset now, CancellationToken ct = default);
+
+    /// <summary>
     /// Marks reminders as delivered but awaiting acknowledgement from the recipient.
     /// Sets <c>completion_status = 'AwaitingAck'</c> and records the delivery and ack-deadline timestamps.
     /// The reminder remains visible to due-reminder queries until it is either acknowledged or its
@@ -198,10 +213,10 @@ public interface IReminderStorage
 
     /// <summary>
     /// Acknowledges a reminder, marking it as fully delivered.
-    /// For recurring reminders the original reminder record is returned so the caller can schedule the next occurrence.
     /// </summary>
     /// <param name="entity">The entity that owns the reminder.</param>
     /// <param name="key">The unique reminder key.</param>
+    /// <param name="dueTimeUtc">The due time that identifies the delivered reminder occurrence.</param>
     /// <param name="ackedAt">The time at which the ack was received.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>
@@ -211,20 +226,7 @@ public interface IReminderStorage
     Task<AckResult> AcknowledgeReminderAsync(
         ReminderEntity entity,
         ReminderKey key,
+        DateTimeOffset dueTimeUtc,
         DateTimeOffset ackedAt,
         CancellationToken ct = default);
-
-    /// <summary>
-    /// Resets all reminders stuck in <c>AwaitingAck</c> state back to <c>Pending</c> so they will
-    /// be re-delivered on the next fetch cycle.
-    /// </summary>
-    /// <remarks>
-    /// Called once during scheduler startup to recover reminders that were left in <c>AwaitingAck</c>
-    /// by a previous scheduler instance that crashed or was relocated before the ack arrived.
-    /// The in-memory <c>_awaitingAck</c> dictionary is always empty at startup, so without this
-    /// call those reminders would be permanently stuck.
-    /// </remarks>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The number of reminders that were reset to <c>Pending</c>.</returns>
-    Task<int> ResetAwaitingAckToPendingAsync(CancellationToken ct = default);
 }

--- a/src/Akka.Reminders/Storage/IReminderStorage.cs
+++ b/src/Akka.Reminders/Storage/IReminderStorage.cs
@@ -213,4 +213,18 @@ public interface IReminderStorage
         ReminderKey key,
         DateTimeOffset ackedAt,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Resets all reminders stuck in <c>AwaitingAck</c> state back to <c>Pending</c> so they will
+    /// be re-delivered on the next fetch cycle.
+    /// </summary>
+    /// <remarks>
+    /// Called once during scheduler startup to recover reminders that were left in <c>AwaitingAck</c>
+    /// by a previous scheduler instance that crashed or was relocated before the ack arrived.
+    /// The in-memory <c>_awaitingAck</c> dictionary is always empty at startup, so without this
+    /// call those reminders would be permanently stuck.
+    /// </remarks>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The number of reminders that were reset to <c>Pending</c>.</returns>
+    Task<int> ResetAwaitingAckToPendingAsync(CancellationToken ct = default);
 }

--- a/src/Akka.Reminders/Storage/InMemoryReminderStorage.cs
+++ b/src/Akka.Reminders/Storage/InMemoryReminderStorage.cs
@@ -13,6 +13,7 @@ public sealed class InMemoryReminderStorage : IReminderStorage
 {
     private readonly ConcurrentDictionary<(ReminderEntity, ReminderKey), ScheduledReminder> _pendingReminders = new();
     private readonly ConcurrentDictionary<(ReminderEntity, ReminderKey), CompletedReminder> _completedReminders = new();
+    private readonly ConcurrentDictionary<(ReminderEntity, ReminderKey), AwaitingAckReminder> _awaitingAckReminders = new();
 
     /// <inheritdoc />
     public Task<ReminderProtocol.ReminderScheduled> ScheduleReminderAsync(
@@ -104,7 +105,11 @@ public sealed class InMemoryReminderStorage : IReminderStorage
     /// <inheritdoc />
     public Task<ReminderOverview> GetRemindersOverviewAsync(DateTimeOffset now, CancellationToken ct = default)
     {
-        var count = _pendingReminders.Count;
+        var pendingKeys = _pendingReminders.Keys
+            .Where(k => !_awaitingAckReminders.ContainsKey(k))
+            .ToList();
+
+        var count = pendingKeys.Count;
 
         if (count == 0)
         {
@@ -115,8 +120,10 @@ public sealed class InMemoryReminderStorage : IReminderStorage
             });
         }
 
-        var nextReminder = _pendingReminders.Values
-            .OrderBy(r => r.When)
+        var nextReminder = pendingKeys
+            .Select(k => _pendingReminders.TryGetValue(k, out var r) ? r : null)
+            .Where(r => r is not null)
+            .OrderBy(r => r!.When)
             .FirstOrDefault();
 
         var timeUntilNext = nextReminder != null
@@ -138,7 +145,7 @@ public sealed class InMemoryReminderStorage : IReminderStorage
         CancellationToken ct = default)
     {
         var dueReminders = _pendingReminders
-            .Where(kvp => kvp.Value.When <= untilDeadline)
+            .Where(kvp => kvp.Value.When <= untilDeadline && !_awaitingAckReminders.ContainsKey(kvp.Key))
             .Select(kvp => kvp.Value)
             .OrderBy(r => r.When)
             .Take(maxCount.Value)
@@ -202,5 +209,67 @@ public sealed class InMemoryReminderStorage : IReminderStorage
         }
 
         return Task.FromResult(true);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> MarkRemindersAsAwaitingAckAsync(
+        IEnumerable<AwaitingAckReminder> reminders,
+        CancellationToken ct = default)
+    {
+        foreach (var reminder in reminders)
+        {
+            var key = (reminder.Entity, reminder.Key);
+            _awaitingAckReminders[key] = reminder;
+        }
+
+        return Task.FromResult(true);
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<ScheduledReminder>> GetTimedOutAckRemindersAsync(
+        DateTimeOffset now,
+        ReminderBatchSize maxCount,
+        CancellationToken ct = default)
+    {
+        var timedOut = _awaitingAckReminders
+            .Where(kvp => kvp.Value.AckDeadline <= now)
+            .OrderBy(kvp => kvp.Value.AckDeadline)
+            .Take(maxCount.Value)
+            .Select(kvp => _pendingReminders.TryGetValue(kvp.Key, out var reminder) ? reminder : null)
+            .Where(r => r is not null)
+            .Select(r => r!)
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<ScheduledReminder>>(timedOut);
+    }
+
+    /// <inheritdoc />
+    public Task<AckResult> AcknowledgeReminderAsync(
+        ReminderEntity entity,
+        ReminderKey key,
+        DateTimeOffset ackedAt,
+        CancellationToken ct = default)
+    {
+        var reminderKey = (entity, key);
+
+        if (!_awaitingAckReminders.TryRemove(reminderKey, out _))
+        {
+            return Task.FromResult(new AckResult(Success: false, IsRecurring: false, OriginalReminder: null));
+        }
+
+        if (!_pendingReminders.TryRemove(reminderKey, out var original))
+        {
+            return Task.FromResult(new AckResult(Success: false, IsRecurring: false, OriginalReminder: null));
+        }
+
+        _completedReminders[reminderKey] = new CompletedReminder(
+            entity, key, ackedAt, ReminderCompletionStatus.Delivered);
+
+        var isRecurring = original.RepeatInterval.HasValue;
+
+        return Task.FromResult(new AckResult(
+            Success: true,
+            IsRecurring: isRecurring,
+            OriginalReminder: isRecurring ? original : null));
     }
 }

--- a/src/Akka.Reminders/Storage/InMemoryReminderStorage.cs
+++ b/src/Akka.Reminders/Storage/InMemoryReminderStorage.cs
@@ -277,4 +277,14 @@ public sealed class InMemoryReminderStorage : IReminderStorage
             IsRecurring: isRecurring,
             OriginalReminder: isRecurring ? original : null));
     }
+
+    /// <inheritdoc />
+    public Task<int> ResetAwaitingAckToPendingAsync(CancellationToken ct = default)
+    {
+        // Clear all awaiting-ack tracking so those reminders become visible to GetNextRemindersAsync again.
+        // The underlying _pendingReminders entries are untouched — they were never removed during delivery.
+        var count = _awaitingAckReminders.Count;
+        _awaitingAckReminders.Clear();
+        return Task.FromResult(count);
+    }
 }

--- a/src/Akka.Reminders/Storage/InMemoryReminderStorage.cs
+++ b/src/Akka.Reminders/Storage/InMemoryReminderStorage.cs
@@ -442,6 +442,21 @@ public sealed class InMemoryReminderStorage : IReminderStorage
     }
 
     /// <inheritdoc />
+    public Task<DateTimeOffset?> GetNextAwaitingAckDeadlineAsync(CancellationToken ct = default)
+    {
+        DateTimeOffset? nextDeadline;
+
+        lock (_sync)
+        {
+            nextDeadline = _awaitingAckReminders.Count == 0
+                ? null
+                : _awaitingAckReminders.Values.Min(v => v.State.AckDeadline);
+        }
+
+        return Task.FromResult(nextDeadline);
+    }
+
+    /// <inheritdoc />
     public async Task<AckResult> AcknowledgeReminderAsync(
         ReminderEntity entity,
         ReminderKey key,

--- a/src/Akka.Reminders/Storage/InMemoryReminderStorage.cs
+++ b/src/Akka.Reminders/Storage/InMemoryReminderStorage.cs
@@ -22,8 +22,10 @@ public sealed class InMemoryReminderStorage : IReminderStorage
     {
         var key = (reminder.Entity, reminder.Key);
 
-        // Always upsert - overwrite any existing reminder with the same key
+        // Always upsert - overwrite any existing reminder with the same key.
+        // Also clear any AwaitingAck state so the reminder is visible to future fetches.
         _pendingReminders[key] = reminder;
+        _awaitingAckReminders.TryRemove(key, out _);
 
         return Task.FromResult(new ReminderProtocol.ReminderScheduled(
             reminder.ToScheduleReminder(),
@@ -40,6 +42,7 @@ public sealed class InMemoryReminderStorage : IReminderStorage
 
         if (_pendingReminders.TryRemove(reminderKey, out _))
         {
+            _awaitingAckReminders.TryRemove(reminderKey, out _);
             return Task.FromResult(new ReminderProtocol.RemindersCancelled(
                 entity,
                 ReminderCancelResponseCode.Success,
@@ -65,6 +68,7 @@ public sealed class InMemoryReminderStorage : IReminderStorage
             {
                 if (_pendingReminders.TryRemove(kvp.Key, out _))
                 {
+                    _awaitingAckReminders.TryRemove(kvp.Key, out _);
                     cancelledKeys.Add(kvp.Key.Item2);
                 }
             }
@@ -187,6 +191,7 @@ public sealed class InMemoryReminderStorage : IReminderStorage
         {
             var key = (completed.Entity, completed.Key);
             _pendingReminders.TryRemove(key, out _);
+            _awaitingAckReminders.TryRemove(key, out _);
             _completedReminders[key] = completed;
         }
 

--- a/src/Akka.Reminders/Storage/InMemoryReminderStorage.cs
+++ b/src/Akka.Reminders/Storage/InMemoryReminderStorage.cs
@@ -11,25 +11,72 @@ namespace Akka.Reminders.Storage;
 /// </remarks>
 public sealed class InMemoryReminderStorage : IReminderStorage
 {
-    private readonly ConcurrentDictionary<(ReminderEntity, ReminderKey), ScheduledReminder> _pendingReminders = new();
-    private readonly ConcurrentDictionary<(ReminderEntity, ReminderKey), CompletedReminder> _completedReminders = new();
-    private readonly ConcurrentDictionary<(ReminderEntity, ReminderKey), AwaitingAckReminder> _awaitingAckReminders = new();
+    private readonly ConcurrentDictionary<(ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc), ScheduledReminder> _pendingReminders = new();
+    private readonly ConcurrentDictionary<(ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc), (ScheduledReminder Reminder, AwaitingAckReminder State)> _awaitingAckReminders = new();
+    private readonly ConcurrentDictionary<(ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc), CompletedReminder> _completedReminders = new();
+
+    private static (ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc) ToKey(ScheduledReminder reminder)
+        => (reminder.Entity, reminder.Key, reminder.DueTimeUtc);
+
+    private static (ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc) ToKey(AwaitingAckReminder reminder)
+        => (reminder.Entity, reminder.Key, reminder.DueTimeUtc.ToUniversalTime());
+
+    private static (ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc) ToKey(CompletedReminder reminder)
+        => (reminder.Entity, reminder.Key, reminder.DueTimeUtc.ToUniversalTime());
 
     /// <inheritdoc />
     public Task<ReminderProtocol.ReminderScheduled> ScheduleReminderAsync(
         ScheduledReminder reminder,
         CancellationToken ct = default)
     {
-        var key = (reminder.Entity, reminder.Key);
+        var matchingPending = _pendingReminders.Keys
+            .Where(k => k.Entity.Equals(reminder.Entity) && k.Key.Equals(reminder.Key))
+            .ToList();
+        foreach (var key in matchingPending)
+        {
+            _pendingReminders.TryRemove(key, out _);
+            _completedReminders[key] = new CompletedReminder(
+                key.Entity,
+                key.Key,
+                key.DueTimeUtc,
+                DateTimeOffset.UtcNow,
+                ReminderCompletionStatus.Cancelled);
+        }
 
-        // Always upsert - overwrite any existing reminder with the same key.
-        // Also clear any AwaitingAck state so the reminder is visible to future fetches.
-        _pendingReminders[key] = reminder;
-        _awaitingAckReminders.TryRemove(key, out _);
+        var matchingAwaiting = _awaitingAckReminders.Keys
+            .Where(k => k.Entity.Equals(reminder.Entity) && k.Key.Equals(reminder.Key))
+            .ToList();
+        foreach (var key in matchingAwaiting)
+        {
+            _awaitingAckReminders.TryRemove(key, out _);
+            _completedReminders[key] = new CompletedReminder(
+                key.Entity,
+                key.Key,
+                key.DueTimeUtc,
+                DateTimeOffset.UtcNow,
+                ReminderCompletionStatus.Cancelled);
+        }
+
+        _pendingReminders[ToKey(reminder)] = reminder;
 
         return Task.FromResult(new ReminderProtocol.ReminderScheduled(
             reminder.ToScheduleReminder(),
             ReminderScheduleResponseCode.Success));
+    }
+
+    /// <inheritdoc />
+    public Task<bool> UpsertReminderOccurrencesAsync(
+        IEnumerable<ScheduledReminder> reminders,
+        CancellationToken ct = default)
+    {
+        foreach (var reminder in reminders)
+        {
+            var key = ToKey(reminder);
+            _pendingReminders[key] = reminder;
+            _awaitingAckReminders.TryRemove(key, out _);
+        }
+
+        return Task.FromResult(true);
     }
 
     /// <inheritdoc />
@@ -38,21 +85,54 @@ public sealed class InMemoryReminderStorage : IReminderStorage
         ReminderKey key,
         CancellationToken ct = default)
     {
-        var reminderKey = (entity, key);
+        var cancelledKeys = new List<ReminderKey>();
 
-        if (_pendingReminders.TryRemove(reminderKey, out _))
+        var pendingKeys = _pendingReminders.Keys
+            .Where(k => k.Entity.Equals(entity) && k.Key.Equals(key))
+            .ToList();
+        foreach (var activeKey in pendingKeys)
         {
-            _awaitingAckReminders.TryRemove(reminderKey, out _);
+            if (_pendingReminders.TryRemove(activeKey, out _))
+            {
+                _completedReminders[activeKey] = new CompletedReminder(
+                    entity,
+                    key,
+                    activeKey.DueTimeUtc,
+                    DateTimeOffset.UtcNow,
+                    ReminderCompletionStatus.Cancelled);
+                cancelledKeys.Add(key);
+            }
+        }
+
+        var awaitingKeys = _awaitingAckReminders.Keys
+            .Where(k => k.Entity.Equals(entity) && k.Key.Equals(key))
+            .ToList();
+        foreach (var activeKey in awaitingKeys)
+        {
+            if (_awaitingAckReminders.TryRemove(activeKey, out _))
+            {
+                _completedReminders[activeKey] = new CompletedReminder(
+                    entity,
+                    key,
+                    activeKey.DueTimeUtc,
+                    DateTimeOffset.UtcNow,
+                    ReminderCompletionStatus.Cancelled);
+                cancelledKeys.Add(key);
+            }
+        }
+
+        if (cancelledKeys.Count == 0)
+        {
             return Task.FromResult(new ReminderProtocol.RemindersCancelled(
                 entity,
-                ReminderCancelResponseCode.Success,
-                new List<ReminderKey> { key }));
+                ReminderCancelResponseCode.NotFound,
+                []));
         }
 
         return Task.FromResult(new ReminderProtocol.RemindersCancelled(
             entity,
-            ReminderCancelResponseCode.NotFound,
-            new List<ReminderKey>()));
+            ReminderCancelResponseCode.Success,
+            cancelledKeys.Distinct().ToList()));
     }
 
     /// <inheritdoc />
@@ -60,32 +140,54 @@ public sealed class InMemoryReminderStorage : IReminderStorage
         ReminderEntity entity,
         CancellationToken ct = default)
     {
-        var cancelledKeys = new List<ReminderKey>();
+        var cancelledKeys = new HashSet<ReminderKey>();
 
-        foreach (var kvp in _pendingReminders)
+        var pendingKeys = _pendingReminders.Keys
+            .Where(k => k.Entity.Equals(entity))
+            .ToList();
+        foreach (var activeKey in pendingKeys)
         {
-            if (kvp.Key.Item1.Equals(entity))
+            if (_pendingReminders.TryRemove(activeKey, out _))
             {
-                if (_pendingReminders.TryRemove(kvp.Key, out _))
-                {
-                    _awaitingAckReminders.TryRemove(kvp.Key, out _);
-                    cancelledKeys.Add(kvp.Key.Item2);
-                }
+                _completedReminders[activeKey] = new CompletedReminder(
+                    activeKey.Entity,
+                    activeKey.Key,
+                    activeKey.DueTimeUtc,
+                    DateTimeOffset.UtcNow,
+                    ReminderCompletionStatus.Cancelled);
+                cancelledKeys.Add(activeKey.Key);
             }
         }
 
-        if (cancelledKeys.Count > 0)
+        var awaitingKeys = _awaitingAckReminders.Keys
+            .Where(k => k.Entity.Equals(entity))
+            .ToList();
+        foreach (var activeKey in awaitingKeys)
+        {
+            if (_awaitingAckReminders.TryRemove(activeKey, out _))
+            {
+                _completedReminders[activeKey] = new CompletedReminder(
+                    activeKey.Entity,
+                    activeKey.Key,
+                    activeKey.DueTimeUtc,
+                    DateTimeOffset.UtcNow,
+                    ReminderCompletionStatus.Cancelled);
+                cancelledKeys.Add(activeKey.Key);
+            }
+        }
+
+        if (cancelledKeys.Count == 0)
         {
             return Task.FromResult(new ReminderProtocol.RemindersCancelled(
                 entity,
-                ReminderCancelResponseCode.Success,
-                cancelledKeys));
+                ReminderCancelResponseCode.NotFound,
+                []));
         }
 
         return Task.FromResult(new ReminderProtocol.RemindersCancelled(
             entity,
-            ReminderCancelResponseCode.NotFound,
-            new List<ReminderKey>()));
+            ReminderCancelResponseCode.Success,
+            cancelledKeys.ToList()));
     }
 
     /// <inheritdoc />
@@ -95,9 +197,11 @@ public sealed class InMemoryReminderStorage : IReminderStorage
         int skip = 0,
         CancellationToken ct = default)
     {
-        var reminders = _pendingReminders
-            .Where(kvp => kvp.Key.Item1.Equals(entity))
-            .Select(kvp => kvp.Value)
+        var now = DateTimeOffset.UtcNow;
+        var reminders = _pendingReminders.Values
+            .Concat(_awaitingAckReminders.Values.Select(v => v.Reminder))
+            .Where(r => r.Entity.Equals(entity))
+            .Where(r => !r.Deadline.IsExpired(now))
             .OrderBy(r => r.When)
             .Skip(skip)
             .Take(take)
@@ -109,35 +213,18 @@ public sealed class InMemoryReminderStorage : IReminderStorage
     /// <inheritdoc />
     public Task<ReminderOverview> GetRemindersOverviewAsync(DateTimeOffset now, CancellationToken ct = default)
     {
-        var pendingKeys = _pendingReminders.Keys
-            .Where(k => !_awaitingAckReminders.ContainsKey(k))
+        var pending = _pendingReminders.Values
+            .Where(r => !r.Deadline.IsExpired(now))
+            .OrderBy(r => r.When)
             .ToList();
 
-        var count = pendingKeys.Count;
-
-        if (count == 0)
-        {
-            return Task.FromResult(new ReminderOverview
-            {
-                TotalPendingReminders = 0,
-                TimeUntilNext = TimeSpan.MaxValue
-            });
-        }
-
-        var nextReminder = pendingKeys
-            .Select(k => _pendingReminders.TryGetValue(k, out var r) ? r : null)
-            .Where(r => r is not null)
-            .OrderBy(r => r!.When)
-            .FirstOrDefault();
-
-        var timeUntilNext = nextReminder != null
-            ? nextReminder.When - now
-            : TimeSpan.MaxValue;
+        if (pending.Count == 0)
+            return Task.FromResult(ReminderOverview.Empty);
 
         return Task.FromResult(new ReminderOverview
         {
-            TotalPendingReminders = count,
-            TimeUntilNext = timeUntilNext
+            TotalPendingReminders = pending.Count,
+            TimeUntilNext = pending[0].When - now
         });
     }
 
@@ -148,37 +235,30 @@ public sealed class InMemoryReminderStorage : IReminderStorage
         ReminderBatchSize maxCount,
         CancellationToken ct = default)
     {
-        var dueReminders = _pendingReminders
-            .Where(kvp => kvp.Value.When <= untilDeadline && !_awaitingAckReminders.ContainsKey(kvp.Key))
-            .Select(kvp => kvp.Value)
+        var dueReminders = _pendingReminders.Values
+            .Where(r => !r.Deadline.IsExpired(now) && r.When <= untilDeadline)
             .OrderBy(r => r.When)
             .Take(maxCount.Value)
             .ToList();
 
-        // Get overview of remaining reminders (those not returned in this batch)
-        var fetchedKeys = new HashSet<(ReminderEntity, ReminderKey)>(
-            dueReminders.Select(r => (r.Entity, r.Key)));
-        var remainingCount = _pendingReminders.Count - dueReminders.Count;
-        var timeUntilNext = TimeSpan.MaxValue;
+        var fetchedKeys = new HashSet<(ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc)>(
+            dueReminders.Select(ToKey));
 
-        if (remainingCount > 0)
-        {
-            var nextReminder = _pendingReminders.Values
-                .Where(r => !fetchedKeys.Contains((r.Entity, r.Key)))
-                .OrderBy(r => r.When)
-                .FirstOrDefault();
+        var remainingPending = _pendingReminders
+            .Where(kvp => !fetchedKeys.Contains(kvp.Key))
+            .Select(kvp => kvp.Value)
+            .Where(r => !r.Deadline.IsExpired(now))
+            .OrderBy(r => r.When)
+            .ToList();
 
-            if (nextReminder != null)
+        var overview = remainingPending.Count == 0
+            ? ReminderOverview.Empty
+            : new ReminderOverview
             {
-                timeUntilNext = nextReminder.When - now;
-            }
-        }
+                TotalPendingReminders = remainingPending.Count,
+                TimeUntilNext = remainingPending[0].When - now
+            };
 
-        var overview = new ReminderOverview
-        {
-            TotalPendingReminders = remainingCount,
-            TimeUntilNext = timeUntilNext
-        };
         return Task.FromResult(new PendingRemindersWithSummary(dueReminders, overview));
     }
 
@@ -189,7 +269,7 @@ public sealed class InMemoryReminderStorage : IReminderStorage
     {
         foreach (var completed in completedReminders)
         {
-            var key = (completed.Entity, completed.Key);
+            var key = ToKey(completed);
             _pendingReminders.TryRemove(key, out _);
             _awaitingAckReminders.TryRemove(key, out _);
             _completedReminders[key] = completed;
@@ -204,7 +284,7 @@ public sealed class InMemoryReminderStorage : IReminderStorage
         CancellationToken ct = default)
     {
         var keysToRemove = _completedReminders
-            .Where(kvp => kvp.Value.When < olderThan)
+            .Where(kvp => kvp.Value.CompletedAt < olderThan)
             .Select(kvp => kvp.Key)
             .ToList();
 
@@ -217,17 +297,67 @@ public sealed class InMemoryReminderStorage : IReminderStorage
     }
 
     /// <inheritdoc />
+    public Task<int> ExpireRemindersAsync(DateTimeOffset now, CancellationToken ct = default)
+    {
+        var expiredCount = 0;
+
+        foreach (var kvp in _pendingReminders.ToArray())
+        {
+            if (kvp.Value.Deadline.IsExpired(now))
+            {
+                if (_pendingReminders.TryRemove(kvp.Key, out _))
+                {
+                    _completedReminders[kvp.Key] = new CompletedReminder(
+                        kvp.Value.Entity,
+                        kvp.Value.Key,
+                        kvp.Value.DueTimeUtc,
+                        now,
+                        ReminderCompletionStatus.Expired);
+                    expiredCount++;
+                }
+            }
+        }
+
+        foreach (var kvp in _awaitingAckReminders.ToArray())
+        {
+            if (kvp.Value.Reminder.Deadline.IsExpired(now))
+            {
+                if (_awaitingAckReminders.TryRemove(kvp.Key, out _))
+                {
+                    _completedReminders[kvp.Key] = new CompletedReminder(
+                        kvp.Value.Reminder.Entity,
+                        kvp.Value.Reminder.Key,
+                        kvp.Value.Reminder.DueTimeUtc,
+                        now,
+                        ReminderCompletionStatus.Expired);
+                    expiredCount++;
+                }
+            }
+        }
+
+        return Task.FromResult(expiredCount);
+    }
+
+    /// <inheritdoc />
     public Task<bool> MarkRemindersAsAwaitingAckAsync(
         IEnumerable<AwaitingAckReminder> reminders,
         CancellationToken ct = default)
     {
+        var success = true;
+
         foreach (var reminder in reminders)
         {
-            var key = (reminder.Entity, reminder.Key);
-            _awaitingAckReminders[key] = reminder;
+            var key = ToKey(reminder);
+            if (!_pendingReminders.TryRemove(key, out var pending))
+            {
+                success = false;
+                continue;
+            }
+
+            _awaitingAckReminders[key] = (pending, reminder);
         }
 
-        return Task.FromResult(true);
+        return Task.FromResult(success);
     }
 
     /// <inheritdoc />
@@ -236,13 +366,11 @@ public sealed class InMemoryReminderStorage : IReminderStorage
         ReminderBatchSize maxCount,
         CancellationToken ct = default)
     {
-        var timedOut = _awaitingAckReminders
-            .Where(kvp => kvp.Value.AckDeadline <= now)
-            .OrderBy(kvp => kvp.Value.AckDeadline)
+        var timedOut = _awaitingAckReminders.Values
+            .Where(v => v.State.AckDeadline <= now)
+            .OrderBy(v => v.State.AckDeadline)
             .Take(maxCount.Value)
-            .Select(kvp => _pendingReminders.TryGetValue(kvp.Key, out var reminder) ? reminder : null)
-            .Where(r => r is not null)
-            .Select(r => r!)
+            .Select(v => v.Reminder)
             .ToList();
 
         return Task.FromResult<IReadOnlyList<ScheduledReminder>>(timedOut);
@@ -252,39 +380,35 @@ public sealed class InMemoryReminderStorage : IReminderStorage
     public Task<AckResult> AcknowledgeReminderAsync(
         ReminderEntity entity,
         ReminderKey key,
+        DateTimeOffset dueTimeUtc,
         DateTimeOffset ackedAt,
         CancellationToken ct = default)
     {
-        var reminderKey = (entity, key);
+        var reminderKey = (entity, key, dueTimeUtc.ToUniversalTime());
 
-        if (!_awaitingAckReminders.TryRemove(reminderKey, out _))
+        if (!_awaitingAckReminders.TryRemove(reminderKey, out var awaiting))
         {
-            return Task.FromResult(new AckResult(Success: false, IsRecurring: false, OriginalReminder: null));
+            return Task.FromResult(new AckResult(false));
         }
 
-        if (!_pendingReminders.TryRemove(reminderKey, out var original))
+        if (awaiting.Reminder.Deadline.IsExpired(ackedAt))
         {
-            return Task.FromResult(new AckResult(Success: false, IsRecurring: false, OriginalReminder: null));
+            _completedReminders[reminderKey] = new CompletedReminder(
+                entity,
+                key,
+                dueTimeUtc,
+                ackedAt,
+                ReminderCompletionStatus.Expired);
+            return Task.FromResult(new AckResult(false));
         }
 
         _completedReminders[reminderKey] = new CompletedReminder(
-            entity, key, ackedAt, ReminderCompletionStatus.Delivered);
+            entity,
+            key,
+            dueTimeUtc,
+            ackedAt,
+            ReminderCompletionStatus.Delivered);
 
-        var isRecurring = original.RepeatInterval.HasValue;
-
-        return Task.FromResult(new AckResult(
-            Success: true,
-            IsRecurring: isRecurring,
-            OriginalReminder: isRecurring ? original : null));
-    }
-
-    /// <inheritdoc />
-    public Task<int> ResetAwaitingAckToPendingAsync(CancellationToken ct = default)
-    {
-        // Clear all awaiting-ack tracking so those reminders become visible to GetNextRemindersAsync again.
-        // The underlying _pendingReminders entries are untouched — they were never removed during delivery.
-        var count = _awaitingAckReminders.Count;
-        _awaitingAckReminders.Clear();
-        return Task.FromResult(count);
+        return Task.FromResult(new AckResult(true));
     }
 }

--- a/src/Akka.Reminders/Storage/InMemoryReminderStorage.cs
+++ b/src/Akka.Reminders/Storage/InMemoryReminderStorage.cs
@@ -20,10 +20,10 @@ public sealed class InMemoryReminderStorage : IReminderStorage
         => (reminder.Entity, reminder.Key, reminder.DueTimeUtc);
 
     private static (ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc) ToKey(AwaitingAckReminder reminder)
-        => (reminder.Entity, reminder.Key, reminder.DueTimeUtc.ToUniversalTime());
+        => (reminder.Entity, reminder.Key, reminder.DueTimeUtc);
 
     private static (ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc) ToKey(CompletedReminder reminder)
-        => (reminder.Entity, reminder.Key, reminder.DueTimeUtc.ToUniversalTime());
+        => (reminder.Entity, reminder.Key, reminder.DueTimeUtc);
 
     /// <inheritdoc />
     public Task<ReminderProtocol.ReminderScheduled> ScheduleReminderAsync(
@@ -476,7 +476,7 @@ public sealed class InMemoryReminderStorage : IReminderStorage
         {
             foreach (var acknowledgement in acknowledgements)
             {
-                var reminderKey = (acknowledgement.Entity, acknowledgement.Key, acknowledgement.DueTimeUtc.ToUniversalTime());
+                var reminderKey = (acknowledgement.Entity, acknowledgement.Key, acknowledgement.DueTimeUtc);
 
                 if (!_awaitingAckReminders.TryRemove(reminderKey, out var awaiting))
                 {

--- a/src/Akka.Reminders/Storage/InMemoryReminderStorage.cs
+++ b/src/Akka.Reminders/Storage/InMemoryReminderStorage.cs
@@ -11,6 +11,7 @@ namespace Akka.Reminders.Storage;
 /// </remarks>
 public sealed class InMemoryReminderStorage : IReminderStorage
 {
+    private readonly object _sync = new();
     private readonly ConcurrentDictionary<(ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc), ScheduledReminder> _pendingReminders = new();
     private readonly ConcurrentDictionary<(ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc), (ScheduledReminder Reminder, AwaitingAckReminder State)> _awaitingAckReminders = new();
     private readonly ConcurrentDictionary<(ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc), CompletedReminder> _completedReminders = new();
@@ -29,35 +30,38 @@ public sealed class InMemoryReminderStorage : IReminderStorage
         ScheduledReminder reminder,
         CancellationToken ct = default)
     {
-        var matchingPending = _pendingReminders.Keys
-            .Where(k => k.Entity.Equals(reminder.Entity) && k.Key.Equals(reminder.Key))
-            .ToList();
-        foreach (var key in matchingPending)
+        lock (_sync)
         {
-            _pendingReminders.TryRemove(key, out _);
-            _completedReminders[key] = new CompletedReminder(
-                key.Entity,
-                key.Key,
-                key.DueTimeUtc,
-                DateTimeOffset.UtcNow,
-                ReminderCompletionStatus.Cancelled);
-        }
+            var matchingPending = _pendingReminders.Keys
+                .Where(k => k.Entity.Equals(reminder.Entity) && k.Key.Equals(reminder.Key))
+                .ToList();
+            foreach (var key in matchingPending)
+            {
+                _pendingReminders.TryRemove(key, out _);
+                _completedReminders[key] = new CompletedReminder(
+                    key.Entity,
+                    key.Key,
+                    key.DueTimeUtc,
+                    DateTimeOffset.UtcNow,
+                    ReminderCompletionStatus.Cancelled);
+            }
 
-        var matchingAwaiting = _awaitingAckReminders.Keys
-            .Where(k => k.Entity.Equals(reminder.Entity) && k.Key.Equals(reminder.Key))
-            .ToList();
-        foreach (var key in matchingAwaiting)
-        {
-            _awaitingAckReminders.TryRemove(key, out _);
-            _completedReminders[key] = new CompletedReminder(
-                key.Entity,
-                key.Key,
-                key.DueTimeUtc,
-                DateTimeOffset.UtcNow,
-                ReminderCompletionStatus.Cancelled);
-        }
+            var matchingAwaiting = _awaitingAckReminders.Keys
+                .Where(k => k.Entity.Equals(reminder.Entity) && k.Key.Equals(reminder.Key))
+                .ToList();
+            foreach (var key in matchingAwaiting)
+            {
+                _awaitingAckReminders.TryRemove(key, out _);
+                _completedReminders[key] = new CompletedReminder(
+                    key.Entity,
+                    key.Key,
+                    key.DueTimeUtc,
+                    DateTimeOffset.UtcNow,
+                    ReminderCompletionStatus.Cancelled);
+            }
 
-        _pendingReminders[ToKey(reminder)] = reminder;
+            _pendingReminders[ToKey(reminder)] = reminder;
+        }
 
         return Task.FromResult(new ReminderProtocol.ReminderScheduled(
             reminder.ToScheduleReminder(),
@@ -69,11 +73,60 @@ public sealed class InMemoryReminderStorage : IReminderStorage
         IEnumerable<ScheduledReminder> reminders,
         CancellationToken ct = default)
     {
-        foreach (var reminder in reminders)
+        lock (_sync)
         {
-            var key = ToKey(reminder);
-            _pendingReminders[key] = reminder;
-            _awaitingAckReminders.TryRemove(key, out _);
+            foreach (var reminder in reminders)
+            {
+                var key = ToKey(reminder);
+                _pendingReminders[key] = reminder;
+                _awaitingAckReminders.TryRemove(key, out _);
+            }
+        }
+
+        return Task.FromResult(true);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> CommitReminderMutationsAsync(ReminderMutationBatch mutationBatch, CancellationToken ct = default)
+    {
+        if (mutationBatch.IsEmpty)
+            return Task.FromResult(true);
+
+        lock (_sync)
+        {
+            var pending = new Dictionary<(ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc), ScheduledReminder>(_pendingReminders);
+            var awaiting = new Dictionary<(ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc), (ScheduledReminder Reminder, AwaitingAckReminder State)>(_awaitingAckReminders);
+            var completed = new Dictionary<(ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc), CompletedReminder>(_completedReminders);
+
+            foreach (var reminder in mutationBatch.PendingUpserts)
+            {
+                var key = ToKey(reminder);
+                pending[key] = reminder;
+                awaiting.Remove(key);
+                completed.Remove(key);
+            }
+
+            foreach (var reminder in mutationBatch.CompletedReminders)
+            {
+                var key = ToKey(reminder);
+                pending.Remove(key);
+                awaiting.Remove(key);
+                completed[key] = reminder;
+            }
+
+            foreach (var reminder in mutationBatch.AwaitingAckReminders)
+            {
+                var key = ToKey(reminder);
+                if (!pending.TryGetValue(key, out var pendingReminder))
+                    return Task.FromResult(false);
+
+                pending.Remove(key);
+                awaiting[key] = (pendingReminder, reminder);
+            }
+
+            ReplaceContents(_pendingReminders, pending);
+            ReplaceContents(_awaitingAckReminders, awaiting);
+            ReplaceContents(_completedReminders, completed);
         }
 
         return Task.FromResult(true);
@@ -87,37 +140,40 @@ public sealed class InMemoryReminderStorage : IReminderStorage
     {
         var cancelledKeys = new List<ReminderKey>();
 
-        var pendingKeys = _pendingReminders.Keys
-            .Where(k => k.Entity.Equals(entity) && k.Key.Equals(key))
-            .ToList();
-        foreach (var activeKey in pendingKeys)
+        lock (_sync)
         {
-            if (_pendingReminders.TryRemove(activeKey, out _))
+            var pendingKeys = _pendingReminders.Keys
+                .Where(k => k.Entity.Equals(entity) && k.Key.Equals(key))
+                .ToList();
+            foreach (var activeKey in pendingKeys)
             {
-                _completedReminders[activeKey] = new CompletedReminder(
-                    entity,
-                    key,
-                    activeKey.DueTimeUtc,
-                    DateTimeOffset.UtcNow,
-                    ReminderCompletionStatus.Cancelled);
-                cancelledKeys.Add(key);
+                if (_pendingReminders.TryRemove(activeKey, out _))
+                {
+                    _completedReminders[activeKey] = new CompletedReminder(
+                        entity,
+                        key,
+                        activeKey.DueTimeUtc,
+                        DateTimeOffset.UtcNow,
+                        ReminderCompletionStatus.Cancelled);
+                    cancelledKeys.Add(key);
+                }
             }
-        }
 
-        var awaitingKeys = _awaitingAckReminders.Keys
-            .Where(k => k.Entity.Equals(entity) && k.Key.Equals(key))
-            .ToList();
-        foreach (var activeKey in awaitingKeys)
-        {
-            if (_awaitingAckReminders.TryRemove(activeKey, out _))
+            var awaitingKeys = _awaitingAckReminders.Keys
+                .Where(k => k.Entity.Equals(entity) && k.Key.Equals(key))
+                .ToList();
+            foreach (var activeKey in awaitingKeys)
             {
-                _completedReminders[activeKey] = new CompletedReminder(
-                    entity,
-                    key,
-                    activeKey.DueTimeUtc,
-                    DateTimeOffset.UtcNow,
-                    ReminderCompletionStatus.Cancelled);
-                cancelledKeys.Add(key);
+                if (_awaitingAckReminders.TryRemove(activeKey, out _))
+                {
+                    _completedReminders[activeKey] = new CompletedReminder(
+                        entity,
+                        key,
+                        activeKey.DueTimeUtc,
+                        DateTimeOffset.UtcNow,
+                        ReminderCompletionStatus.Cancelled);
+                    cancelledKeys.Add(key);
+                }
             }
         }
 
@@ -142,37 +198,40 @@ public sealed class InMemoryReminderStorage : IReminderStorage
     {
         var cancelledKeys = new HashSet<ReminderKey>();
 
-        var pendingKeys = _pendingReminders.Keys
-            .Where(k => k.Entity.Equals(entity))
-            .ToList();
-        foreach (var activeKey in pendingKeys)
+        lock (_sync)
         {
-            if (_pendingReminders.TryRemove(activeKey, out _))
+            var pendingKeys = _pendingReminders.Keys
+                .Where(k => k.Entity.Equals(entity))
+                .ToList();
+            foreach (var activeKey in pendingKeys)
             {
-                _completedReminders[activeKey] = new CompletedReminder(
-                    activeKey.Entity,
-                    activeKey.Key,
-                    activeKey.DueTimeUtc,
-                    DateTimeOffset.UtcNow,
-                    ReminderCompletionStatus.Cancelled);
-                cancelledKeys.Add(activeKey.Key);
+                if (_pendingReminders.TryRemove(activeKey, out _))
+                {
+                    _completedReminders[activeKey] = new CompletedReminder(
+                        activeKey.Entity,
+                        activeKey.Key,
+                        activeKey.DueTimeUtc,
+                        DateTimeOffset.UtcNow,
+                        ReminderCompletionStatus.Cancelled);
+                    cancelledKeys.Add(activeKey.Key);
+                }
             }
-        }
 
-        var awaitingKeys = _awaitingAckReminders.Keys
-            .Where(k => k.Entity.Equals(entity))
-            .ToList();
-        foreach (var activeKey in awaitingKeys)
-        {
-            if (_awaitingAckReminders.TryRemove(activeKey, out _))
+            var awaitingKeys = _awaitingAckReminders.Keys
+                .Where(k => k.Entity.Equals(entity))
+                .ToList();
+            foreach (var activeKey in awaitingKeys)
             {
-                _completedReminders[activeKey] = new CompletedReminder(
-                    activeKey.Entity,
-                    activeKey.Key,
-                    activeKey.DueTimeUtc,
-                    DateTimeOffset.UtcNow,
-                    ReminderCompletionStatus.Cancelled);
-                cancelledKeys.Add(activeKey.Key);
+                if (_awaitingAckReminders.TryRemove(activeKey, out _))
+                {
+                    _completedReminders[activeKey] = new CompletedReminder(
+                        activeKey.Entity,
+                        activeKey.Key,
+                        activeKey.DueTimeUtc,
+                        DateTimeOffset.UtcNow,
+                        ReminderCompletionStatus.Cancelled);
+                    cancelledKeys.Add(activeKey.Key);
+                }
             }
         }
 
@@ -267,12 +326,15 @@ public sealed class InMemoryReminderStorage : IReminderStorage
         IEnumerable<CompletedReminder> completedReminders,
         CancellationToken ct = default)
     {
-        foreach (var completed in completedReminders)
+        lock (_sync)
         {
-            var key = ToKey(completed);
-            _pendingReminders.TryRemove(key, out _);
-            _awaitingAckReminders.TryRemove(key, out _);
-            _completedReminders[key] = completed;
+            foreach (var completed in completedReminders)
+            {
+                var key = ToKey(completed);
+                _pendingReminders.TryRemove(key, out _);
+                _awaitingAckReminders.TryRemove(key, out _);
+                _completedReminders[key] = completed;
+            }
         }
 
         return Task.FromResult(true);
@@ -345,16 +407,19 @@ public sealed class InMemoryReminderStorage : IReminderStorage
     {
         var success = true;
 
-        foreach (var reminder in reminders)
+        lock (_sync)
         {
-            var key = ToKey(reminder);
-            if (!_pendingReminders.TryRemove(key, out var pending))
+            foreach (var reminder in reminders)
             {
-                success = false;
-                continue;
-            }
+                var key = ToKey(reminder);
+                if (!_pendingReminders.TryRemove(key, out var pending))
+                {
+                    success = false;
+                    continue;
+                }
 
-            _awaitingAckReminders[key] = (pending, reminder);
+                _awaitingAckReminders[key] = (pending, reminder);
+            }
         }
 
         return Task.FromResult(success);
@@ -377,38 +442,79 @@ public sealed class InMemoryReminderStorage : IReminderStorage
     }
 
     /// <inheritdoc />
-    public Task<AckResult> AcknowledgeReminderAsync(
+    public async Task<AckResult> AcknowledgeReminderAsync(
         ReminderEntity entity,
         ReminderKey key,
         DateTimeOffset dueTimeUtc,
         DateTimeOffset ackedAt,
         CancellationToken ct = default)
+        => (await AcknowledgeRemindersAsync([new ReminderAcknowledgement(entity, key, dueTimeUtc, ackedAt)], ct))[0];
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<AckResult>> AcknowledgeRemindersAsync(
+        IEnumerable<ReminderAcknowledgement> acknowledgements,
+        CancellationToken ct = default)
     {
-        var reminderKey = (entity, key, dueTimeUtc.ToUniversalTime());
+        var results = new List<AckResult>();
 
-        if (!_awaitingAckReminders.TryRemove(reminderKey, out var awaiting))
+        lock (_sync)
         {
-            return Task.FromResult(new AckResult(false));
+            foreach (var acknowledgement in acknowledgements)
+            {
+                var reminderKey = (acknowledgement.Entity, acknowledgement.Key, acknowledgement.DueTimeUtc.ToUniversalTime());
+
+                if (!_awaitingAckReminders.TryRemove(reminderKey, out var awaiting))
+                {
+                    results.Add(new AckResult(
+                        acknowledgement.Entity,
+                        acknowledgement.Key,
+                        acknowledgement.DueTimeUtc,
+                        ReminderAckStorageStatus.NotFound,
+                        "Reminder occurrence was not awaiting acknowledgement or was already stale."));
+                    continue;
+                }
+
+                if (awaiting.Reminder.Deadline.IsExpired(acknowledgement.AckedAt))
+                {
+                    _completedReminders[reminderKey] = new CompletedReminder(
+                        acknowledgement.Entity,
+                        acknowledgement.Key,
+                        acknowledgement.DueTimeUtc,
+                        acknowledgement.AckedAt,
+                        ReminderCompletionStatus.Expired);
+                    results.Add(new AckResult(
+                        acknowledgement.Entity,
+                        acknowledgement.Key,
+                        acknowledgement.DueTimeUtc,
+                        ReminderAckStorageStatus.NotFound,
+                        "Reminder occurrence was not awaiting acknowledgement or was already stale."));
+                    continue;
+                }
+
+                _completedReminders[reminderKey] = new CompletedReminder(
+                    acknowledgement.Entity,
+                    acknowledgement.Key,
+                    acknowledgement.DueTimeUtc,
+                    acknowledgement.AckedAt,
+                    ReminderCompletionStatus.Delivered);
+
+                results.Add(new AckResult(
+                    acknowledgement.Entity,
+                    acknowledgement.Key,
+                    acknowledgement.DueTimeUtc,
+                    ReminderAckStorageStatus.Success));
+            }
         }
 
-        if (awaiting.Reminder.Deadline.IsExpired(ackedAt))
-        {
-            _completedReminders[reminderKey] = new CompletedReminder(
-                entity,
-                key,
-                dueTimeUtc,
-                ackedAt,
-                ReminderCompletionStatus.Expired);
-            return Task.FromResult(new AckResult(false));
-        }
+        return Task.FromResult<IReadOnlyList<AckResult>>(results);
+    }
 
-        _completedReminders[reminderKey] = new CompletedReminder(
-            entity,
-            key,
-            dueTimeUtc,
-            ackedAt,
-            ReminderCompletionStatus.Delivered);
-
-        return Task.FromResult(new AckResult(true));
+    private static void ReplaceContents<TValue>(
+        ConcurrentDictionary<(ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc), TValue> target,
+        Dictionary<(ReminderEntity Entity, ReminderKey Key, DateTimeOffset DueTimeUtc), TValue> source)
+    {
+        target.Clear();
+        foreach (var pair in source)
+            target[pair.Key] = pair.Value;
     }
 }


### PR DESCRIPTION
## Summary
- redesign reminder occurrence semantics around `DueTimeUtc`, absolute `DeliveryDeadlineUtc`, and latest-only recurring reminders
- persist and acknowledge reminder occurrences by `(Entity, Key, DueTimeUtc)` so retries and late acks converge on the same occurrence identity
- make schedule overwrite and chunk mutation commits atomic with `CommitReminderMutationsAsync`, while buffering and batching acknowledgement writes inside the scheduler
- reduce storage hot-path load with batched SQL ack updates, scheduler-managed ack deadline scheduling, and less overview churn
- update docs, tests, and benchmark coverage for fetch, acknowledgement, and mutation paths

## Architectural Notes
- occurrence identity now follows due time instead of mutable delivery timestamps, which keeps retry, timeout, and late-ack paths talking about the same row
- overwrite scheduling stays transactional to avoid the old cancel-then-upsert gap
- each delivery chunk commits its upserts, terminal completions, and awaiting-ack transitions together before any messages are sent
- acknowledgements are the intentionally buffered part of the design: they can flush in batches without weakening accepted reminder durability

## Benchmark Notes
- `FetchAndCompleteAllReminders` still looks like the main optimization target at larger reminder counts; 25k reminders landed around 1.25s to 1.33s in the current PostgreSQL runs
- `AcknowledgeAllReminders`: 1000 reminders = 41.98 ms, 5000 reminders = 194.54 ms
- `CommitReminderMutations`: 1000 reminders = 51.97 ms, 5000 reminders = 233.36 ms

## Breaking Changes
- `ReminderEnvelope.Deadline` is now non-nullable; unbounded reminders use `ReminderDeadline.Infinite`
- recurring reminders are latest-only and occurrence identity is `DueTimeUtc`
- storage rows and acknowledgements are keyed by `(Entity, Key, DueTimeUtc)`
- SQL providers now persist `due_time_utc` and absolute `delivery_deadline_utc`

## Validation
- `dotnet build -c Release`
- `dotnet test "src/Akka.Reminders.Tests/Akka.Reminders.Tests.csproj" -c Release --no-build` (`195 passed, 0 failed`)
- `dotnet run -c Release --project src/Akka.Reminders.Benchmarks -- --filter "*FetchAndCompleteAllReminders*" --job Medium`
- `dotnet run -c Release --project src/Akka.Reminders.Benchmarks -- --filter "*AcknowledgeAllReminders*" "*CommitReminderMutations*"`

## Follow-up Issues
- #105 Benchmark mixed backlog reminder fetch workloads and capture query plans
- #106 Investigate reducing payload hydration cost in due-reminder fetches
- #107 Evaluate PostgreSQL index and query tuning for due-reminder scans