### PR TITLE
Delegate inner message serialization for wire protocol messages

### DIFF
--- a/src/Akka.Reminders.Tests/Serialization/ReminderSerializerSpecs.cs
+++ b/src/Akka.Reminders.Tests/Serialization/ReminderSerializerSpecs.cs
@@ -241,6 +241,259 @@ public class ReminderSerializerSpecs : Akka.Hosting.TestKit.TestKit
     }
 
     #endregion
+
+    #region ScheduleReminder
+
+    [Fact]
+    public void Can_serialize_ScheduleReminder_with_string_payload()
+    {
+        var cmd = new ReminderProtocol.ScheduleReminder(
+            new ReminderEntity("my-region", "entity-42"),
+            new ReminderKey("daily-report"),
+            new DateTimeOffset(2026, 3, 20, 12, 0, 0, TimeSpan.Zero),
+            "generate report");
+
+        var result = AssertAndReturn(cmd);
+
+        Assert.Equal(cmd.Entity, result.Entity);
+        Assert.Equal(cmd.Key, result.Key);
+        Assert.Equal(cmd.When, result.When);
+        Assert.Equal("generate report", result.Message);
+        Assert.Null(result.RepeatInterval);
+        Assert.Null(result.MaxDeliveryWindow);
+    }
+
+    [Fact]
+    public void Can_serialize_ScheduleReminder_with_json_payload()
+    {
+        var payload = new InvoiceReminder
+        {
+            InvoiceId = "INV-2026-0099",
+            AmountDue = 500.00m,
+            Currency = "EUR",
+            CustomerEmail = "test@example.com"
+        };
+
+        var cmd = new ReminderProtocol.ScheduleReminder(
+            new ReminderEntity("invoices", "customer-1"),
+            new ReminderKey("payment-due"),
+            new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
+            payload);
+
+        var result = AssertAndReturn(cmd);
+
+        Assert.Equal(cmd.Entity, result.Entity);
+        Assert.Equal(cmd.Key, result.Key);
+        Assert.Equal(cmd.When, result.When);
+
+        var deserialized = Assert.IsType<InvoiceReminder>(result.Message);
+        Assert.Equal(payload.InvoiceId, deserialized.InvoiceId);
+        Assert.Equal(payload.AmountDue, deserialized.AmountDue);
+        Assert.Equal(payload.Currency, deserialized.Currency);
+        Assert.Equal(payload.CustomerEmail, deserialized.CustomerEmail);
+    }
+
+    [Fact]
+    public void Can_serialize_ScheduleReminder_with_repeat_interval()
+    {
+        var cmd = new ReminderProtocol.ScheduleReminder(
+            new ReminderEntity("region", "entity"),
+            new ReminderKey("recurring"),
+            DateTimeOffset.UtcNow,
+            "tick",
+            RepeatInterval: TimeSpan.FromHours(1));
+
+        var result = AssertAndReturn(cmd);
+
+        Assert.Equal(cmd.Entity, result.Entity);
+        Assert.Equal(cmd.Key, result.Key);
+        Assert.Equal("tick", result.Message);
+        Assert.Equal(TimeSpan.FromHours(1), result.RepeatInterval);
+        Assert.Null(result.MaxDeliveryWindow);
+    }
+
+    [Fact]
+    public void Can_serialize_ScheduleReminder_with_max_delivery_window()
+    {
+        var cmd = new ReminderProtocol.ScheduleReminder(
+            new ReminderEntity("region", "entity"),
+            new ReminderKey("bounded"),
+            DateTimeOffset.UtcNow,
+            "payload",
+            RepeatInterval: TimeSpan.FromMinutes(30),
+            MaxDeliveryWindow: TimeSpan.FromMinutes(5));
+
+        var result = AssertAndReturn(cmd);
+
+        Assert.Equal(cmd.Entity, result.Entity);
+        Assert.Equal(cmd.Key, result.Key);
+        Assert.Equal("payload", result.Message);
+        Assert.Equal(TimeSpan.FromMinutes(30), result.RepeatInterval);
+        Assert.Equal(TimeSpan.FromMinutes(5), result.MaxDeliveryWindow);
+    }
+
+    #endregion
+
+    #region ReminderScheduled
+
+    [Fact]
+    public void Can_serialize_ReminderScheduled_success()
+    {
+        var cmd = new ReminderProtocol.ScheduleReminder(
+            new ReminderEntity("region", "entity"),
+            new ReminderKey("key"),
+            new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero),
+            "my-payload",
+            RepeatInterval: TimeSpan.FromHours(2));
+
+        var scheduled = new ReminderProtocol.ReminderScheduled(
+            cmd,
+            ReminderScheduleResponseCode.Success);
+
+        var result = AssertAndReturn(scheduled);
+
+        Assert.Equal(cmd.Entity, result.Entity);
+        Assert.Equal(cmd.Key, result.Key);
+        Assert.Equal(cmd.When, result.When);
+        Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
+        Assert.Null(result.Message);
+
+        Assert.Equal("my-payload", result.OriginalCommand.Message);
+        Assert.Equal(TimeSpan.FromHours(2), result.OriginalCommand.RepeatInterval);
+    }
+
+    [Fact]
+    public void Can_serialize_ReminderScheduled_error_with_message()
+    {
+        var cmd = new ReminderProtocol.ScheduleReminder(
+            new ReminderEntity("region", "entity"),
+            new ReminderKey("key"),
+            DateTimeOffset.UtcNow,
+            "payload");
+
+        var scheduled = new ReminderProtocol.ReminderScheduled(
+            cmd,
+            ReminderScheduleResponseCode.Error,
+            "Shard region not available");
+
+        var result = AssertAndReturn(scheduled);
+
+        Assert.Equal(ReminderScheduleResponseCode.Error, result.ResponseCode);
+        Assert.Equal("Shard region not available", result.Message);
+        Assert.Equal("payload", result.OriginalCommand.Message);
+    }
+
+    #endregion
+
+    #region RemindersForEntity
+
+    [Fact]
+    public void Can_serialize_RemindersForEntity_with_empty_list()
+    {
+        var msg = new ReminderProtocol.RemindersForEntity(
+            new ReminderEntity("region", "entity"),
+            FetchRemindersResponseCode.NotFound,
+            Array.Empty<ScheduledReminder>(),
+            "No reminders found");
+
+        var result = AssertAndReturn(msg);
+
+        Assert.Equal(msg.Entity, result.Entity);
+        Assert.Equal(FetchRemindersResponseCode.NotFound, result.ResponseCode);
+        Assert.Equal("No reminders found", result.Message);
+        Assert.Empty(result.Reminders);
+    }
+
+    [Fact]
+    public void Can_serialize_RemindersForEntity_with_multiple_reminders()
+    {
+        var entity = new ReminderEntity("orders", "order-42");
+        var when1 = new DateTimeOffset(2026, 5, 1, 10, 0, 0, TimeSpan.Zero);
+        var when2 = new DateTimeOffset(2026, 5, 2, 14, 0, 0, TimeSpan.Zero);
+
+        var reminders = new List<ScheduledReminder>
+        {
+            new(entity, new ReminderKey("reminder-1"), when1, "payload-1",
+                RepeatInterval: TimeSpan.FromHours(1),
+                AttemptCount: 3,
+                LastFailureReason: "timeout",
+                MaxDeliveryWindow: TimeSpan.FromMinutes(5),
+                DeliveryDeadlineUtc: when1.AddMinutes(5),
+                OccurrenceDueTimeUtc: when1.AddMinutes(-1)),
+            new(entity, new ReminderKey("reminder-2"), when2, "payload-2")
+        };
+
+        var msg = new ReminderProtocol.RemindersForEntity(
+            entity,
+            FetchRemindersResponseCode.Success,
+            reminders);
+
+        var result = AssertAndReturn(msg);
+
+        Assert.Equal(entity, result.Entity);
+        Assert.Equal(FetchRemindersResponseCode.Success, result.ResponseCode);
+        Assert.Null(result.Message);
+        Assert.Equal(2, result.Reminders.Count);
+
+        // First reminder — all fields populated
+        var r0 = result.Reminders[0];
+        Assert.Equal(new ReminderKey("reminder-1"), r0.Key);
+        Assert.Equal(when1, r0.When);
+        Assert.Equal("payload-1", r0.Message);
+        Assert.Equal(TimeSpan.FromHours(1), r0.RepeatInterval);
+        Assert.Equal(3, r0.AttemptCount);
+        Assert.Equal("timeout", r0.LastFailureReason);
+        Assert.Equal(TimeSpan.FromMinutes(5), r0.MaxDeliveryWindow);
+        Assert.Equal(when1.AddMinutes(5), r0.DeliveryDeadlineUtc);
+        Assert.Equal(when1.AddMinutes(-1), r0.OccurrenceDueTimeUtc);
+
+        // Second reminder — minimal fields
+        var r1 = result.Reminders[1];
+        Assert.Equal(new ReminderKey("reminder-2"), r1.Key);
+        Assert.Equal(when2, r1.When);
+        Assert.Equal("payload-2", r1.Message);
+        Assert.Null(r1.RepeatInterval);
+        Assert.Equal(0, r1.AttemptCount);
+        Assert.Null(r1.LastFailureReason);
+        Assert.Null(r1.MaxDeliveryWindow);
+        Assert.Null(r1.DeliveryDeadlineUtc);
+        Assert.Null(r1.OccurrenceDueTimeUtc);
+    }
+
+    [Fact]
+    public void Can_serialize_RemindersForEntity_with_json_payload_in_reminders()
+    {
+        var entity = new ReminderEntity("invoices", "customer-7");
+        var payload = new InvoiceReminder
+        {
+            InvoiceId = "INV-001",
+            AmountDue = 99.95m,
+            Currency = "GBP",
+            CustomerEmail = "user@example.com"
+        };
+
+        var reminders = new List<ScheduledReminder>
+        {
+            new(entity, new ReminderKey("invoice-reminder"), DateTimeOffset.UtcNow, payload)
+        };
+
+        var msg = new ReminderProtocol.RemindersForEntity(
+            entity,
+            FetchRemindersResponseCode.Success,
+            reminders);
+
+        var result = AssertAndReturn(msg);
+
+        Assert.Single(result.Reminders);
+        var r = result.Reminders[0];
+        var deserialized = Assert.IsType<InvoiceReminder>(r.Message);
+        Assert.Equal(payload.InvoiceId, deserialized.InvoiceId);
+        Assert.Equal(payload.AmountDue, deserialized.AmountDue);
+        Assert.Equal(payload.Currency, deserialized.Currency);
+        Assert.Equal(payload.CustomerEmail, deserialized.CustomerEmail);
+    }
+
+    #endregion
 }
 
 /// <summary>

