### PR TITLE
Add opt-in Protobuf reminder serializer

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,11 @@
   <!-- Akka.Hosting packages - brings in core Akka transitively -->
   <ItemGroup>
     <PackageVersion Include="Akka.Cluster.Hosting" Version="$(AkkaHostingVersion)" />
+    <PackageVersion Include="Google.Protobuf" Version="3.35.1" />
+    <PackageVersion Include="Grpc.Tools" Version="2.83.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageVersion>
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.4" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.5" />

--- a/README.md
+++ b/README.md
@@ -190,6 +190,31 @@ public class MyEntityActor : ReceiveActor
 
 ## Configuration
 
+### Protobuf Wire Serializer
+
+Akka.Reminders registers both wire serializers on every node. The legacy serializer remains the default writer during the compatibility rollout.
+
+Enable Protobuf writes after every cluster node runs a version that contains the Protobuf reader:
+
+```csharp
+.WithReminders("reminder-host", reminders => reminders
+    .WithStorage(_ => new InMemoryReminderStorage())
+    .WithProtobufSerializer())
+```
+
+The same option is available on `WithLocalReminders()`.
+
+The rollout has two phases:
+
+1. Upgrade every node while legacy writes remain active. Both serializer IDs can read messages.
+2. Enable `WithProtobufSerializer()` on every node. New reminder messages then use Protobuf.
+
+The library logs a startup warning while the legacy serializer owns the write binding. Serializer ID `22550` remains available for legacy reads. Serializer ID `22551` identifies Protobuf messages.
+
+The flag does not rewrite existing SQLite rows. A payload keeps its old serializer metadata until an upsert rewrites that payload. The upsert replaces the serializer ID, manifest, and payload with the active serializer output. User payloads keep their own Akka.NET serializer bindings.
+
+> **Warning:** Do not roll back to a release that lacks the Protobuf reader after you enable Protobuf writes. A durable payload can retain serializer ID `22551`. You can disable new Protobuf writes only while all nodes keep the Protobuf reader installed.
+
 ### SQL Server Storage
 
 `using Akka.Reminders.SqlServer.Hosting;`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,18 @@
+#### Next ####
+
+**New Features**
+
+- Added an opt-in Protobuf wire serializer for reminder protocol messages.
+- Kept serializer ID `22550` as a permanent legacy reader.
+- Added a startup warning that directs users to `WithProtobufSerializer()`.
+
+**Upgrade Order**
+
+1. Upgrade every cluster node while legacy writes remain active.
+2. Enable `WithProtobufSerializer()` on every node after the first step is complete.
+
+Do not roll back to a release that lacks the Protobuf reader after step 2. Durable payloads can retain serializer ID `22551`.
+
 #### 0.6.0 May 28th 2026 ####
 
 **Bug Fixes**

--- a/src/Akka.Reminders.Tests/Serialization/ReminderSerializerBindingSpecs.cs
+++ b/src/Akka.Reminders.Tests/Serialization/ReminderSerializerBindingSpecs.cs
@@ -1,0 +1,99 @@
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Reminders.Serialization;
+using Akka.Serialization;
+using Xunit.Abstractions;
+
+namespace Akka.Reminders.Tests.Serialization;
+
+public abstract class ReminderSerializerBindingSpecBase : Akka.Hosting.TestKit.TestKit
+{
+    protected ReminderSerializerBindingSpecBase(ITestOutputHelper output) : base(output: output)
+    {
+    }
+
+    protected abstract bool UseProtobufSerializer { get; }
+
+    protected abstract Type ExpectedWriteSerializerType { get; }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder.WithLocalReminders(reminders =>
+        {
+            if (UseProtobufSerializer)
+                reminders.WithProtobufSerializer();
+        });
+    }
+
+    [Fact]
+    public void Selected_serializer_owns_the_write_binding()
+    {
+        var serializer = Sys.Serialization.FindSerializerFor(CreateAck());
+
+        Assert.IsType(ExpectedWriteSerializerType, serializer);
+    }
+
+    [Fact]
+    public void Both_serializer_ids_remain_available_for_reads()
+    {
+        var system = (ExtendedActorSystem)Sys;
+        var message = CreateAck();
+        SerializerWithStringManifest[] serializers =
+        [
+            new ReminderSerializer(system),
+            new ProtobufReminderSerializer(system)
+        ];
+
+        foreach (var serializer in serializers)
+        {
+            var result = Sys.Serialization.Deserialize(
+                serializer.ToBinary(message),
+                serializer.Identifier,
+                serializer.Manifest(message));
+
+            Assert.Equal(message, Assert.IsType<ReminderProtocol.ReminderAck>(result));
+        }
+    }
+
+    private static ReminderProtocol.ReminderAck CreateAck() => new(
+        new ReminderEntity("region", "entity"),
+        new ReminderKey("key"),
+        new DateTimeOffset(2026, 8, 7, 13, 0, 0, TimeSpan.Zero));
+}
+
+public sealed class LegacyReminderSerializerBindingSpecs(ITestOutputHelper output)
+    : ReminderSerializerBindingSpecBase(output)
+{
+    protected override bool UseProtobufSerializer => false;
+
+    protected override Type ExpectedWriteSerializerType => typeof(ReminderSerializer);
+}
+
+public sealed class ProtobufReminderSerializerBindingSpecs(ITestOutputHelper output)
+    : ReminderSerializerBindingSpecBase(output)
+{
+    protected override bool UseProtobufSerializer => true;
+
+    protected override Type ExpectedWriteSerializerType => typeof(ProtobufReminderSerializer);
+}
+
+public sealed class ReminderSerializerWarningSpecs(ITestOutputHelper output) : Akka.Hosting.TestKit.TestKit(output: output)
+{
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+    }
+
+    [Fact]
+    public void Legacy_write_binding_logs_the_migration_warning()
+    {
+        EventFilter.Warning(contains: "Enable WithProtobufSerializer()")
+            .ExpectOne(() => AkkaHostingExtensions.WarnIfLegacySerializerWrites(Sys, useProtobufSerializer: false));
+    }
+
+    [Fact]
+    public void Protobuf_write_binding_does_not_log_the_migration_warning()
+    {
+        EventFilter.Warning(contains: "Enable WithProtobufSerializer()")
+            .Expect(0, () => AkkaHostingExtensions.WarnIfLegacySerializerWrites(Sys, useProtobufSerializer: true));
+    }
+}

--- a/src/Akka.Reminders.Tests/Serialization/ReminderSerializerSpecs.cs
+++ b/src/Akka.Reminders.Tests/Serialization/ReminderSerializerSpecs.cs
@@ -1,22 +1,24 @@
 using Akka.Hosting;
 using Akka.Hosting.TestKit;
 using Akka.Reminders.Serialization;
+using Akka.Reminders.Serialization.Proto;
 using Akka.Serialization;
