### PR TITLE
fix: bump Testcontainers to 4.11.0 and fix breaking API changes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,8 +17,8 @@
     <PackageVersion Include="Akka.Hosting.TestKit" Version="$(AkkaHostingVersion)" />
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="4.2.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.2.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/src/Akka.Reminders.Migration.Tests/PostgreSqlMigrationSpecs.cs
+++ b/src/Akka.Reminders.Migration.Tests/PostgreSqlMigrationSpecs.cs
@@ -85,8 +85,7 @@ VALUES
 
     public async Task InitializeAsync()
     {
-        _container = new PostgreSqlBuilder()
-            .WithImage("postgres:16-alpine")
+        _container = new PostgreSqlBuilder("postgres:16-alpine")
             .Build();
 
         await _container.StartAsync();

--- a/src/Akka.Reminders.Migration.Tests/SqlServerMigrationSpecs.cs
+++ b/src/Akka.Reminders.Migration.Tests/SqlServerMigrationSpecs.cs
@@ -178,8 +178,7 @@ VALUES
 
     public async Task InitializeAsync()
     {
-        _container = new MsSqlBuilder()
-            .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+        _container = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-latest")
             .WithPassword("yourStrong(!)Password")
             .Build();
 

--- a/src/Akka.Reminders.Tests/Storage/SqlReminderStorageSpecs.cs
+++ b/src/Akka.Reminders.Tests/Storage/SqlReminderStorageSpecs.cs
@@ -21,8 +21,7 @@ public class SqlServerReminderStorageSpecs : ReminderStorageSpecBase
     {
         _system = ActorSystem.Create("test-system");
 
-        _container = new MsSqlBuilder()
-            .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+        _container = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-latest")
             .WithPassword("yourStrong(!)Password")
             .Build();
 
@@ -57,8 +56,7 @@ public class PostgreSqlReminderStorageSpecs : ReminderStorageSpecBase
     {
         _system = ActorSystem.Create("test-system");
 
-        _container = new PostgreSqlBuilder()
-            .WithImage("postgres:16-alpine")
+        _container = new PostgreSqlBuilder("postgres:16-alpine")
             .Build();
 
         await _container.StartAsync();


### PR DESCRIPTION
Testcontainers 4.11.0 made parameterless constructors obsolete, which TreatWarningsAsErrors=true promotes to build errors.

Changes:
- MsSqlBuilder: pass image to constructor instead of .WithImage()
- PostgreSqlBuilder: pass image to constructor instead of .WithImage()
- Bumps: Testcontainers.MsSql 4.2.0→4.11.0, Testcontainers.PostgreSql 4.2.0→4.11.0, Microsoft.Data.Sqlite 10.0.3→10.0.5