--- a/src/Akka.Reminders/ReminderProtocol.cs
+++ b/src/Akka.Reminders/ReminderProtocol.cs
@@ -230,7 +230,7 @@ public static class ReminderProtocol
         DateTimeOffset When,
         object Message,
         TimeSpan? RepeatInterval = null,
-        TimeSpan? MaxDeliveryWindow = null) : IReminderCommand
+        TimeSpan? MaxDeliveryWindow = null) : IReminderCommand, IReminderWireMessage
     {
         public ScheduledReminder ToScheduledReminder() => new(
             Entity,
@@ -254,7 +254,7 @@ public static class ReminderProtocol
     public sealed record ReminderScheduled(
         ScheduleReminder OriginalCommand,
         ReminderScheduleResponseCode ResponseCode,
-        string? Message = null) : IReminderResponse
+        string? Message = null) : IReminderResponse, IReminderWireMessage
     {
         /// <inheritdoc />
         public ReminderEntity Entity => OriginalCommand.Entity;
@@ -276,7 +276,7 @@ public static class ReminderProtocol
         ReminderEntity Entity,
         FetchRemindersResponseCode ResponseCode,
         IReadOnlyList<ScheduledReminder> Reminders,
-        string? Message = null) : IReminderResponse;
+        string? Message = null) : IReminderResponse, IReminderWireMessage;
 
     /// <summary>
     /// Sent by a recipient to confirm that a reminder has been successfully processed.