+using Google.Protobuf;
 using Xunit.Abstractions;
 
 namespace Akka.Reminders.Tests.Serialization;
 
 /// <summary>
-/// Round-trip serialization tests for <see cref="ReminderSerializer"/>.
+/// Defines round-trip tests for the Protobuf reminder serializer.
 ///
 /// Follows the core Akka.NET pattern (see ClusterMessageSerializerSpec):
 /// register the serializer via <see cref="AkkaConfigurationBuilder.WithCustomSerializer"/>,
 /// use a small <see cref="AssertAndReturn{T}"/> helper that verifies the correct serializer
 /// is resolved and the message survives a ToBinary → FromBinary cycle.
 /// </summary>
-public class ReminderSerializerSpecs : Akka.Hosting.TestKit.TestKit
+public sealed class ProtobufReminderSerializerSpecs : Akka.Hosting.TestKit.TestKit
 {
-    public ReminderSerializerSpecs(ITestOutputHelper output)
+    public ProtobufReminderSerializerSpecs(ITestOutputHelper output)
         : base(output: output)
     {
     }
@@ -26,17 +28,17 @@ public class ReminderSerializerSpecs : Akka.Hosting.TestKit.TestKit
         builder.WithCustomSerializer(
             "reminder-serializer",
             [typeof(IReminderWireMessage)],
-            system => new ReminderSerializer(system));
+            system => new ProtobufReminderSerializer(system));
     }
 
     /// <summary>
-    /// Serializes and deserializes a message, asserting that <see cref="ReminderSerializer"/>
+    /// Serializes and deserializes a message, asserting that <see cref="ProtobufReminderSerializer"/>
     /// is the resolved serializer. Returns the deserialized instance for further assertions.
     /// </summary>
     private T AssertAndReturn<T>(T message) where T : notnull
     {
         var serializer = (SerializerWithStringManifest)Sys.Serialization.FindSerializerFor(message);
-        Assert.IsType<ReminderSerializer>(serializer);
+        Assert.IsType<ProtobufReminderSerializer>(serializer);
 
         var bytes = serializer.ToBinary(message);
         var manifest = serializer.Manifest(message);
@@ -494,6 +496,95 @@ public class ReminderSerializerSpecs : Akka.Hosting.TestKit.TestKit
     }
 
     #endregion
+
+    [Fact]
+    public void Legacy_wire_contracts_stay_frozen_and_readable()
+    {
+        var serializer = new ReminderSerializer((Akka.Actor.ExtendedActorSystem)Sys);
+        var entity = new ReminderEntity("region", "entity");
+        var key = new ReminderKey("key");
+        var time = new DateTimeOffset(2026, 8, 7, 13, 0, 0, TimeSpan.Zero);
+        var command = new ReminderProtocol.ScheduleReminder(entity, key, time, "payload");
+        (string Manifest, string Base64, object Message)[] fixtures =
+        [
+            ("re", "BnJlZ2lvbgZlbnRpdHkDa2V5AMj+yYP03ggADsLtg/TeCAEAAAAACQAAACJwYXlsb2FkIg==",
+                new ReminderEnvelope<string>(entity, key, time, new ReminderDeadline(time.AddMinutes(1)), "payload")),
+            ("ra", "BnJlZ2lvbgZlbnRpdHkDa2V5AMj+yYP03gg=",
+                new ReminderProtocol.ReminderAck(entity, key, time)),
+            ("rar", "BnJlZ2lvbgZlbnRpdHkDa2V5AMj+yYP03ggCAAAABWVycm9y",
+                new ReminderProtocol.ReminderAckResponse(entity, key, time, ReminderAckResponseCode.Error, "error")),
+            ("sr", "BnJlZ2lvbgZlbnRpdHkDa2V5AMj+yYP03ggAAAEAAAAACQAAACJwYXlsb2FkIg==", command),
+            ("rsd", "BnJlZ2lvbgZlbnRpdHkDa2V5AMj+yYP03ggAAAEAAAAACQAAACJwYXlsb2FkIgIAAAAFZXJyb3I=",
+                new ReminderProtocol.ReminderScheduled(command, ReminderScheduleResponseCode.Error, "error")),
+            ("rfe", "BnJlZ2lvbgZlbnRpdHkAAAAAAAEAAAADa2V5AMj+yYP03ggAAAAAAAAAAAABAAAAAAkAAAAicGF5bG9hZCI=",
+                new ReminderProtocol.RemindersForEntity(
+                    entity,
+                    FetchRemindersResponseCode.Success,
+                    [new ScheduledReminder(entity, key, time, "payload")]))
+        ];
+
+        foreach (var fixture in fixtures)
+        {
+            Assert.Equal(fixture.Manifest, serializer.Manifest(fixture.Message));
+            Assert.Equal(fixture.Base64, Convert.ToBase64String(serializer.ToBinary(fixture.Message)));
+            AssertLegacyEquivalent(
+                fixture.Message,
+                serializer.FromBinary(Convert.FromBase64String(fixture.Base64), fixture.Manifest));
+        }
+    }
+
+    [Fact]
+    public void Reader_ignores_unknown_fields()
+    {
+        var serializer = new ProtobufReminderSerializer((Akka.Actor.ExtendedActorSystem)Sys);
+        var message = new ReminderProtocol.ReminderAck(
+            new ReminderEntity("region", "entity"),
+            new ReminderKey("key"),
+            new DateTimeOffset(2026, 8, 7, 13, 0, 0, TimeSpan.Zero));
+        var bytes = serializer.ToBinary(message).Concat(new byte[] { 0x98, 0x06, 0x01 }).ToArray();
+
+        var result = serializer.FromBinary(bytes, serializer.Manifest(message));
+
+        Assert.Equal(message, Assert.IsType<ReminderProtocol.ReminderAck>(result));
+    }
+
+    [Fact]
+    public void Reader_rejects_an_unspecified_response_code()
+    {
+        var serializer = new ProtobufReminderSerializer((Akka.Actor.ExtendedActorSystem)Sys);
+        var response = new ReminderAckResponseProto
+        {
+            Entity = new ReminderEntityProto { ShardRegionName = "region", EntityId = "entity" },
+            Key = "key",
+            DueTimeUtcTicks = new DateTimeOffset(2026, 8, 7, 13, 0, 0, TimeSpan.Zero).UtcTicks
+        };
+
+        Assert.Throws<InvalidDataException>(() => serializer.FromBinary(response.ToByteArray(), "rar"));
+    }
+
+    private static void AssertLegacyEquivalent(object expected, object actual)
+    {
+        switch (expected, actual)
+        {
+            case (ReminderEnvelope expectedEnvelope, ReminderEnvelope actualEnvelope):
+                Assert.Equal(expectedEnvelope.Entity, actualEnvelope.Entity);
+                Assert.Equal(expectedEnvelope.Key, actualEnvelope.Key);
+                Assert.Equal(expectedEnvelope.DueTimeUtc, actualEnvelope.DueTimeUtc);
+                Assert.Equal(expectedEnvelope.Deadline, actualEnvelope.Deadline);
+                Assert.Equal(expectedEnvelope.Message, actualEnvelope.Message);
+                break;
+            case (ReminderProtocol.RemindersForEntity expectedReminders,
+                ReminderProtocol.RemindersForEntity actualReminders):
+                Assert.Equal(expectedReminders.Entity, actualReminders.Entity);
+                Assert.Equal(expectedReminders.ResponseCode, actualReminders.ResponseCode);
+                Assert.Equal(expectedReminders.Message, actualReminders.Message);
+                Assert.Equal(expectedReminders.Reminders, actualReminders.Reminders);
+                break;
+            default:
+                Assert.Equal(expected, actual);
+                break;
+        }
+    }
 }
 
 /// <summary>