--- a/src/Akka.Reminders/Serialization/ReminderSerializer.cs
+++ b/src/Akka.Reminders/Serialization/ReminderSerializer.cs
@@ -55,6 +55,62 @@ namespace Akka.Reminders.Serialization;
 /// └──────────────────────────────────────────────────────────────┘
 /// </code>
 ///
+/// <para><b>Wire format: ScheduleReminder (manifest "sr")</b></para>
+/// <code>
+/// ┌──────────────────────────────────────────────────────────────┐
+/// │ ShardRegionName      : length-prefixed UTF-8 string         │
+/// │ EntityId             : length-prefixed UTF-8 string         │
+/// │ Key.Name             : length-prefixed UTF-8 string         │
+/// │ When                 : Int64 (UTC ticks)                    │
+/// │ HasRepeatInterval    : bool                                 │
+/// │ RepeatInterval       : Int64 (ticks) — only if present      │
+/// │ HasMaxDeliveryWindow : bool                                 │
+/// │ MaxDeliveryWindow    : Int64 (ticks) — only if present      │
+/// │ InnerSerializerId    : Int32 (Akka serializer identifier)   │
+/// │ InnerManifest        : length-prefixed UTF-8 string         │
+/// │ InnerPayloadLength   : Int32                                │
+/// │ InnerPayload         : byte[] (serialized by Akka)          │
+/// └──────────────────────────────────────────────────────────────┘
+/// </code>
+///
+/// <para><b>Wire format: ReminderScheduled (manifest "rsd")</b></para>
+/// <code>
+/// ┌──────────────────────────────────────────────────────────────┐
+/// │ [ScheduleReminder fields — same layout as above]            │
+/// │ ResponseCode         : Int32 (enum)                         │
+/// │ Message              : length-prefixed UTF-8 string (or "") │
+/// └──────────────────────────────────────────────────────────────┘
+/// </code>
+///
+/// <para><b>Wire format: RemindersForEntity (manifest "rfe")</b></para>
+/// <code>
+/// ┌──────────────────────────────────────────────────────────────┐
+/// │ ShardRegionName      : length-prefixed UTF-8 string         │
+/// │ EntityId             : length-prefixed UTF-8 string         │
+/// │ ResponseCode         : Int32 (enum)                         │
+/// │ Message              : length-prefixed UTF-8 string (or "") │
+/// │ ReminderCount        : Int32                                │
+/// │ [For each ScheduledReminder:]                               │
+/// │   Key.Name             : length-prefixed UTF-8 string       │
+/// │   When                 : Int64 (UTC ticks)                  │
+/// │   HasRepeatInterval    : bool                               │
+/// │   RepeatInterval       : Int64 (ticks) — only if present    │
+/// │   AttemptCount         : Int32                               │
+/// │   HasLastFailureReason : bool                               │
+/// │   LastFailureReason    : length-prefixed UTF-8 — only if    │
+/// │   HasMaxDeliveryWindow : bool                               │
+/// │   MaxDeliveryWindow    : Int64 (ticks) — only if present    │
+/// │   HasDeliveryDeadline  : bool                               │
+/// │   DeliveryDeadlineUtc  : Int64 (UTC ticks) — only if present│
+/// │   HasOccurrenceDueTime : bool                               │
+/// │   OccurrenceDueTimeUtc : Int64 (UTC ticks) — only if present│
+/// │   InnerSerializerId    : Int32                               │
+/// │   InnerManifest        : length-prefixed UTF-8 string       │
+/// │   InnerPayloadLength   : Int32                               │
+/// │   InnerPayload         : byte[]                              │
+/// └──────────────────────────────────────────────────────────────┘
+/// </code>
+///
 /// <para>
 /// Deserialization of <see cref="ReminderEnvelope"/> reconstructs the strongly-typed
 /// <see cref="ReminderEnvelope{T}"/> by using the runtime type of the deserialized inner