--- a/src/Akka.Reminders.Tests/Serialization/ReminderSerializerUpgradeSpecs.cs
+++ b/src/Akka.Reminders.Tests/Serialization/ReminderSerializerUpgradeSpecs.cs
@@ -1,0 +1,172 @@
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Reminders.Serialization;
+using Akka.Reminders.Sharding;
+using Akka.Reminders.Sqlite;
+using Akka.Reminders.Sqlite.Configuration;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Akka.Reminders.Tests.Serialization;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class ReminderSerializerUpgradeCollection
+{
+    public const string Name = "Reminder serializer upgrade";
+}
+
+[Collection(ReminderSerializerUpgradeCollection.Name)]
+public sealed class ReminderSerializerUpgradeSpecs
+{
+    [Fact]
+    public async Task Protobuf_host_reads_and_delivers_a_reminder_payload_written_by_the_legacy_serializer()
+    {
+        var databasePath = Path.Combine(Path.GetTempPath(), $"akka-reminders-serializer-{Guid.NewGuid():N}.db");
+        var connectionString = $"Data Source={databasePath}";
+        var entity = new ReminderEntity("upgrade-region", "entity-1");
+        var key = new ReminderKey("legacy-payload");
+        var storedDueTime = DateTimeOffset.UtcNow.AddHours(1);
+        var storedMessage = new ReminderProtocol.ReminderAck(
+            entity,
+            new ReminderKey("inner-ack"),
+            new DateTimeOffset(2026, 8, 7, 13, 0, 0, TimeSpan.Zero));
+
+        try
+        {
+            SerializedPayloadMetadata legacyMetadata;
+            var legacyResolver = new CapturingResolver();
+            using (var legacyHost = CreateHost(connectionString, legacyResolver, useProtobufSerializer: false))
+            {
+                await legacyHost.StartAsync();
+                var system = legacyHost.Services.GetRequiredService<ActorSystem>();
+                var client = system.ReminderClient().CreateClient(entity.ShardRegionName, entity.EntityId);
+
+                var result = await client.ScheduleSingleReminderAsync(
+                    key,
+                    storedDueTime,
+                    storedMessage);
+
+                Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
+                legacyMetadata = await ReadSerializedPayloadMetadataAsync(connectionString, key);
+                Assert.Equal(22550, legacyMetadata.SerializerId);
+                Assert.Equal("ra", legacyMetadata.Manifest);
+                Assert.Equal(
+                    "DnVwZ3JhZGUtcmVnaW9uCGVudGl0eS0xCWlubmVyLWFjawDI/smD9N4I",
+                    Convert.ToBase64String(legacyMetadata.Payload));
+                await legacyHost.StopAsync();
+            }
+
+            await MoveReminderIntoDueWindowAsync(connectionString, key);
+
+            var protobufResolver = new CapturingResolver();
+            using (var protobufHost = CreateHost(connectionString, protobufResolver, useProtobufSerializer: true))
+            {
+                await protobufHost.StartAsync();
+                var system = protobufHost.Services.GetRequiredService<ActorSystem>();
+                var selectedSerializer = system.Serialization.FindSerializerFor(storedMessage);
+                Assert.IsType<ProtobufReminderSerializer>(selectedSerializer);
+
+                var delivered = await protobufResolver.Delivery.WaitAsync(TimeSpan.FromSeconds(10));
+                var typedEnvelope = Assert.IsType<ReminderEnvelope<ReminderProtocol.ReminderAck>>(delivered);
+                Assert.Equal(storedMessage, typedEnvelope.Message);
+
+                var ack = await system.ReminderClient().AckAsync(typedEnvelope);
+                Assert.Equal(ReminderAckResponseCode.Success, ack.ResponseCode);
+
+                var client = system.ReminderClient().CreateClient(entity.ShardRegionName, entity.EntityId);
+                var updatedMessage = storedMessage with { DueTimeUtc = storedMessage.DueTimeUtc.AddMinutes(1) };
+                var scheduleResult = await client.ScheduleSingleReminderAsync(
+                    key,
+                    storedDueTime,
+                    updatedMessage);
+
+                Assert.Equal(ReminderScheduleResponseCode.Success, scheduleResult.ResponseCode);
+                var protobufMetadata = await ReadSerializedPayloadMetadataAsync(connectionString, key);
+                Assert.Equal(22551, protobufMetadata.SerializerId);
+                Assert.Equal("ra", protobufMetadata.Manifest);
+                Assert.False(legacyMetadata.Payload.SequenceEqual(protobufMetadata.Payload));
+                await protobufHost.StopAsync();
+            }
+        }
+        finally
+        {
+            if (File.Exists(databasePath))
+                File.Delete(databasePath);
+        }
+    }
+
+    private static IHost CreateHost(
+        string connectionString,
+        CapturingResolver resolver,
+        bool useProtobufSerializer)
+    {
+        return new HostBuilder()
+            .ConfigureServices(services => services.AddAkka(
+                $"serializer-upgrade-{Guid.NewGuid():N}",
+                (builder, _) => builder.WithLocalReminders(reminders =>
+                {
+                    reminders
+                        .WithStorage(system => new SqliteReminderStorage(
+                            SqliteReminderStorageSettings.Create(connectionString),
+                            system))
+                        .WithResolver(_ => resolver)
+                        .WithSettings(new ReminderSettings
+                        {
+                            MaxSlippage = TimeSpan.FromMilliseconds(100),
+                            StorageTimeout = TimeSpan.FromSeconds(5),
+                            AckTimeout = TimeSpan.FromSeconds(5)
+                        });
+
+                    if (useProtobufSerializer)
+                        reminders.WithProtobufSerializer();
+                })))
+            .Build();
+    }
+
+    private static async Task<SerializedPayloadMetadata> ReadSerializedPayloadMetadataAsync(
+        string connectionString,
+        ReminderKey key)
+    {
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT serializer_id, manifest, payload FROM scheduled_reminders WHERE reminder_key = $key";
+        command.Parameters.AddWithValue("$key", key.Name);
+        await using var reader = await command.ExecuteReaderAsync();
+        Assert.True(await reader.ReadAsync());
+        return new SerializedPayloadMetadata(
+            reader.GetInt32(0),
+            reader.GetString(1),
+            (byte[])reader.GetValue(2));
+    }
+
+    private static async Task MoveReminderIntoDueWindowAsync(string connectionString, ReminderKey key)
+    {
+        await using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "UPDATE scheduled_reminders SET when_utc = $whenUtc WHERE reminder_key = $key";
+        command.Parameters.AddWithValue("$whenUtc", DateTime.UtcNow.AddMinutes(-1));
+        command.Parameters.AddWithValue("$key", key.Name);
+        Assert.Equal(1, await command.ExecuteNonQueryAsync());
+    }
+
+    private sealed record SerializedPayloadMetadata(int SerializerId, string Manifest, byte[] Payload);
+
+    private sealed class CapturingResolver : IShardRegionResolver
+    {
+        private readonly TaskCompletionSource<ReminderEnvelope> _delivery =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<ReminderEnvelope> Delivery => _delivery.Task;
+
+        public IActorRef? TryResolve(ReminderEntity entity) => ActorRefs.Nobody;
+
+        public void DeliverReminder(ReminderEntity entity, ReminderEnvelope envelope, IActorRef? sender = null)
+        {
+            _delivery.TrySetResult(envelope);
+        }
+    }
+}