@@ -66,6 +122,9 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
     private const string ReminderEnvelopeManifest = "re";
     private const string ReminderAckManifest = "ra";
     private const string ReminderAckResponseManifest = "rar";
+    private const string ScheduleReminderManifest = "sr";
+    private const string ReminderScheduledManifest = "rsd";
+    private const string RemindersForEntityManifest = "rfe";
 
     private static readonly Type ReminderEnvelopeOpenGenericType = typeof(ReminderEnvelope<>);
 
@@ -94,6 +153,9 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
         ReminderEnvelope => ReminderEnvelopeManifest,
         ReminderProtocol.ReminderAck => ReminderAckManifest,
         ReminderProtocol.ReminderAckResponse => ReminderAckResponseManifest,
+        ReminderProtocol.ScheduleReminder => ScheduleReminderManifest,
+        ReminderProtocol.ReminderScheduled => ReminderScheduledManifest,
+        ReminderProtocol.RemindersForEntity => RemindersForEntityManifest,
         _ => throw new ArgumentException($"{nameof(ReminderSerializer)} does not support serializing [{o.GetType().FullName}]", nameof(o))
     };
 
@@ -103,6 +165,9 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
         ReminderEnvelope envelope => SerializeReminderEnvelope(envelope),
         ReminderProtocol.ReminderAck ack => SerializeReminderAck(ack),
         ReminderProtocol.ReminderAckResponse ackResponse => SerializeReminderAckResponse(ackResponse),