--- a/src/Akka.Reminders/Akka.Reminders.csproj
+++ b/src/Akka.Reminders/Akka.Reminders.csproj
@@ -16,6 +16,15 @@
 
     <ItemGroup>
       <PackageReference Include="Akka.Cluster.Hosting" />
+      <PackageReference Include="Google.Protobuf" />
+      <PackageReference Include="Grpc.Tools">
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <Protobuf Include="Serialization/Proto/reminder.proto" GrpcServices="None" Access="Internal" />
     </ItemGroup>
 
 </Project>

--- a/src/Akka.Reminders/AkkaHostingExtensions.cs
+++ b/src/Akka.Reminders/AkkaHostingExtensions.cs
@@ -10,16 +10,30 @@ namespace Akka.Reminders;
 /// </summary>
 public static class AkkaHostingExtensions
 {
+    private const string LegacySerializerWarning =
+        "Akka.Reminders uses the legacy wire serializer for new messages. " +
+        "Enable WithProtobufSerializer() after all cluster nodes support the Protobuf reader.";
+
+    internal static void WarnIfLegacySerializerWrites(ActorSystem system, bool useProtobufSerializer)
+    {
+        if (!useProtobufSerializer)
+            Logging.GetLogger(system, typeof(AkkaHostingExtensions)).Warning(LegacySerializerWarning);
+    }
+
     /// <summary>
-    /// Registers the <see cref="Serialization.ReminderSerializer"/> for all
-    /// <see cref="IReminderWireMessage"/> types using the Akka.Hosting serializer API.
+    /// Registers both reminder serializers and selects the serializer for new writes.
     /// </summary>
-    private static void RegisterReminderSerializer(AkkaConfigurationBuilder builder)
+    private static void RegisterReminderSerializers(AkkaConfigurationBuilder builder, bool useProtobufSerializer)
     {
         builder.WithCustomSerializer(
             "reminder-serializer",
-            [typeof(IReminderWireMessage)],
+            useProtobufSerializer ? [] : [typeof(IReminderWireMessage)],
             system => new Serialization.ReminderSerializer(system));
+
+        builder.WithCustomSerializer(
+            "reminder-protobuf-serializer",
+            useProtobufSerializer ? [typeof(IReminderWireMessage)] : [],
+            system => new Serialization.ProtobufReminderSerializer(system));
     }
 
     /// <summary>
@@ -49,8 +63,7 @@ public static class AkkaHostingExtensions
         configure?.Invoke(reminderBuilder);
         var setup = reminderBuilder.Build();
 
-        // Register the reminder serializer for all IReminderWireMessage types.
-        RegisterReminderSerializer(builder);
+        RegisterReminderSerializers(builder, setup.UseProtobufSerializer);
 
         // Add the setup to the actor system
         builder.AddSetup(setup);
@@ -60,6 +73,8 @@ public static class AkkaHostingExtensions
         {
             var extendedSystem = (ExtendedActorSystem)system;
             var log = Logging.GetLogger(system, typeof(AkkaHostingExtensions));
+
+            WarnIfLegacySerializerWrites(system, setup.UseProtobufSerializer);
 
             // Check if this node has the required role to host the singleton
             var nodeRoles = system.Settings.Config.GetStringList("akka.cluster.roles");
@@ -151,12 +166,13 @@ public static class AkkaHostingExtensions
         var localBuilder = new LocalReminderConfigurationBuilder();
         configure?.Invoke(localBuilder);
 
-        // Register the reminder serializer for all IReminderWireMessage types.
-        RegisterReminderSerializer(builder);
+        RegisterReminderSerializers(builder, localBuilder.GetUseProtobufSerializer());
 
         builder.WithActors((system, registry) =>
         {
             var extendedSystem = (ExtendedActorSystem)system;
+
+            WarnIfLegacySerializerWrites(system, localBuilder.GetUseProtobufSerializer());
 
             // Create the storage and resolver instances from the local builder
             var storage = localBuilder.GetStorageFactory()(system);

--- a/src/Akka.Reminders/LocalReminderConfigurationBuilder.cs
+++ b/src/Akka.Reminders/LocalReminderConfigurationBuilder.cs
@@ -18,6 +18,7 @@ public sealed class LocalReminderConfigurationBuilder
     private Func<ActorSystem, IReminderStorage>? _storageFactory;
     private Func<ActorSystem, IShardRegionResolver>? _resolver;
     private ReminderSettings _settings = new();
+    private bool _useProtobufSerializer;
 
     /// <summary>
     /// Registers a shard region that reminders can be delivered to during testing.
@@ -124,12 +125,21 @@ public sealed class LocalReminderConfigurationBuilder
         return this;
     }
 
+    /// <summary>
+    /// Uses Protobuf for new reminder protocol messages.
+    /// </summary>
+    public LocalReminderConfigurationBuilder WithProtobufSerializer()
+    {
+        _useProtobufSerializer = true;
+        return this;
+    }
+
     internal Func<ActorSystem, IReminderStorage> GetStorageFactory()
     {
         return _storageFactory ?? (_ => new InMemoryReminderStorage());
     }
 
-    internal Func<ActorSystem,IShardRegionResolver> GetResolver()
+    internal Func<ActorSystem, IShardRegionResolver> GetResolver()
     {
         return _resolver ?? (_ => new TestShardRegionResolver(_shardRegions));
     }
@@ -137,5 +147,10 @@ public sealed class LocalReminderConfigurationBuilder
     internal ReminderSettings GetSettings()
     {
         return _settings;
+    }
+
+    internal bool GetUseProtobufSerializer()
+    {
+        return _useProtobufSerializer;
     }
 }

--- a/src/Akka.Reminders/ReminderConfigurationBuilder.cs
+++ b/src/Akka.Reminders/ReminderConfigurationBuilder.cs
@@ -13,6 +13,7 @@ public sealed class ReminderConfigurationBuilder
     private Func<ActorSystem, IShardRegionResolver>? _resolverFactory;
     private ReminderSettings _settings = new();
     private string? _role;
+    private bool _useProtobufSerializer;
 
     /// <summary>
     /// Configures the storage backend using a factory function.
@@ -85,6 +86,18 @@ public sealed class ReminderConfigurationBuilder
     }
 
     /// <summary>
+    /// Uses Protobuf for new reminder protocol messages.
+    /// </summary>
+    /// <remarks>
+    /// Upgrade all nodes to a version that contains the Protobuf reader before you enable this option.
+    /// </remarks>
+    public ReminderConfigurationBuilder WithProtobufSerializer()
+    {
+        _useProtobufSerializer = true;
+        return this;
+    }
+
+    /// <summary>
     /// Builds the internal <see cref="ReminderSetup"/> from the configured options.
     /// </summary>
     internal ReminderSetup Build()
@@ -101,6 +114,9 @@ public sealed class ReminderConfigurationBuilder
 
         if (_role != null)
             setup = setup.WithRole(_role);
+
+        if (_useProtobufSerializer)
+            setup = setup.WithProtobufSerializer();
 
         return setup;
     }

--- a/src/Akka.Reminders/ReminderSetup.cs
+++ b/src/Akka.Reminders/ReminderSetup.cs
@@ -54,6 +54,14 @@ public sealed class ReminderSetup : Setup
     public string? Role { get; init; }
 
     /// <summary>
+    /// Gets a value that selects Protobuf for new reminder protocol messages.
+    /// </summary>
+    /// <remarks>
+    /// Both serializers remain available for reads. The default value keeps legacy writes.
+    /// </remarks>
+    public bool UseProtobufSerializer { get; init; }
+
+    /// <summary>
     /// Creates a copy of this setup with the specified storage factory.
     /// </summary>
     public ReminderSetup WithStorage(Func<ActorSystem, IReminderStorage> storageFactory)
@@ -63,7 +71,8 @@ public sealed class ReminderSetup : Setup
             StorageFactory = storageFactory,
             ShardRegionResolverFactory = ShardRegionResolverFactory,
             Settings = Settings,
-            Role = Role
+            Role = Role,
+            UseProtobufSerializer = UseProtobufSerializer
         };
     }
 
@@ -77,7 +86,8 @@ public sealed class ReminderSetup : Setup
             StorageFactory = StorageFactory,
             ShardRegionResolverFactory = resolverFactory,
             Settings = Settings,
-            Role = Role
+            Role = Role,
+            UseProtobufSerializer = UseProtobufSerializer
         };
     }
 
@@ -92,7 +102,8 @@ public sealed class ReminderSetup : Setup
             StorageFactory = StorageFactory,
             ShardRegionResolverFactory = ShardRegionResolverFactory,
             Settings = settings,
-            Role = Role
+            Role = Role,
+            UseProtobufSerializer = UseProtobufSerializer
         };
     }
 
@@ -106,7 +117,23 @@ public sealed class ReminderSetup : Setup
             StorageFactory = StorageFactory,
             ShardRegionResolverFactory = ShardRegionResolverFactory,
             Settings = Settings,
-            Role = role
+            Role = role,
+            UseProtobufSerializer = UseProtobufSerializer
+        };
+    }
+
+    /// <summary>
+    /// Creates a copy that uses Protobuf for new reminder protocol messages.
+    /// </summary>
+    public ReminderSetup WithProtobufSerializer()
+    {
+        return new ReminderSetup
+        {
+            StorageFactory = StorageFactory,
+            ShardRegionResolverFactory = ShardRegionResolverFactory,
+            Settings = Settings,
+            Role = Role,
+            UseProtobufSerializer = true
         };
     }
 }

--- a/src/Akka.Reminders/Serialization/Proto/reminder.proto
+++ b/src/Akka.Reminders/Serialization/Proto/reminder.proto
@@ -1,0 +1,94 @@
+syntax = "proto3";
+
+package akka.reminders.serialization;
+
+option csharp_namespace = "Akka.Reminders.Serialization.Proto";
+
+message ReminderEntityProto {
+  string shard_region_name = 1;
+  string entity_id = 2;
+}
+
+message SerializedPayloadProto {
+  int32 serializer_id = 1;
+  string manifest = 2;
+  bytes payload = 3;
+}
+
+message ReminderEnvelopeProto {
+  ReminderEntityProto entity = 1;
+  string key = 2;
+  int64 due_time_utc_ticks = 3;
+  int64 deadline_utc_ticks = 4;
+  SerializedPayloadProto message = 5;
+}
+
+message ReminderAckProto {
+  ReminderEntityProto entity = 1;
+  string key = 2;
+  int64 due_time_utc_ticks = 3;
+}
+
+enum ReminderAckResponseCodeProto {
+  REMINDER_ACK_RESPONSE_UNSPECIFIED = 0;
+  REMINDER_ACK_RESPONSE_SUCCESS = 1;
+  REMINDER_ACK_RESPONSE_NOT_FOUND = 2;
+  REMINDER_ACK_RESPONSE_ERROR = 3;
+}
+
+message ReminderAckResponseProto {
+  ReminderEntityProto entity = 1;
+  string key = 2;
+  int64 due_time_utc_ticks = 3;
+  ReminderAckResponseCodeProto response_code = 4;
+  optional string message = 5;
+}
+
+message ScheduleReminderProto {
+  ReminderEntityProto entity = 1;
+  string key = 2;
+  int64 when_utc_ticks = 3;
+  SerializedPayloadProto message = 4;
+  optional int64 repeat_interval_ticks = 5;
+  optional int64 max_delivery_window_ticks = 6;
+}
+
+enum ReminderScheduleResponseCodeProto {
+  REMINDER_SCHEDULE_RESPONSE_UNSPECIFIED = 0;
+  REMINDER_SCHEDULE_RESPONSE_SUCCESS = 1;
+  REMINDER_SCHEDULE_RESPONSE_SHARD_REGION_NOT_FOUND = 2;
+  REMINDER_SCHEDULE_RESPONSE_ERROR = 3;
+}
+
+message ReminderScheduledProto {
+  ScheduleReminderProto original_command = 1;
+  ReminderScheduleResponseCodeProto response_code = 2;
+  optional string message = 3;
+}
+
+message ScheduledReminderProto {
+  ReminderEntityProto entity = 1;
+  string key = 2;
+  int64 when_utc_ticks = 3;
+  SerializedPayloadProto message = 4;
+  optional int64 repeat_interval_ticks = 5;
+  int32 attempt_count = 6;
+  optional string last_failure_reason = 7;
+  optional int64 max_delivery_window_ticks = 8;
+  optional int64 delivery_deadline_utc_ticks = 9;
+  optional int64 occurrence_due_time_utc_ticks = 10;
+}
+
+enum FetchRemindersResponseCodeProto {
+  FETCH_REMINDERS_RESPONSE_UNSPECIFIED = 0;
+  FETCH_REMINDERS_RESPONSE_SUCCESS = 1;
+  FETCH_REMINDERS_RESPONSE_ERROR = 2;
+  FETCH_REMINDERS_RESPONSE_NOT_FOUND = 3;
+}
+
+message RemindersForEntityProto {
+  ReminderEntityProto entity = 1;
+  FetchRemindersResponseCodeProto response_code = 2;
+  repeated ScheduledReminderProto reminders = 3;
+  optional string message = 4;
+}