+        ReminderProtocol.ScheduleReminder cmd => SerializeScheduleReminder(cmd),
+        ReminderProtocol.ReminderScheduled scheduled => SerializeReminderScheduled(scheduled),
+        ReminderProtocol.RemindersForEntity reminders => SerializeRemindersForEntity(reminders),
         _ => throw new ArgumentException($"{nameof(ReminderSerializer)} does not support serializing [{obj.GetType().FullName}]", nameof(obj))
     };
 
@@ -112,6 +177,9 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
         ReminderEnvelopeManifest => DeserializeReminderEnvelope(bytes),
         ReminderAckManifest => DeserializeReminderAck(bytes),
         ReminderAckResponseManifest => DeserializeReminderAckResponse(bytes),
+        ScheduleReminderManifest => DeserializeScheduleReminder(bytes),
+        ReminderScheduledManifest => DeserializeReminderScheduled(bytes),
+        RemindersForEntityManifest => DeserializeRemindersForEntity(bytes),
         _ => throw new ArgumentException($"{nameof(ReminderSerializer)} does not recognize manifest [{manifest}]", nameof(manifest))
     };
 
@@ -241,5 +309,283 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
             dueTimeUtc,
             responseCode,
             string.IsNullOrEmpty(message) ? null : message);
+    }
+
+    private byte[] SerializeScheduleReminder(ReminderProtocol.ScheduleReminder cmd)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+
+        WriteScheduleReminderFields(writer, cmd);
+
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    private ReminderProtocol.ScheduleReminder DeserializeScheduleReminder(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes);
+        using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+
+        return ReadScheduleReminderFields(reader);
+    }
+
+    private byte[] SerializeReminderScheduled(ReminderProtocol.ReminderScheduled scheduled)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+
+        // Write the ScheduleReminder fields inline
+        WriteScheduleReminderFields(writer, scheduled.OriginalCommand);
+
+        // Write ReminderScheduled-specific fields
+        writer.Write((int)scheduled.ResponseCode);
+        writer.Write(scheduled.Message ?? string.Empty);
+
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    private ReminderProtocol.ReminderScheduled DeserializeReminderScheduled(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes);
+        using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+
+        var originalCommand = ReadScheduleReminderFields(reader);
+
+        var responseCode = (ReminderScheduleResponseCode)reader.ReadInt32();
+        var message = reader.ReadString();
+
+        return new ReminderProtocol.ReminderScheduled(
+            originalCommand,
+            responseCode,
+            string.IsNullOrEmpty(message) ? null : message);
+    }
+
+    private byte[] SerializeRemindersForEntity(ReminderProtocol.RemindersForEntity reminders)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+
+        // Write entity fields
+        writer.Write(reminders.Entity.ShardRegionName);
+        writer.Write(reminders.Entity.EntityId);
+
+        // Write response metadata
+        writer.Write((int)reminders.ResponseCode);
+        writer.Write(reminders.Message ?? string.Empty);
+
+        // Write reminder list
+        writer.Write(reminders.Reminders.Count);
+        foreach (var reminder in reminders.Reminders)
+        {
+            WriteScheduledReminderFields(writer, reminder);
+        }
+
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    private ReminderProtocol.RemindersForEntity DeserializeRemindersForEntity(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes);
+        using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+
+        var shardRegionName = reader.ReadString();
+        var entityId = reader.ReadString();
+        var entity = new ReminderEntity(shardRegionName, entityId);
+
+        var responseCode = (FetchRemindersResponseCode)reader.ReadInt32();
+        var message = reader.ReadString();
+
+        var count = reader.ReadInt32();
+        var list = new List<ScheduledReminder>(count);
+        for (var i = 0; i < count; i++)
+        {
+            list.Add(ReadScheduledReminderFields(reader, entity));
+        }
+
+        return new ReminderProtocol.RemindersForEntity(
+            entity,
+            responseCode,
+            list,
+            string.IsNullOrEmpty(message) ? null : message);
+    }
+
+    /// <summary>
+    /// Writes ScheduleReminder fields to the writer (shared between ScheduleReminder and ReminderScheduled).
+    /// </summary>
+    private void WriteScheduleReminderFields(BinaryWriter writer, ReminderProtocol.ScheduleReminder cmd)
+    {
+        writer.Write(cmd.Entity.ShardRegionName);
+        writer.Write(cmd.Entity.EntityId);
+        writer.Write(cmd.Key.Name);
+        writer.Write(cmd.When.UtcTicks);
+
+        // Nullable RepeatInterval
+        writer.Write(cmd.RepeatInterval.HasValue);
+        if (cmd.RepeatInterval.HasValue)
+            writer.Write(cmd.RepeatInterval.Value.Ticks);
+
+        // Nullable MaxDeliveryWindow
+        writer.Write(cmd.MaxDeliveryWindow.HasValue);
+        if (cmd.MaxDeliveryWindow.HasValue)
+            writer.Write(cmd.MaxDeliveryWindow.Value.Ticks);
+
+        // Delegate inner message serialization to Akka's serialization infrastructure
+        var innerSerializer = SerializationSystem.FindSerializerFor(cmd.Message);
+        var innerManifest = Akka.Serialization.Serialization.ManifestFor(innerSerializer, cmd.Message);
+        var innerBytes = innerSerializer.ToBinary(cmd.Message);
+
+        writer.Write(innerSerializer.Identifier);
+        writer.Write(innerManifest);
+        writer.Write(innerBytes.Length);
+        writer.Write(innerBytes);
+    }
+
+    /// <summary>
+    /// Reads ScheduleReminder fields from the reader (shared between ScheduleReminder and ReminderScheduled).
+    /// </summary>
+    private ReminderProtocol.ScheduleReminder ReadScheduleReminderFields(BinaryReader reader)
+    {
+        var shardRegionName = reader.ReadString();
+        var entityId = reader.ReadString();
+        var entity = new ReminderEntity(shardRegionName, entityId);
+
+        var keyName = reader.ReadString();
+        var key = new ReminderKey(keyName);
+
+        var when = new DateTimeOffset(reader.ReadInt64(), TimeSpan.Zero);
+
+        // Nullable RepeatInterval
+        TimeSpan? repeatInterval = null;
+        if (reader.ReadBoolean())
+            repeatInterval = TimeSpan.FromTicks(reader.ReadInt64());
+
+        // Nullable MaxDeliveryWindow
+        TimeSpan? maxDeliveryWindow = null;
+        if (reader.ReadBoolean())
+            maxDeliveryWindow = TimeSpan.FromTicks(reader.ReadInt64());
+
+        // Inner message
+        var innerSerializerId = reader.ReadInt32();
+        var innerManifest = reader.ReadString();
+        var innerLength = reader.ReadInt32();
+        var innerBytes = reader.ReadBytes(innerLength);
+        var innerMessage = SerializationSystem.Deserialize(innerBytes, innerSerializerId, innerManifest);
+
+        return new ReminderProtocol.ScheduleReminder(
+            entity,
+            key,
+            when,
+            innerMessage,
+            repeatInterval,
+            maxDeliveryWindow);
+    }
+
+    /// <summary>
+    /// Writes a single ScheduledReminder's fields to the writer (used in RemindersForEntity).
+    /// </summary>
+    private void WriteScheduledReminderFields(BinaryWriter writer, ScheduledReminder reminder)
+    {
+        writer.Write(reminder.Key.Name);
+        writer.Write(reminder.When.UtcTicks);
+
+        // Nullable RepeatInterval
+        writer.Write(reminder.RepeatInterval.HasValue);
+        if (reminder.RepeatInterval.HasValue)
+            writer.Write(reminder.RepeatInterval.Value.Ticks);
+
+        // AttemptCount
+        writer.Write(reminder.AttemptCount);
+
+        // Nullable LastFailureReason
+        var hasFailureReason = !string.IsNullOrEmpty(reminder.LastFailureReason);
+        writer.Write(hasFailureReason);
+        if (hasFailureReason)
+            writer.Write(reminder.LastFailureReason!);
+
+        // Nullable MaxDeliveryWindow
+        writer.Write(reminder.MaxDeliveryWindow.HasValue);
+        if (reminder.MaxDeliveryWindow.HasValue)
+            writer.Write(reminder.MaxDeliveryWindow.Value.Ticks);
+
+        // Nullable DeliveryDeadlineUtc
+        writer.Write(reminder.DeliveryDeadlineUtc.HasValue);
+        if (reminder.DeliveryDeadlineUtc.HasValue)
+            writer.Write(reminder.DeliveryDeadlineUtc.Value.UtcTicks);
+
+        // Nullable OccurrenceDueTimeUtc
+        writer.Write(reminder.OccurrenceDueTimeUtc.HasValue);
+        if (reminder.OccurrenceDueTimeUtc.HasValue)
+            writer.Write(reminder.OccurrenceDueTimeUtc.Value.UtcTicks);
+
+        // Inner message
+        var innerSerializer = SerializationSystem.FindSerializerFor(reminder.Message);
+        var innerManifest = Akka.Serialization.Serialization.ManifestFor(innerSerializer, reminder.Message);
+        var innerBytes = innerSerializer.ToBinary(reminder.Message);
+
+        writer.Write(innerSerializer.Identifier);
+        writer.Write(innerManifest);
+        writer.Write(innerBytes.Length);
+        writer.Write(innerBytes);
+    }
+
+    /// <summary>
+    /// Reads a single ScheduledReminder's fields from the reader (used in RemindersForEntity).
+    /// </summary>
+    private ScheduledReminder ReadScheduledReminderFields(BinaryReader reader, ReminderEntity entity)
+    {
+        var keyName = reader.ReadString();
+        var key = new ReminderKey(keyName);
+
+        var when = new DateTimeOffset(reader.ReadInt64(), TimeSpan.Zero);
+
+        // Nullable RepeatInterval
+        TimeSpan? repeatInterval = null;
+        if (reader.ReadBoolean())
+            repeatInterval = TimeSpan.FromTicks(reader.ReadInt64());
+
+        // AttemptCount
+        var attemptCount = reader.ReadInt32();
+
+        // Nullable LastFailureReason
+        string? lastFailureReason = null;
+        if (reader.ReadBoolean())
+            lastFailureReason = reader.ReadString();
+
+        // Nullable MaxDeliveryWindow
+        TimeSpan? maxDeliveryWindow = null;
+        if (reader.ReadBoolean())
+            maxDeliveryWindow = TimeSpan.FromTicks(reader.ReadInt64());
+
+        // Nullable DeliveryDeadlineUtc
+        DateTimeOffset? deliveryDeadlineUtc = null;
+        if (reader.ReadBoolean())
+            deliveryDeadlineUtc = new DateTimeOffset(reader.ReadInt64(), TimeSpan.Zero);
+
+        // Nullable OccurrenceDueTimeUtc
+        DateTimeOffset? occurrenceDueTimeUtc = null;
+        if (reader.ReadBoolean())
+            occurrenceDueTimeUtc = new DateTimeOffset(reader.ReadInt64(), TimeSpan.Zero);
+
+        // Inner message
+        var innerSerializerId = reader.ReadInt32();
+        var innerManifest = reader.ReadString();
+        var innerLength = reader.ReadInt32();
+        var innerBytes = reader.ReadBytes(innerLength);
+        var innerMessage = SerializationSystem.Deserialize(innerBytes, innerSerializerId, innerManifest);
+
+        return new ScheduledReminder(
+            entity,
+            key,
+            when,
+            innerMessage,
+            repeatInterval,
+            attemptCount,
+            lastFailureReason,
+            maxDeliveryWindow,
+            deliveryDeadlineUtc,
+            occurrenceDueTimeUtc);
     }
 }