--- a/src/Akka.Reminders/Serialization/ProtobufReminderSerializer.cs
+++ b/src/Akka.Reminders/Serialization/ProtobufReminderSerializer.cs
@@ -1,0 +1,333 @@
+using Akka.Actor;
+using Akka.Reminders.Serialization.Proto;
+using Akka.Serialization;
+using Google.Protobuf;
+
+namespace Akka.Reminders.Serialization;
+
+/// <summary>
+/// Serializes reminder protocol messages with Protocol Buffers.
+/// </summary>
+/// <remarks>
+/// The serializer delegates each user payload to the serializer that the actor system selects.
+/// Serializer ID 22551 identifies this format. Serializer ID 22550 remains the legacy format.
+/// </remarks>
+public sealed class ProtobufReminderSerializer : SerializerWithStringManifest
+{
+    private const string ReminderEnvelopeManifest = "re";
+    private const string ReminderAckManifest = "ra";
+    private const string ReminderAckResponseManifest = "rar";
+    private const string ScheduleReminderManifest = "sr";
+    private const string ReminderScheduledManifest = "rsd";
+    private const string RemindersForEntityManifest = "rfe";
+
+    private static readonly Type ReminderEnvelopeOpenGenericType = typeof(ReminderEnvelope<>);
+
+    private readonly ExtendedActorSystem _system;
+    private Akka.Serialization.Serialization? _serialization;
+
+    /// <summary>
+    /// Creates a Protobuf reminder serializer for the actor system.
+    /// </summary>
+    public ProtobufReminderSerializer(ExtendedActorSystem system) : base(system)
+    {
+        _system = system;
+    }
+
+    private Akka.Serialization.Serialization SerializationSystem => _serialization ??= _system.Serialization;
+
+    /// <inheritdoc />
+    public override int Identifier => 22551;
+
+    /// <inheritdoc />
+    public override string Manifest(object o) => o switch
+    {
+        ReminderEnvelope => ReminderEnvelopeManifest,
+        ReminderProtocol.ReminderAck => ReminderAckManifest,
+        ReminderProtocol.ReminderAckResponse => ReminderAckResponseManifest,
+        ReminderProtocol.ScheduleReminder => ScheduleReminderManifest,
+        ReminderProtocol.ReminderScheduled => ReminderScheduledManifest,
+        ReminderProtocol.RemindersForEntity => RemindersForEntityManifest,
+        _ => throw UnsupportedType(o)
+    };
+
+    /// <inheritdoc />
+    public override byte[] ToBinary(object obj) => obj switch
+    {
+        ReminderEnvelope envelope => Serialize(envelope).ToByteArray(),
+        ReminderProtocol.ReminderAck ack => Serialize(ack).ToByteArray(),
+        ReminderProtocol.ReminderAckResponse response => Serialize(response).ToByteArray(),
+        ReminderProtocol.ScheduleReminder command => Serialize(command).ToByteArray(),
+        ReminderProtocol.ReminderScheduled response => Serialize(response).ToByteArray(),
+        ReminderProtocol.RemindersForEntity response => Serialize(response).ToByteArray(),
+        _ => throw UnsupportedType(obj)
+    };
+
+    /// <inheritdoc />
+    public override object FromBinary(byte[] bytes, string manifest) => manifest switch
+    {
+        ReminderEnvelopeManifest => Deserialize(ReminderEnvelopeProto.Parser.ParseFrom(bytes)),
+        ReminderAckManifest => Deserialize(ReminderAckProto.Parser.ParseFrom(bytes)),
+        ReminderAckResponseManifest => Deserialize(ReminderAckResponseProto.Parser.ParseFrom(bytes)),
+        ScheduleReminderManifest => Deserialize(ScheduleReminderProto.Parser.ParseFrom(bytes)),
+        ReminderScheduledManifest => Deserialize(ReminderScheduledProto.Parser.ParseFrom(bytes)),
+        RemindersForEntityManifest => Deserialize(RemindersForEntityProto.Parser.ParseFrom(bytes)),
+        _ => throw new ArgumentException(
+            $"{nameof(ProtobufReminderSerializer)} does not recognize manifest [{manifest}]",
+            nameof(manifest))
+    };
+
+    private ReminderEnvelopeProto Serialize(ReminderEnvelope envelope) => new()
+    {
+        Entity = Serialize(envelope.Entity),
+        Key = envelope.Key.Name,
+        DueTimeUtcTicks = envelope.DueTimeUtc.UtcTicks,
+        DeadlineUtcTicks = envelope.Deadline.UtcDateTime.UtcTicks,
+        Message = SerializePayload(envelope.Message)
+    };
+
+    private ReminderEnvelope Deserialize(ReminderEnvelopeProto envelope)
+    {
+        var message = DeserializePayload(envelope.Message);
+        var envelopeType = ReminderEnvelopeOpenGenericType.MakeGenericType(message.GetType());
+        var result = Activator.CreateInstance(
+            envelopeType,
+            Deserialize(envelope.Entity),
+            new ReminderKey(envelope.Key),
+            FromUtcTicks(envelope.DueTimeUtcTicks),
+            new ReminderDeadline(FromUtcTicks(envelope.DeadlineUtcTicks)),
+            message);
+
+        return (ReminderEnvelope)(result ?? throw new InvalidOperationException(
+            $"Failed to create {envelopeType.FullName}."));
+    }
+
+    private static ReminderAckProto Serialize(ReminderProtocol.ReminderAck ack) => new()
+    {
+        Entity = Serialize(ack.Entity),
+        Key = ack.Key.Name,
+        DueTimeUtcTicks = ack.DueTimeUtc.UtcTicks
+    };
+
+    private static ReminderProtocol.ReminderAck Deserialize(ReminderAckProto ack) => new(
+        Deserialize(ack.Entity),
+        new ReminderKey(ack.Key),
+        FromUtcTicks(ack.DueTimeUtcTicks));
+
+    private static ReminderAckResponseProto Serialize(ReminderProtocol.ReminderAckResponse response)
+    {
+        var result = new ReminderAckResponseProto
+        {
+            Entity = Serialize(response.Entity),
+            Key = response.Key.Name,
+            DueTimeUtcTicks = response.DueTimeUtc.UtcTicks,
+            ResponseCode = Serialize(response.ResponseCode)
+        };
+
+        if (response.Message is not null)
+            result.Message = response.Message;
+
+        return result;
+    }
+
+    private static ReminderProtocol.ReminderAckResponse Deserialize(ReminderAckResponseProto response) => new(
+        Deserialize(response.Entity),
+        new ReminderKey(response.Key),
+        FromUtcTicks(response.DueTimeUtcTicks),
+        Deserialize(response.ResponseCode),
+        response.HasMessage ? response.Message : null);
+
+    private ScheduleReminderProto Serialize(ReminderProtocol.ScheduleReminder command)
+    {
+        var result = new ScheduleReminderProto
+        {
+            Entity = Serialize(command.Entity),
+            Key = command.Key.Name,
+            WhenUtcTicks = command.When.UtcTicks,
+            Message = SerializePayload(command.Message)
+        };
+
+        if (command.RepeatInterval is { } repeatInterval)
+            result.RepeatIntervalTicks = repeatInterval.Ticks;
+
+        if (command.MaxDeliveryWindow is { } maxDeliveryWindow)
+            result.MaxDeliveryWindowTicks = maxDeliveryWindow.Ticks;
+
+        return result;
+    }
+
+    private ReminderProtocol.ScheduleReminder Deserialize(ScheduleReminderProto command) => new(
+        Deserialize(command.Entity),
+        new ReminderKey(command.Key),
+        FromUtcTicks(command.WhenUtcTicks),
+        DeserializePayload(command.Message),
+        command.HasRepeatIntervalTicks ? TimeSpan.FromTicks(command.RepeatIntervalTicks) : null,
+        command.HasMaxDeliveryWindowTicks ? TimeSpan.FromTicks(command.MaxDeliveryWindowTicks) : null);
+
+    private ReminderScheduledProto Serialize(ReminderProtocol.ReminderScheduled response)
+    {
+        var result = new ReminderScheduledProto
+        {
+            OriginalCommand = Serialize(response.OriginalCommand),
+            ResponseCode = Serialize(response.ResponseCode)
+        };
+
+        if (response.Message is not null)
+            result.Message = response.Message;
+
+        return result;
+    }
+
+    private ReminderProtocol.ReminderScheduled Deserialize(ReminderScheduledProto response) => new(
+        Deserialize(response.OriginalCommand),
+        Deserialize(response.ResponseCode),
+        response.HasMessage ? response.Message : null);
+
+    private RemindersForEntityProto Serialize(ReminderProtocol.RemindersForEntity response)
+    {
+        var result = new RemindersForEntityProto
+        {
+            Entity = Serialize(response.Entity),
+            ResponseCode = Serialize(response.ResponseCode)
+        };
+
+        result.Reminders.Add(response.Reminders.Select(Serialize));
+
+        if (response.Message is not null)
+            result.Message = response.Message;
+
+        return result;
+    }
+
+    private ReminderProtocol.RemindersForEntity Deserialize(RemindersForEntityProto response) => new(
+        Deserialize(response.Entity),
+        Deserialize(response.ResponseCode),
+        response.Reminders.Select(Deserialize).ToArray(),
+        response.HasMessage ? response.Message : null);
+
+    private ScheduledReminderProto Serialize(ScheduledReminder reminder)
+    {
+        var result = new ScheduledReminderProto
+        {
+            Entity = Serialize(reminder.Entity),
+            Key = reminder.Key.Name,
+            WhenUtcTicks = reminder.When.UtcTicks,
+            Message = SerializePayload(reminder.Message),
+            AttemptCount = reminder.AttemptCount
+        };
+
+        if (reminder.RepeatInterval is { } repeatInterval)
+            result.RepeatIntervalTicks = repeatInterval.Ticks;
+
+        if (reminder.LastFailureReason is not null)
+            result.LastFailureReason = reminder.LastFailureReason;
+
+        if (reminder.MaxDeliveryWindow is { } maxDeliveryWindow)
+            result.MaxDeliveryWindowTicks = maxDeliveryWindow.Ticks;
+
+        if (reminder.DeliveryDeadlineUtc is { } deliveryDeadline)
+            result.DeliveryDeadlineUtcTicks = deliveryDeadline.UtcTicks;
+
+        if (reminder.OccurrenceDueTimeUtc is { } occurrenceDueTime)
+            result.OccurrenceDueTimeUtcTicks = occurrenceDueTime.UtcTicks;
+
+        return result;
+    }
+
+    private ScheduledReminder Deserialize(ScheduledReminderProto reminder) => new(
+        Deserialize(reminder.Entity),
+        new ReminderKey(reminder.Key),
+        FromUtcTicks(reminder.WhenUtcTicks),
+        DeserializePayload(reminder.Message),
+        reminder.HasRepeatIntervalTicks ? TimeSpan.FromTicks(reminder.RepeatIntervalTicks) : null,
+        reminder.AttemptCount,
+        reminder.HasLastFailureReason ? reminder.LastFailureReason : null,
+        reminder.HasMaxDeliveryWindowTicks ? TimeSpan.FromTicks(reminder.MaxDeliveryWindowTicks) : null,
+        reminder.HasDeliveryDeadlineUtcTicks ? FromUtcTicks(reminder.DeliveryDeadlineUtcTicks) : null,
+        reminder.HasOccurrenceDueTimeUtcTicks ? FromUtcTicks(reminder.OccurrenceDueTimeUtcTicks) : null);
+
+    private SerializedPayloadProto SerializePayload(object message)
+    {
+        var serializer = SerializationSystem.FindSerializerFor(message);
+        return new SerializedPayloadProto
+        {
+            SerializerId = serializer.Identifier,
+            Manifest = Akka.Serialization.Serialization.ManifestFor(serializer, message),
+            Payload = ByteString.CopyFrom(serializer.ToBinary(message))
+        };
+    }
+
+    private object DeserializePayload(SerializedPayloadProto payload) => SerializationSystem.Deserialize(
+        payload.Payload.ToByteArray(),
+        payload.SerializerId,
+        payload.Manifest);
+
+    private static ReminderEntityProto Serialize(ReminderEntity entity) => new()
+    {
+        ShardRegionName = entity.ShardRegionName,
+        EntityId = entity.EntityId
+    };
+
+    private static ReminderEntity Deserialize(ReminderEntityProto entity) => new(
+        entity.ShardRegionName,
+        entity.EntityId);
+
+    private static DateTimeOffset FromUtcTicks(long ticks) => new(ticks, TimeSpan.Zero);
+
+    private static ReminderAckResponseCodeProto Serialize(ReminderAckResponseCode code) => code switch
+    {
+        ReminderAckResponseCode.Success => ReminderAckResponseCodeProto.ReminderAckResponseSuccess,
+        ReminderAckResponseCode.NotFound => ReminderAckResponseCodeProto.ReminderAckResponseNotFound,
+        ReminderAckResponseCode.Error => ReminderAckResponseCodeProto.ReminderAckResponseError,
+        _ => throw UnknownEnumValue(code)
+    };
+
+    private static ReminderAckResponseCode Deserialize(ReminderAckResponseCodeProto code) => code switch
+    {
+        ReminderAckResponseCodeProto.ReminderAckResponseSuccess => ReminderAckResponseCode.Success,
+        ReminderAckResponseCodeProto.ReminderAckResponseNotFound => ReminderAckResponseCode.NotFound,
+        ReminderAckResponseCodeProto.ReminderAckResponseError => ReminderAckResponseCode.Error,
+        _ => throw UnknownEnumValue(code)
+    };
+
+    private static ReminderScheduleResponseCodeProto Serialize(ReminderScheduleResponseCode code) => code switch
+    {
+        ReminderScheduleResponseCode.Success => ReminderScheduleResponseCodeProto.ReminderScheduleResponseSuccess,
+        ReminderScheduleResponseCode.ShardRegionNotFound =>
+            ReminderScheduleResponseCodeProto.ReminderScheduleResponseShardRegionNotFound,
+        ReminderScheduleResponseCode.Error => ReminderScheduleResponseCodeProto.ReminderScheduleResponseError,
+        _ => throw UnknownEnumValue(code)
+    };
+
+    private static ReminderScheduleResponseCode Deserialize(ReminderScheduleResponseCodeProto code) => code switch
+    {
+        ReminderScheduleResponseCodeProto.ReminderScheduleResponseSuccess => ReminderScheduleResponseCode.Success,
+        ReminderScheduleResponseCodeProto.ReminderScheduleResponseShardRegionNotFound =>
+            ReminderScheduleResponseCode.ShardRegionNotFound,
+        ReminderScheduleResponseCodeProto.ReminderScheduleResponseError => ReminderScheduleResponseCode.Error,
+        _ => throw UnknownEnumValue(code)
+    };
+
+    private static FetchRemindersResponseCodeProto Serialize(FetchRemindersResponseCode code) => code switch
+    {
+        FetchRemindersResponseCode.Success => FetchRemindersResponseCodeProto.FetchRemindersResponseSuccess,
+        FetchRemindersResponseCode.Error => FetchRemindersResponseCodeProto.FetchRemindersResponseError,
+        FetchRemindersResponseCode.NotFound => FetchRemindersResponseCodeProto.FetchRemindersResponseNotFound,
+        _ => throw UnknownEnumValue(code)
+    };
+
+    private static FetchRemindersResponseCode Deserialize(FetchRemindersResponseCodeProto code) => code switch
+    {
+        FetchRemindersResponseCodeProto.FetchRemindersResponseSuccess => FetchRemindersResponseCode.Success,
+        FetchRemindersResponseCodeProto.FetchRemindersResponseError => FetchRemindersResponseCode.Error,
+        FetchRemindersResponseCodeProto.FetchRemindersResponseNotFound => FetchRemindersResponseCode.NotFound,
+        _ => throw UnknownEnumValue(code)
+    };
+
+    private static InvalidDataException UnknownEnumValue<T>(T value) where T : struct, Enum =>
+        new($"Unknown {typeof(T).Name} value [{value}].");
+
+    private static ArgumentException UnsupportedType(object value) => new(
+        $"{nameof(ProtobufReminderSerializer)} does not support serializing [{value.GetType().FullName}]",
+        nameof(value));
+}