### PR DESCRIPTION
## Summary
- Add custom serialization for `ScheduleReminder`, `ReminderScheduled`, and `RemindersForEntity` in `ReminderSerializer`
- These messages carry user-defined `object Message` payloads across the `ClusterSingletonProxy` wire hop
- Previously serialized by default Newtonsoft.Json — silently broke for user types with custom Akka serializers (Protobuf, MessagePack, etc.)
- Now all three delegate the inner `Message` to `FindSerializerFor` using the same pattern as `ReminderEnvelope`
- Added `IReminderWireMessage` marker to all three types

## What changed
- `ReminderProtocol.cs`: `IReminderWireMessage` added to `ScheduleReminder`, `ReminderScheduled`, `RemindersForEntity`
- `ReminderSerializer.cs`: 6 new serialize/deserialize methods with shared field helpers, wire format diagrams updated
- `ReminderSerializerSpecs.cs`: 9 new round-trip tests (string/JSON payloads, optional fields, error responses, lists)

## Why this matters
The storage layer already correctly delegates inner message serialization via `FindSerializerFor`. But the client → scheduler wire hop did not — the entire `ScheduleReminder` record was serialized as a monolithic JSON blob, bypassing the user's custom serializer registration. This is a correctness issue for any user whose reminder payloads use non-JSON serializers.

## Test plan
- [x] 19/19 serializer round-trip tests pass
- [x] 214/214 full test suite passes
- [ ] CI green