--- a/src/Akka.Reminders/Serialization/ReminderSerializer.cs
+++ b/src/Akka.Reminders/Serialization/ReminderSerializer.cs
@@ -5,11 +5,14 @@ using Akka.Serialization;
 namespace Akka.Reminders.Serialization;
 
 /// <summary>
-/// Custom Akka serializer for all <see cref="IReminderWireMessage"/> types. Handles cross-node
-/// serialization for Akka.Remote and Akka.Cluster deployments. Registered via
-/// <c>WithCustomSerializer</c> in <see cref="AkkaHostingExtensions"/>.
+/// Reads and writes the legacy reminder wire format.
 /// </summary>
 /// <remarks>
+/// <para>
+/// Serializer ID 22550 and its manifests are permanent compatibility contracts.
+/// Do not add new protocol messages to this format. Use <see cref="ProtobufReminderSerializer"/>.
+/// </para>
+///
 /// <para>
 /// Uses a hand-rolled binary format via <see cref="BinaryWriter"/>/<see cref="BinaryReader"/>.
 /// Strings are length-prefixed UTF-8 (BinaryWriter's default string encoding). Timestamps are


### PR DESCRIPTION
## Summary

- Keep serializer ID `22550` as the permanent legacy reader.
- Add serializer ID `22551` for Protocol Buffers.
- Keep legacy writes as the default during the compatibility phase.
- Add `WithProtobufSerializer()` as the write-binding opt-in.
- Log a startup warning while legacy writes remain active.
- Keep generated Protobuf contracts internal.
- Document the rollout, metadata rewrite, and rollback rules.

This PR is the precursor for #135. The delivery-control PR will rebase onto this contract after merge.

## Upgrade order

1. Upgrade every cluster node while legacy writes remain active.
2. Enable `WithProtobufSerializer()` on every node.
3. Do not roll back to a release that lacks serializer ID `22551`.

An existing durable payload keeps serializer ID `22550` until an upsert rewrites it. The upsert replaces the serializer ID, manifest, and payload.

## Validation

- `dotnet build Akka.Reminders.slnx --no-restore`
- 33 focused serialization, binding, warning, and upgrade tests passed.
- A two-host SQLite test loads a released `0.6.0` golden payload after restart.
- The same test proves that an update changes serializer ID `22550` to `22551`.
- Six golden fixtures protect all released legacy manifests.
- `dotnet pack` passed.
- Slopwatch reported only three existing scheduler warnings.
- Two independent adversarial reviews found no remaining issues.

The full container-backed test project exceeded the local 180-second limit. The focused affected suite passed.
