### PR TITLE
chore: upgrade Akka.NET to 1.5.70 (xunit v3 migration)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <!-- Akka.Hosting packages (github.com/akkadotnet/Akka.Hosting) -->
-    <AkkaHostingVersion>1.5.62</AkkaHostingVersion>
+    <AkkaHostingVersion>1.5.70</AkkaHostingVersion>
   </PropertyGroup>
   <!-- Akka.Hosting packages - brings in core Akka transitively -->
   <ItemGroup>
@@ -16,10 +16,12 @@
   <ItemGroup>
     <PackageVersion Include="Akka.Hosting.TestKit" Version="$(AkkaHostingVersion)" />
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />
+    <PackageVersion Include="FluentAssertions" Version="8.10.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
   <!-- Benchmark dependencies -->

--- a/src/Akka.Reminders.Tests/Akka.Reminders.Tests.csproj
+++ b/src/Akka.Reminders.Tests/Akka.Reminders.Tests.csproj
@@ -12,10 +12,11 @@
     <PackageReference Include="Akka.Cluster.Hosting" />
     <PackageReference Include="Akka.Hosting.TestKit" />
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Testcontainers.MsSql" />
     <PackageReference Include="Testcontainers.PostgreSql" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/src/Akka.Reminders.Tests/LocalReminderSpecs.cs
+++ b/src/Akka.Reminders.Tests/LocalReminderSpecs.cs
@@ -3,7 +3,6 @@ using Akka.Hosting;
 using Akka.Reminders.Sharding;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Reminders.Tests;
 
@@ -62,11 +61,11 @@ public class LocalReminderSpecs : Akka.Hosting.TestKit.TestKit
         var when = DateTimeOffset.UtcNow.AddMilliseconds(200);
 
         // Act - schedule a reminder
-        var scheduleResult = await client.ScheduleSingleReminderAsync(key, when, message);
+        var scheduleResult = await client.ScheduleSingleReminderAsync(key, when, message, ct: TestContext.Current.CancellationToken);
         scheduleResult.ResponseCode.Should().Be(ReminderScheduleResponseCode.Success);
 
         // Assert - the reminder should be delivered as a ReminderEnvelope
-        var envelope = await targetActor.ExpectMsgAsync<ReminderEnvelope<TestMessage>>(TimeSpan.FromSeconds(2));
+        var envelope = await targetActor.ExpectMsgAsync<ReminderEnvelope<TestMessage>>(TimeSpan.FromSeconds(2), cancellationToken: TestContext.Current.CancellationToken);
         envelope.Message.Content.Should().Be("Payment Retry");
 
         Output?.WriteLine($"Reminder delivered successfully to {targetActor.Ref.Path}");
@@ -90,18 +89,18 @@ public class LocalReminderSpecs : Akka.Hosting.TestKit.TestKit
         await billingClient.ScheduleSingleReminderAsync(
             new ReminderKey("billing-reminder"),
             DateTimeOffset.UtcNow.AddMilliseconds(100),
-            new TestMessage("Bill Customer"));
+            new TestMessage("Bill Customer"), ct: TestContext.Current.CancellationToken);
 
         await notificationClient.ScheduleSingleReminderAsync(
             new ReminderKey("notification-reminder"),
             DateTimeOffset.UtcNow.AddMilliseconds(100),
-            new TestMessage("Send Notification"));
+            new TestMessage("Send Notification"), ct: TestContext.Current.CancellationToken);
 
         // Assert - each reminder should be delivered as a ReminderEnvelope to its respective shard region
-        var billingEnvelope = await billingActor.ExpectMsgAsync<ReminderEnvelope<TestMessage>>(TimeSpan.FromSeconds(2));
+        var billingEnvelope = await billingActor.ExpectMsgAsync<ReminderEnvelope<TestMessage>>(TimeSpan.FromSeconds(2), cancellationToken: TestContext.Current.CancellationToken);
         billingEnvelope.Message.Content.Should().Be("Bill Customer");
 
-        var notificationEnvelope = await notificationActor.ExpectMsgAsync<ReminderEnvelope<TestMessage>>(TimeSpan.FromSeconds(2));
+        var notificationEnvelope = await notificationActor.ExpectMsgAsync<ReminderEnvelope<TestMessage>>(TimeSpan.FromSeconds(2), cancellationToken: TestContext.Current.CancellationToken);
         notificationEnvelope.Message.Content.Should().Be("Send Notification");
     }
 

--- a/src/Akka.Reminders.Tests/NonHostRoleClusterSpecs.cs
+++ b/src/Akka.Reminders.Tests/NonHostRoleClusterSpecs.cs
@@ -6,7 +6,6 @@ using Akka.Hosting.TestKit;
 using Akka.Reminders.Sharding;
 using Akka.Reminders.Storage;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Akka.Reminders.Tests;
 
@@ -90,7 +89,7 @@ public class NonHostRoleClusterSpecs : Akka.Hosting.TestKit.TestKit
         // Assert - The actor should not exist (will throw or return ActorNotFound)
         var probe = CreateTestProbe();
         selection.Tell(new Identify("test"), probe);
-        var identity = probe.ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(3));
+        var identity = probe.ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
 
         // ActorRef should be null since the singleton manager wasn't created
         identity.Subject.Should().BeNull("the singleton manager should not be created on non-host nodes");
@@ -119,7 +118,7 @@ public class NonHostRoleClusterSpecs : Akka.Hosting.TestKit.TestKit
 
         // Act
         selection.Tell(new Identify("test"), probe);
-        var identity = probe.ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(3));
+        var identity = probe.ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         identity.Subject.Should().NotBeNull("the proxy actor should exist on non-host nodes");

--- a/src/Akka.Reminders.Tests/ReminderClientExtensionSpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderClientExtensionSpecs.cs
@@ -4,7 +4,6 @@ using Akka.Hosting;
 using Akka.Reminders.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Xunit.Abstractions;
 
 namespace Akka.Reminders.Tests;
 

--- a/src/Akka.Reminders.Tests/ReminderClientSpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderClientSpecs.cs
@@ -3,7 +3,6 @@ using Akka.Hosting;
 using Akka.Hosting.TestKit;
 using Akka.Reminders.Sharding;
 using Akka.Reminders.Storage;
-using Xunit.Abstractions;
 
 namespace Akka.Reminders.Tests;
 
@@ -136,7 +135,7 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
         var result = await client.ScheduleSingleReminderAsync(
             new ReminderKey("test-reminder"),
             DateTimeOffset.UtcNow.AddMilliseconds(100),
-            "test message");
+            "test message", ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
@@ -154,7 +153,7 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
         var result = await client.ScheduleSingleReminderAsync(
             new ReminderKey("test-reminder"),
             DateTimeOffset.UtcNow.AddMilliseconds(100),
-            "test message");
+            "test message", ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(ReminderScheduleResponseCode.ShardRegionNotFound, result.ResponseCode);
@@ -176,20 +175,20 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
         var result1 = await client.ScheduleSingleReminderAsync(
             key,
             DateTimeOffset.UtcNow.AddHours(1),
-            "message 1");
+            "message 1", ct: TestContext.Current.CancellationToken);
 
         // Act - Schedule second reminder with same key
         var result2 = await client.ScheduleSingleReminderAsync(
             key,
             DateTimeOffset.UtcNow.AddHours(2),
-            "message 2");
+            "message 2", ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(ReminderScheduleResponseCode.Success, result1.ResponseCode);
         Assert.Equal(ReminderScheduleResponseCode.Success, result2.ResponseCode);
 
         // Verify only one reminder exists
-        var list = await client.ListRemindersAsync();
+        var list = await client.ListRemindersAsync(TestContext.Current.CancellationToken);
         Assert.Single(list.Reminders);
         Assert.Equal("message 2", list.Reminders[0].Message);
     }
@@ -214,13 +213,13 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
             new ReminderKey("recurring-reminder"),
             DateTimeOffset.UtcNow.AddMilliseconds(100),
             TimeSpan.FromMinutes(5),
-            "recurring message");
+            "recurring message", ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
 
         // Verify the reminder was stored with repeat interval
-        var list = await client.ListRemindersAsync();
+        var list = await client.ListRemindersAsync(TestContext.Current.CancellationToken);
         Assert.Single(list.Reminders);
         Assert.Equal(TimeSpan.FromMinutes(5), list.Reminders[0].RepeatInterval);
     }
@@ -241,11 +240,11 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
             new ReminderKey("deadline-reminder"),
             when,
             "deadline message",
-            maxDeliveryWindow: window);
+            maxDeliveryWindow: window, TestContext.Current.CancellationToken);
 
         Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
 
-        var list = await client.ListRemindersAsync();
+        var list = await client.ListRemindersAsync(TestContext.Current.CancellationToken);
         Assert.Single(list.Reminders);
         Assert.Equal(window, list.Reminders[0].MaxDeliveryWindow);
         Assert.True(list.Reminders[0].DeliveryDeadlineUtc.HasValue);
@@ -267,17 +266,17 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
         var key = new ReminderKey("test-reminder");
         await EnsureReminderSchedulerReady(client);
 
-        await client.ScheduleSingleReminderAsync(key, DateTimeOffset.UtcNow.AddHours(1), "test message");
+        await client.ScheduleSingleReminderAsync(key, DateTimeOffset.UtcNow.AddHours(1), "test message", ct: TestContext.Current.CancellationToken);
 
         // Act
-        var result = await client.CancelReminderAsync(key);
+        var result = await client.CancelReminderAsync(key, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(ReminderCancelResponseCode.Success, result.ResponseCode);
         Assert.Contains(key, result.Keys);
 
         // Verify reminder was removed
-        var list = await client.ListRemindersAsync();
+        var list = await client.ListRemindersAsync(TestContext.Current.CancellationToken);
         Assert.Empty(list.Reminders);
     }
 
@@ -290,7 +289,7 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
         await EnsureReminderSchedulerReady(client);
 
         // Act
-        var result = await client.CancelReminderAsync(new ReminderKey("nonexistent"));
+        var result = await client.CancelReminderAsync(new ReminderKey("nonexistent"), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(ReminderCancelResponseCode.NotFound, result.ResponseCode);
@@ -307,18 +306,18 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
         var client = extension.CreateClient("test-region", "entity-1");
         await EnsureReminderSchedulerReady(client);
 
-        await client.ScheduleSingleReminderAsync(new ReminderKey("r1"), DateTimeOffset.UtcNow.AddHours(1), "m1");
-        await client.ScheduleSingleReminderAsync(new ReminderKey("r2"), DateTimeOffset.UtcNow.AddHours(2), "m2");
+        await client.ScheduleSingleReminderAsync(new ReminderKey("r1"), DateTimeOffset.UtcNow.AddHours(1), "m1", ct: TestContext.Current.CancellationToken);
+        await client.ScheduleSingleReminderAsync(new ReminderKey("r2"), DateTimeOffset.UtcNow.AddHours(2), "m2", ct: TestContext.Current.CancellationToken);
 
         // Act
-        var result = await client.CancelAllRemindersAsync();
+        var result = await client.CancelAllRemindersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(ReminderCancelResponseCode.Success, result.ResponseCode);
         Assert.Equal(2, result.Keys.Count);
 
         // Verify all reminders were removed
-        var list = await client.ListRemindersAsync();
+        var list = await client.ListRemindersAsync(TestContext.Current.CancellationToken);
         Assert.Empty(list.Reminders);
     }
 
@@ -335,7 +334,7 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
         await EnsureReminderSchedulerReady(client);
 
         // Act
-        var result = await client.ListRemindersAsync();
+        var result = await client.ListRemindersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(FetchRemindersResponseCode.Success, result.ResponseCode);
@@ -353,11 +352,11 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
         var client = extension.CreateClient("test-region", "entity-1");
         await EnsureReminderSchedulerReady(client);
 
-        await client.ScheduleSingleReminderAsync(new ReminderKey("r1"), DateTimeOffset.UtcNow.AddHours(1), "m1");
-        await client.ScheduleSingleReminderAsync(new ReminderKey("r2"), DateTimeOffset.UtcNow.AddHours(2), "m2");
+        await client.ScheduleSingleReminderAsync(new ReminderKey("r1"), DateTimeOffset.UtcNow.AddHours(1), "m1", ct: TestContext.Current.CancellationToken);
+        await client.ScheduleSingleReminderAsync(new ReminderKey("r2"), DateTimeOffset.UtcNow.AddHours(2), "m2", ct: TestContext.Current.CancellationToken);
 
         // Act
-        var result = await client.ListRemindersAsync();
+        var result = await client.ListRemindersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(FetchRemindersResponseCode.Success, result.ResponseCode);
@@ -376,12 +375,12 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
         var client2 = extension.CreateClient("test-region", "entity-2");
         await EnsureReminderSchedulerReady(client1);
 
-        await client1.ScheduleSingleReminderAsync(new ReminderKey("r1"), DateTimeOffset.UtcNow.AddHours(1), "m1");
-        await client2.ScheduleSingleReminderAsync(new ReminderKey("r2"), DateTimeOffset.UtcNow.AddHours(2), "m2");
+        await client1.ScheduleSingleReminderAsync(new ReminderKey("r1"), DateTimeOffset.UtcNow.AddHours(1), "m1", ct: TestContext.Current.CancellationToken);
+        await client2.ScheduleSingleReminderAsync(new ReminderKey("r2"), DateTimeOffset.UtcNow.AddHours(2), "m2", ct: TestContext.Current.CancellationToken);
 
         // Act
-        var result1 = await client1.ListRemindersAsync();
-        var result2 = await client2.ListRemindersAsync();
+        var result1 = await client1.ListRemindersAsync(TestContext.Current.CancellationToken);
+        var result2 = await client2.ListRemindersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result1.Reminders);

--- a/src/Akka.Reminders.Tests/ReminderClientSpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderClientSpecs.cs
@@ -131,7 +131,7 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
             ReminderDeadline.Infinite,
             "payload");
 
-        await Assert.ThrowsAsync<ArgumentException>(() => client.NackAsync(envelope, " "));
+        await Assert.ThrowsAsync<ArgumentException>(() => client.NackAsync(envelope, " ", ct: TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -145,8 +145,8 @@ public class ReminderClientSpecs : Akka.Hosting.TestKit.TestKit
             ReminderDeadline.Infinite,
             "payload");
 
-        await Assert.ThrowsAsync<ArgumentException>(() => client.AckAsync(envelope));
-        await Assert.ThrowsAsync<ArgumentException>(() => client.NackAsync(envelope, "failed"));
+        await Assert.ThrowsAsync<ArgumentException>(() => client.AckAsync(envelope, ct: TestContext.Current.CancellationToken));
+        await Assert.ThrowsAsync<ArgumentException>(() => client.NackAsync(envelope, "failed", ct: TestContext.Current.CancellationToken));
     }
 
     #endregion

--- a/src/Akka.Reminders.Tests/ReminderClusterIntegrationSpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderClusterIntegrationSpecs.cs
@@ -6,7 +6,6 @@ using Akka.Hosting;
 using Akka.Hosting.TestKit;
 using Akka.Reminders.Sharding;
 using Akka.Reminders.Storage;
-using Xunit.Abstractions;
 
 namespace Akka.Reminders.Tests;
 
@@ -85,7 +84,7 @@ public class ReminderClusterIntegrationSpecs : Akka.Hosting.TestKit.TestKit
         await EnsureReminderSchedulerReady(client);
 
         // Get the shard region to observe messages
-        var shardRegion = await Sys.ActorSelection($"/system/sharding/{ShardRegionName}").ResolveOne(TimeSpan.FromSeconds(5));
+        var shardRegion = await Sys.ActorSelection($"/system/sharding/{ShardRegionName}").ResolveOne(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         var probe = CreateTestProbe();
 
         // Subscribe to entity events
@@ -96,13 +95,13 @@ public class ReminderClusterIntegrationSpecs : Akka.Hosting.TestKit.TestKit
         var result = await client.ScheduleSingleReminderAsync(
             new ReminderKey("test-reminder"),
             DateTimeOffset.UtcNow.AddMilliseconds(100),
-            new EntityMessage("entity-1", "test message"));
+            new EntityMessage("entity-1", "test message"), ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
 
         // Wait for the reminder to be delivered
-        var received = probe.ExpectMsg<TestEntity.ReminderReceived>(TimeSpan.FromSeconds(10));
+        var received = probe.ExpectMsg<TestEntity.ReminderReceived>(TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("entity-1", received.EntityId);
         Assert.Equal("test message", received.Message);
     }
@@ -124,7 +123,7 @@ public class ReminderClusterIntegrationSpecs : Akka.Hosting.TestKit.TestKit
             new ReminderKey("recurring-reminder"),
             DateTimeOffset.UtcNow.AddMilliseconds(100),
             TimeSpan.FromMilliseconds(500),
-            new EntityMessage("entity-2", "recurring message"));
+            new EntityMessage("entity-2", "recurring message"), ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
@@ -132,20 +131,20 @@ public class ReminderClusterIntegrationSpecs : Akka.Hosting.TestKit.TestKit
         // Wait for multiple occurrences — first delivery traverses the full
         // cluster singleton → shard region → entity actor chain which has
         // higher latency on constrained CI runners.
-        var msg1 = probe.ExpectMsg<TestEntity.ReminderReceived>(TimeSpan.FromSeconds(10));
+        var msg1 = probe.ExpectMsg<TestEntity.ReminderReceived>(TimeSpan.FromSeconds(10), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("entity-2", msg1.EntityId);
         Assert.Equal("recurring message", msg1.Message);
 
-        var msg2 = probe.ExpectMsg<TestEntity.ReminderReceived>(TimeSpan.FromSeconds(5));
+        var msg2 = probe.ExpectMsg<TestEntity.ReminderReceived>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("entity-2", msg2.EntityId);
         Assert.Equal("recurring message", msg2.Message);
 
-        var msg3 = probe.ExpectMsg<TestEntity.ReminderReceived>(TimeSpan.FromSeconds(5));
+        var msg3 = probe.ExpectMsg<TestEntity.ReminderReceived>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("entity-2", msg3.EntityId);
         Assert.Equal("recurring message", msg3.Message);
 
         // Cancel the reminder to stop it
-        await client.CancelReminderAsync(new ReminderKey("recurring-reminder"));
+        await client.CancelReminderAsync(new ReminderKey("recurring-reminder"), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -165,17 +164,17 @@ public class ReminderClusterIntegrationSpecs : Akka.Hosting.TestKit.TestKit
         await client1.ScheduleSingleReminderAsync(
             new ReminderKey("reminder-1"),
             DateTimeOffset.UtcNow.AddMilliseconds(100),
-            new EntityMessage("entity-3", "message for entity-3"));
+            new EntityMessage("entity-3", "message for entity-3"), ct: TestContext.Current.CancellationToken);
 
         await client2.ScheduleSingleReminderAsync(
             new ReminderKey("reminder-2"),
             DateTimeOffset.UtcNow.AddMilliseconds(150),
-            new EntityMessage("entity-4", "message for entity-4"));
+            new EntityMessage("entity-4", "message for entity-4"), ct: TestContext.Current.CancellationToken);
 
         // Assert - Both entities should receive their messages
         var messages = new List<TestEntity.ReminderReceived>();
-        messages.Add(probe.ExpectMsg<TestEntity.ReminderReceived>(TimeSpan.FromSeconds(5)));
-        messages.Add(probe.ExpectMsg<TestEntity.ReminderReceived>(TimeSpan.FromSeconds(5)));
+        messages.Add(probe.ExpectMsg<TestEntity.ReminderReceived>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken));
+        messages.Add(probe.ExpectMsg<TestEntity.ReminderReceived>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken));
 
         // Verify both entities received their correct messages
         Assert.Contains(messages, m => m.EntityId == "entity-3" && m.Message == "message for entity-3");
@@ -200,15 +199,15 @@ public class ReminderClusterIntegrationSpecs : Akka.Hosting.TestKit.TestKit
         await client.ScheduleSingleReminderAsync(
             key,
             DateTimeOffset.UtcNow.AddSeconds(2),
-            new EntityMessage("entity-5", "should not be delivered"));
+            new EntityMessage("entity-5", "should not be delivered"), ct: TestContext.Current.CancellationToken);
 
-        var cancelResult = await client.CancelReminderAsync(key);
+        var cancelResult = await client.CancelReminderAsync(key, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(ReminderCancelResponseCode.Success, cancelResult.ResponseCode);
 
         // Wait longer than the reminder was scheduled for
-        probe.ExpectNoMsg(TimeSpan.FromSeconds(3));
+        probe.ExpectNoMsg(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
     }
 }
 

--- a/src/Akka.Reminders.Tests/ReminderSchedulerRecoverySpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderSchedulerRecoverySpecs.cs
@@ -4,7 +4,6 @@ using Akka.Hosting.TestKit;
 using Akka.Reminders.Sharding;
 using Akka.Reminders.Storage;
 using Akka.TestKit;
-using Xunit.Abstractions;
 
 namespace Akka.Reminders.Tests;
 
@@ -124,18 +123,18 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         // Advance past reminder-1's due time. The scheduler's fetch timer fires and
         // delivers reminder-1 to the test probe via the shard region resolver.
         testScheduler.Advance(TimeSpan.FromSeconds(11));
-        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("message 1", envelope1.Message);
 
         // Ack reminder-1 so it's marked Delivered and won't be re-fetched on the next tick.
         await AckAndWait(scheduler, envelope1);
 
         // Reminder-2 hasn't fired yet — its due time is T+20s, we're only at T+11s.
-        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
 
         // Advance to reminder-2's due time.
         testScheduler.Advance(TimeSpan.FromSeconds(10));
-        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("message 2", envelope2.Message);
     }
 
@@ -188,9 +187,9 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
 
         var messages = new List<string>();
-        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         messages.Add(envelope1.Message);
-        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         messages.Add(envelope2.Message);
 
         // Both overdue reminders should be delivered (order within a batch may vary).
@@ -229,7 +228,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 
         // First occurrence: advance past T+5s, receive delivery.
         testScheduler.Advance(TimeSpan.FromSeconds(6));
-        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("recurring message", envelope1.Message);
 
         // Ack the first delivery. The next occurrence (T+10s) was already persisted
@@ -238,14 +237,14 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 
         // Second occurrence: advance by another interval.
         testScheduler.Advance(TimeSpan.FromSeconds(5));
-        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("recurring message", envelope2.Message);
 
         await AckAndWait(scheduler, envelope2);
 
         // Third occurrence: confirms the cycle continues indefinitely.
         testScheduler.Advance(TimeSpan.FromSeconds(5));
-        var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("recurring message", envelope3.Message);
     }
 
@@ -288,7 +287,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         await WaitForSchedulerReady(firstScheduler);
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
 
-        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("timeout message", envelope.Message);
 
         // Stop the first scheduler without acking — the occurrence stays AwaitingAck in storage.
@@ -311,7 +310,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
             var reminders = await _storage.GetRemindersForEntityAsync(
                 reminder.Entity, take: 10, skip: 0, CancellationToken.None);
             Assert.Single(reminders, r => r.AttemptCount == 1);
-        }, TimeSpan.FromSeconds(5));
+        }, TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
 
         var finalReminders = await _storage.GetRemindersForEntityAsync(reminder.Entity, take: 10, skip: 0, CancellationToken.None);
         var retried = Assert.Single(finalReminders, r => r.AttemptCount == 1);
@@ -349,7 +348,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
             reminderTime,
             "future message"), testProbe.Ref);
 
-        var scheduleResponse = await testProbe.ExpectMsgAsync<ReminderProtocol.ReminderScheduled>(TimeSpan.FromSeconds(5));
+        var scheduleResponse = await testProbe.ExpectMsgAsync<ReminderProtocol.ReminderScheduled>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(ReminderScheduleResponseCode.Success, scheduleResponse.ResponseCode);
 
         // Crash: stop the scheduler while the reminder is still in the future.
@@ -365,7 +364,7 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
         // Advance past the reminder's due time. The recovered scheduler delivers it.
         testScheduler.Advance(TimeSpan.FromSeconds(16));
 
-        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("future message", envelope.Message);
     }
 
@@ -426,11 +425,11 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 
         // All three are overdue and fetched in a single batch.
         var messages = new List<string>();
-        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         messages.Add(envelope1.Message);
-        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         messages.Add(envelope2.Message);
-        var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         messages.Add(envelope3.Message);
 
         // All delivered — order within a batch may vary due to async processing.
@@ -482,18 +481,18 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
 
         // Overdue reminder fires immediately on the first tick.
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
-        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("overdue message", envelope1.Message);
 
         // Ack the overdue reminder so it doesn't interfere with the future one.
         await AckAndWait(scheduler, envelope1);
 
         // Future reminder hasn't fired yet — its due time is T+10s.
-        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
 
         // Advance to the future reminder's due time.
         testScheduler.Advance(TimeSpan.FromSeconds(10));
-        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("future message", envelope2.Message);
     }
 
@@ -520,11 +519,11 @@ public class ReminderSchedulerRecoverySpecs : Akka.Hosting.TestKit.TestKit
             testScheduler.Now.AddSeconds(5),
             "test message"), testProbe.Ref);
 
-        var response = await testProbe.ExpectMsgAsync<ReminderProtocol.ReminderScheduled>(TimeSpan.FromSeconds(5));
+        var response = await testProbe.ExpectMsgAsync<ReminderProtocol.ReminderScheduled>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(ReminderScheduleResponseCode.Success, response.ResponseCode);
 
         testScheduler.Advance(TimeSpan.FromSeconds(6));
-        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("test message", envelope.Message);
     }
 }

--- a/src/Akka.Reminders.Tests/ReminderSchedulerTimingSpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderSchedulerTimingSpecs.cs
@@ -5,7 +5,6 @@ using Akka.Hosting.TestKit;
 using Akka.Reminders.Sharding;
 using Akka.Reminders.Storage;
 using Akka.TestKit;
-using Xunit.Abstractions;
 
 namespace Akka.Reminders.Tests;
 
@@ -74,7 +73,7 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         var result = await client.ScheduleSingleReminderAsync(
             new ReminderKey("test-reminder"),
             reminderTime,
-            "test message");
+            "test message", ct: TestContext.Current.CancellationToken);
 
         Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
 
@@ -84,7 +83,7 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         Output?.WriteLine($"Advancing by 9 seconds...");
         testScheduler.Advance(TimeSpan.FromSeconds(9));
         Output?.WriteLine($"TestScheduler.Now after advance: {testScheduler.Now}");
-        testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+        testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
 
         // Advance time by 2 more seconds (11 total) - reminder SHOULD fire now
         Output?.WriteLine($"Advancing by 2 more seconds...");
@@ -92,7 +91,7 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         Output?.WriteLine($"TestScheduler.Now after second advance: {testScheduler.Now}");
 
         // Assert - Verify the reminder message was received
-        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("test message", envelope.Message);
     }
 
@@ -115,17 +114,17 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         await client.ScheduleSingleReminderAsync(
             new ReminderKey("reminder-3"),
             now.AddSeconds(30),
-            "third");
+            "third", ct: TestContext.Current.CancellationToken);
 
         await client.ScheduleSingleReminderAsync(
             new ReminderKey("reminder-1"),
             now.AddSeconds(10),
-            "first");
+            "first", ct: TestContext.Current.CancellationToken);
 
         await client.ScheduleSingleReminderAsync(
             new ReminderKey("reminder-2"),
             now.AddSeconds(20),
-            "second");
+            "second", ct: TestContext.Current.CancellationToken);
 
         Output?.WriteLine($"TestScheduler.Now after scheduling: {testScheduler.Now}");
 
@@ -133,28 +132,28 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         Output?.WriteLine($"Advancing by 11 seconds...");
         testScheduler.Advance(TimeSpan.FromSeconds(11));
         Output?.WriteLine($"TestScheduler.Now after first advance: {testScheduler.Now}");
-        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("first", envelope1.Message);
         Output?.WriteLine($"Received first message");
 
         // Ack to prevent "first" from being re-delivered on the next fetch
-        await client.AckAsync(envelope1);
+        await client.AckAsync(envelope1, TestContext.Current.CancellationToken);
 
         // Wait for processing to complete and next timer to be scheduled
-        await AwaitConditionAsync(() => Task.FromResult(true), TimeSpan.FromMilliseconds(100));
+        await AwaitConditionAsync(() => Task.FromResult(true), TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
 
         testScheduler.Advance(TimeSpan.FromSeconds(10));
-        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("second", envelope2.Message);
 
         // Ack to prevent "second" from being re-delivered on the next fetch
-        await client.AckAsync(envelope2);
+        await client.AckAsync(envelope2, TestContext.Current.CancellationToken);
 
         // Wait for processing to complete and next timer to be scheduled
-        await AwaitConditionAsync(() => Task.FromResult(true), TimeSpan.FromMilliseconds(100));
+        await AwaitConditionAsync(() => Task.FromResult(true), TimeSpan.FromMilliseconds(100), cancellationToken: TestContext.Current.CancellationToken);
 
         testScheduler.Advance(TimeSpan.FromSeconds(10));
-        var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("third", envelope3.Message);
     }
 
@@ -170,7 +169,7 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
 
         // Wait for scheduler to be initialized by sending a benign query
         // and verifying we get a proper response (not dead letter)
-        var initCheck = await client.ListRemindersAsync();
+        var initCheck = await client.ListRemindersAsync(TestContext.Current.CancellationToken);
         Assert.Equal(FetchRemindersResponseCode.Success, initCheck.ResponseCode);
 
         var testScheduler = (TestScheduler)Sys.Scheduler;
@@ -182,7 +181,7 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
             new ReminderKey("recurring-reminder"),
             now.AddSeconds(5),
             interval,
-            "recurring message");
+            "recurring message", ct: TestContext.Current.CancellationToken);
 
         Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
 
@@ -190,16 +189,16 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         Output?.WriteLine($"Before first advance - TestScheduler.Now: {testScheduler.Now}");
         testScheduler.Advance(TimeSpan.FromSeconds(6));
         Output?.WriteLine($"After first advance - TestScheduler.Now: {testScheduler.Now}");
-        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("recurring message", envelope1.Message);
         Output?.WriteLine($"Received first recurring message");
 
         // Ack the first delivery so the scheduler schedules the next occurrence
-        await client.AckAsync(envelope1);
+        await client.AckAsync(envelope1, TestContext.Current.CancellationToken);
 
         // Allow async processing to complete, then verify the next occurrence is scheduled
-        testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
-        var list1 = await client.ListRemindersAsync();
+        testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
+        var list1 = await client.ListRemindersAsync(TestContext.Current.CancellationToken);
         Assert.Single(list1.Reminders);
         Output?.WriteLine($"Next reminder scheduled for: {list1.Reminders[0].When}");
 
@@ -207,20 +206,20 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         Output?.WriteLine($"Before second advance - TestScheduler.Now: {testScheduler.Now}");
         testScheduler.Advance(interval);
         Output?.WriteLine($"After second advance - TestScheduler.Now: {testScheduler.Now}");
-        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("recurring message", envelope2.Message);
 
         // Ack the second delivery
-        await client.AckAsync(envelope2);
+        await client.AckAsync(envelope2, TestContext.Current.CancellationToken);
 
         // Allow async processing to complete
-        testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
-        var list2 = await client.ListRemindersAsync();
+        testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
+        var list2 = await client.ListRemindersAsync(TestContext.Current.CancellationToken);
         Assert.Single(list2.Reminders);
 
         // Verify third occurrence
         testScheduler.Advance(interval);
-        var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope3 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("recurring message", envelope3.Message);
     }
 
@@ -238,12 +237,12 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
             new ReminderKey("deadline-reminder"),
             dueTime,
             "deadline message",
-            maxDeliveryWindow: TimeSpan.FromSeconds(2));
+            maxDeliveryWindow: TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
 
         Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
 
         testScheduler.Advance(TimeSpan.FromSeconds(6));
-        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(dueTime, envelope.DueTimeUtc);
         Assert.False(envelope.Deadline.IsInfinite);
@@ -269,12 +268,12 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
             new ReminderKey("ack-deadline-reminder"),
             dueTime,
             "ack deadline message",
-            maxDeliveryWindow: TimeSpan.FromSeconds(60));
+            maxDeliveryWindow: TimeSpan.FromSeconds(60), TestContext.Current.CancellationToken);
 
         Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
 
         testScheduler.Advance(TimeSpan.FromSeconds(6));
-        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(dueTime, envelope.DueTimeUtc);
         Assert.False(envelope.Deadline.IsInfinite);
@@ -309,12 +308,12 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
             new ReminderKey("occurrence-deadline-reminder"),
             dueTime,
             "occurrence deadline message",
-            maxDeliveryWindow: TimeSpan.FromSeconds(2));
+            maxDeliveryWindow: TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
 
         Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
 
         testScheduler.Advance(TimeSpan.FromSeconds(6));
-        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(dueTime, envelope.DueTimeUtc);
         Assert.False(envelope.Deadline.IsInfinite);
@@ -340,12 +339,12 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         var result = await client.ScheduleSingleReminderAsync(
             new ReminderKey("unbounded-reminder"),
             dueTime,
-            "unbounded message");
+            "unbounded message", ct: TestContext.Current.CancellationToken);
 
         Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
 
         testScheduler.Advance(TimeSpan.FromSeconds(6));
-        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(dueTime, envelope.DueTimeUtc);
         // Unbounded with more retries: deadline should be ack timeout, not infinite
@@ -368,16 +367,16 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
             new ReminderKey("latest-only-recurring"),
             now.AddSeconds(5),
             interval,
-            "recurring message");
+            "recurring message", ct: TestContext.Current.CancellationToken);
 
         Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
 
         testScheduler.Advance(TimeSpan.FromSeconds(6));
-        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(now.AddSeconds(5), envelope1.DueTimeUtc);
 
-        testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
-        var reminders = await client.ListRemindersAsync();
+        testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
+        var reminders = await client.ListRemindersAsync(TestContext.Current.CancellationToken);
         Assert.Contains(reminders.Reminders, r => r.DueTimeUtc == now.AddSeconds(10));
     }
 
@@ -396,27 +395,27 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
             new ReminderKey("superseded-recurring"),
             now.AddSeconds(5),
             interval,
-            "recurring message");
+            "recurring message", ct: TestContext.Current.CancellationToken);
 
         Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
 
         testScheduler.Advance(TimeSpan.FromSeconds(6));
-        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope1 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
 
         // Let the scheduler finish persisting and timer-scheduling the superseding occurrence
         // before we advance virtual time again.
-        testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
-        var reminders = await client.ListRemindersAsync();
+        testProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
+        var reminders = await client.ListRemindersAsync(TestContext.Current.CancellationToken);
         Assert.Contains(reminders.Reminders, r => r.DueTimeUtc == now.AddSeconds(10));
 
         testScheduler.Advance(interval);
-        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope2 = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(now.AddSeconds(10), envelope2.DueTimeUtc);
 
-        var staleAck = await client.AckAsync(envelope1);
+        var staleAck = await client.AckAsync(envelope1, TestContext.Current.CancellationToken);
         Assert.Equal(ReminderAckResponseCode.NotFound, staleAck.ResponseCode);
 
-        var currentAck = await client.AckAsync(envelope2);
+        var currentAck = await client.AckAsync(envelope2, TestContext.Current.CancellationToken);
         Assert.Equal(ReminderAckResponseCode.Success, currentAck.ResponseCode);
     }
 
@@ -438,17 +437,17 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         await client.ScheduleSingleReminderAsync(
             key,
             now.AddSeconds(10),
-            "test message");
+            "test message", ct: TestContext.Current.CancellationToken);
 
         // Act - Cancel the reminder before it fires
-        var cancelResult = await client.CancelReminderAsync(key);
+        var cancelResult = await client.CancelReminderAsync(key, TestContext.Current.CancellationToken);
         Assert.Equal(ReminderCancelResponseCode.Success, cancelResult.ResponseCode);
 
         // Advance time past when reminder should have fired
         testScheduler.Advance(TimeSpan.FromSeconds(15));
 
         // Assert - Verify no message was received
-        testProbe.ExpectNoMsg(TimeSpan.FromSeconds(1));
+        testProbe.ExpectNoMsg(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -468,7 +467,7 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         var result = await client.ScheduleSingleReminderAsync(
             new ReminderKey("immediate-reminder"),
             now.AddMilliseconds(500), // Within 1 second slippage
-            "immediate message");
+            "immediate message", ct: TestContext.Current.CancellationToken);
 
         Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
 
@@ -478,7 +477,7 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         testScheduler.Advance(TimeSpan.FromSeconds(2));
 
         // Assert
-        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("immediate message", envelope.Message);
     }
 }

--- a/src/Akka.Reminders.Tests/ReminderSchedulerTimingSpecs.cs
+++ b/src/Akka.Reminders.Tests/ReminderSchedulerTimingSpecs.cs
@@ -431,33 +431,33 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         var dueTime = testScheduler.Now.AddSeconds(5);
         var key = new ReminderKey("nack-retry");
 
-        var scheduled = await client.ScheduleSingleReminderAsync(key, dueTime, "retry me");
+        var scheduled = await client.ScheduleSingleReminderAsync(key, dueTime, "retry me", ct: TestContext.Current.CancellationToken);
         Assert.Equal(ReminderScheduleResponseCode.Success, scheduled.ResponseCode);
 
         testScheduler.Advance(TimeSpan.FromSeconds(6));
-        var first = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
-        var firstNack = await client.NackAsync(first, "first failure");
+        var first = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        var firstNack = await client.NackAsync(first, "first failure", ct: TestContext.Current.CancellationToken);
         Assert.Equal(ReminderNackResponseCode.RetryScheduled, firstNack.ResponseCode);
         Assert.Equal(1, firstNack.AttemptCount);
 
-        var pending = await client.GetOccurrenceStatusAsync(first.Key, first.DueTimeUtc);
+        var pending = await client.GetOccurrenceStatusAsync(first.Key, first.DueTimeUtc, ct: TestContext.Current.CancellationToken);
         Assert.Equal(ReminderOccurrenceStatusResponseCode.Success, pending.ResponseCode);
         Assert.Equal(ReminderCompletionStatus.Pending, pending.Status?.CompletionStatus);
         Assert.Equal("first failure", pending.Status?.LastFailureReason);
 
         testScheduler.Advance(TimeSpan.FromSeconds(6));
-        var second = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
-        var secondNack = await client.NackAsync(second, "second failure");
+        var second = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        var secondNack = await client.NackAsync(second, "second failure", ct: TestContext.Current.CancellationToken);
         Assert.Equal(ReminderNackResponseCode.RetryScheduled, secondNack.ResponseCode);
         Assert.Equal(2, secondNack.AttemptCount);
 
         testScheduler.Advance(TimeSpan.FromSeconds(11));
-        var third = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
-        var thirdNack = await client.NackAsync(third, "final failure");
+        var third = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        var thirdNack = await client.NackAsync(third, "final failure", ct: TestContext.Current.CancellationToken);
         Assert.Equal(ReminderNackResponseCode.Failed, thirdNack.ResponseCode);
         Assert.Equal(3, thirdNack.AttemptCount);
 
-        var failed = await client.GetOccurrenceStatusAsync(third.Key, third.DueTimeUtc);
+        var failed = await client.GetOccurrenceStatusAsync(third.Key, third.DueTimeUtc, ct: TestContext.Current.CancellationToken);
         Assert.Equal(ReminderOccurrenceStatusResponseCode.Success, failed.ResponseCode);
         Assert.Equal(ReminderCompletionStatus.Failed, failed.Status?.CompletionStatus);
         Assert.Equal(3, failed.Status?.AttemptCount);
@@ -470,16 +470,16 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         var testProbe = CreateTestProbe();
         _resolver.RegisterShardRegion("test-region", testProbe);
         var client = Sys.ReminderClient().CreateClient("test-region", "ack-first");
-        Assert.Equal(FetchRemindersResponseCode.Success, (await client.ListRemindersAsync()).ResponseCode);
+        Assert.Equal(FetchRemindersResponseCode.Success, (await client.ListRemindersAsync(TestContext.Current.CancellationToken)).ResponseCode);
         var testScheduler = (TestScheduler)Sys.Scheduler;
         var dueTime = testScheduler.Now.AddSeconds(5);
 
-        await client.ScheduleSingleReminderAsync(new ReminderKey("ack-first"), dueTime, "payload");
+        await client.ScheduleSingleReminderAsync(new ReminderKey("ack-first"), dueTime, "payload", ct: TestContext.Current.CancellationToken);
         testScheduler.Advance(TimeSpan.FromSeconds(6));
-        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
 
-        var ack = await client.AckAsync(envelope);
-        var nack = await client.NackAsync(envelope, "too late");
+        var ack = await client.AckAsync(envelope, ct: TestContext.Current.CancellationToken);
+        var nack = await client.NackAsync(envelope, "too late", ct: TestContext.Current.CancellationToken);
 
         Assert.Equal(ReminderAckResponseCode.Success, ack.ResponseCode);
         Assert.Equal(ReminderNackResponseCode.NotFound, nack.ResponseCode);
@@ -491,16 +491,16 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         var testProbe = CreateTestProbe();
         _resolver.RegisterShardRegion("test-region", testProbe);
         var client = Sys.ReminderClient().CreateClient("test-region", "nack-first");
-        Assert.Equal(FetchRemindersResponseCode.Success, (await client.ListRemindersAsync()).ResponseCode);
+        Assert.Equal(FetchRemindersResponseCode.Success, (await client.ListRemindersAsync(TestContext.Current.CancellationToken)).ResponseCode);
         var testScheduler = (TestScheduler)Sys.Scheduler;
         var dueTime = testScheduler.Now.AddSeconds(5);
 
-        await client.ScheduleSingleReminderAsync(new ReminderKey("nack-first"), dueTime, "payload");
+        await client.ScheduleSingleReminderAsync(new ReminderKey("nack-first"), dueTime, "payload", ct: TestContext.Current.CancellationToken);
         testScheduler.Advance(TimeSpan.FromSeconds(6));
-        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        var envelope = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
 
-        var nack = await client.NackAsync(envelope, "failed");
-        var ack = await client.AckAsync(envelope);
+        var nack = await client.NackAsync(envelope, "failed", ct: TestContext.Current.CancellationToken);
+        var ack = await client.AckAsync(envelope, ct: TestContext.Current.CancellationToken);
 
         Assert.Equal(ReminderNackResponseCode.RetryScheduled, nack.ResponseCode);
         Assert.Equal(ReminderAckResponseCode.NotFound, ack.ResponseCode);
@@ -512,13 +512,13 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         var testProbe = CreateTestProbe();
         _resolver.RegisterShardRegion("missing-region", testProbe);
         var client = Sys.ReminderClient().CreateClient("missing-region", "poison");
-        Assert.Equal(FetchRemindersResponseCode.Success, (await client.ListRemindersAsync()).ResponseCode);
+        Assert.Equal(FetchRemindersResponseCode.Success, (await client.ListRemindersAsync(TestContext.Current.CancellationToken)).ResponseCode);
         var testScheduler = (TestScheduler)Sys.Scheduler;
         var dueTime = testScheduler.Now.AddSeconds(5);
         var key = new ReminderKey("missing-shard");
         const string failureReason = "ShardRegion [missing-region] not found";
 
-        var scheduled = await client.ScheduleSingleReminderAsync(key, dueTime, "payload");
+        var scheduled = await client.ScheduleSingleReminderAsync(key, dueTime, "payload", ct: TestContext.Current.CancellationToken);
         Assert.Equal(ReminderScheduleResponseCode.Success, scheduled.ResponseCode);
         Assert.True(_resolver.UnregisterShardRegion("missing-region"));
 
@@ -527,14 +527,14 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         {
             var status = await client.GetOccurrenceStatusAsync(key, dueTime);
             Assert.Equal(1, status.Status?.AttemptCount);
-        }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(50));
+        }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
 
         testScheduler.Advance(TimeSpan.FromSeconds(6));
         await AwaitAssertAsync(async () =>
         {
             var status = await client.GetOccurrenceStatusAsync(key, dueTime);
             Assert.Equal(2, status.Status?.AttemptCount);
-        }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(50));
+        }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
 
         testScheduler.Advance(TimeSpan.FromSeconds(11));
         await AwaitAssertAsync(async () =>
@@ -544,7 +544,7 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
             Assert.Equal(3, status.Status?.AttemptCount);
             Assert.Equal(failureReason, status.Status?.LastFailureReason);
             Assert.Null(status.Status?.NextAttemptAtUtc);
-        }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(50));
+        }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(50), cancellationToken: TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -553,7 +553,7 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
         var testProbe = CreateTestProbe();
         _resolver.RegisterShardRegion("test-region", testProbe);
         var client = Sys.ReminderClient().CreateClient("test-region", "recurring-poison");
-        Assert.Equal(FetchRemindersResponseCode.Success, (await client.ListRemindersAsync()).ResponseCode);
+        Assert.Equal(FetchRemindersResponseCode.Success, (await client.ListRemindersAsync(TestContext.Current.CancellationToken)).ResponseCode);
         var testScheduler = (TestScheduler)Sys.Scheduler;
         var dueTime = testScheduler.Now.AddSeconds(5);
         var key = new ReminderKey("recurring-poison");
@@ -562,22 +562,22 @@ public class ReminderSchedulerTimingSpecs : Akka.Hosting.TestKit.TestKit
             key,
             dueTime,
             TimeSpan.FromSeconds(60),
-            "payload");
+            "payload", ct: TestContext.Current.CancellationToken);
 
         testScheduler.Advance(TimeSpan.FromSeconds(6));
-        var first = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
-        await client.NackAsync(first, "first failure");
+        var first = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await client.NackAsync(first, "first failure", ct: TestContext.Current.CancellationToken);
 
         testScheduler.Advance(TimeSpan.FromSeconds(6));
-        var second = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
-        await client.NackAsync(second, "second failure");
+        var second = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        await client.NackAsync(second, "second failure", ct: TestContext.Current.CancellationToken);
 
         testScheduler.Advance(TimeSpan.FromSeconds(11));
-        var third = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
-        var terminal = await client.NackAsync(third, "final failure");
+        var third = await testProbe.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
+        var terminal = await client.NackAsync(third, "final failure", ct: TestContext.Current.CancellationToken);
         Assert.Equal(ReminderNackResponseCode.Failed, terminal.ResponseCode);
 
-        var reminders = await client.ListRemindersAsync();
+        var reminders = await client.ListRemindersAsync(TestContext.Current.CancellationToken);
         Assert.Contains(reminders.Reminders, reminder => reminder.DueTimeUtc == dueTime.AddSeconds(60));
     }
 

--- a/src/Akka.Reminders.Tests/Serialization/ReminderSerializerSpecs.cs
+++ b/src/Akka.Reminders.Tests/Serialization/ReminderSerializerSpecs.cs
@@ -2,7 +2,6 @@ using Akka.Hosting;
 using Akka.Hosting.TestKit;
 using Akka.Reminders.Serialization;
 using Akka.Serialization;
-using Xunit.Abstractions;
 
 namespace Akka.Reminders.Tests.Serialization;
 

--- a/src/Akka.Reminders.Tests/Serialization/ReminderSerializerSpecs.cs
+++ b/src/Akka.Reminders.Tests/Serialization/ReminderSerializerSpecs.cs
@@ -577,6 +577,67 @@ public class ReminderSerializerSpecs : Akka.Hosting.TestKit.TestKit
     }
 
     #endregion
+
+    #region Cancel and query commands
+
+    [Fact]
+    public void Can_serialize_CancelReminder()
+    {
+        AssertEqual(new ReminderProtocol.CancelReminder(
+            new ReminderEntity("orders", "order-123"),
+            new ReminderKey("payment-reminder")));
+    }
+
+    [Fact]
+    public void Can_serialize_CancelAllReminders()
+    {
+        AssertEqual(new ReminderProtocol.CancelAllReminders(
+            new ReminderEntity("orders", "order-123")));
+    }
+
+    [Fact]
+    public void Can_serialize_GetReminders()
+    {
+        AssertEqual(new ReminderProtocol.GetReminders(
+            new ReminderEntity("orders", "order-123")));
+    }
+
+    [Fact]
+    public void Can_serialize_RemindersCancelled_with_keys()
+    {
+        var entity = new ReminderEntity("orders", "order-123");
+        var msg = new ReminderProtocol.RemindersCancelled(
+            entity,
+            ReminderCancelResponseCode.Success,
+            [new ReminderKey("reminder-1"), new ReminderKey("reminder-2")],
+            "cancelled 2 reminders");
+
+        var result = AssertAndReturn(msg);
+
+        Assert.Equal(entity, result.Entity);
+        Assert.Equal(ReminderCancelResponseCode.Success, result.ResponseCode);
+        Assert.Equal(msg.Keys, result.Keys);
+        Assert.Equal("cancelled 2 reminders", result.Message);
+    }
+
+    [Fact]
+    public void Can_serialize_RemindersCancelled_empty_not_found()
+    {
+        var entity = new ReminderEntity("orders", "order-123");
+        var msg = new ReminderProtocol.RemindersCancelled(
+            entity,
+            ReminderCancelResponseCode.NotFound,
+            []);
+
+        var result = AssertAndReturn(msg);
+
+        Assert.Equal(entity, result.Entity);
+        Assert.Equal(ReminderCancelResponseCode.NotFound, result.ResponseCode);
+        Assert.Empty(result.Keys);
+        Assert.Null(result.Message);
+    }
+
+    #endregion
 }
 
 /// <summary>

--- a/src/Akka.Reminders.Tests/Storage/InMemoryReminderStorageSpecs.cs
+++ b/src/Akka.Reminders.Tests/Storage/InMemoryReminderStorageSpecs.cs
@@ -23,7 +23,7 @@ public class InMemoryReminderStorageSpecs : ReminderStorageSpecBase
     {
         var storage = new InMemoryReminderStorage();
         var reminder = CreateTestReminder();
-        await storage.ScheduleReminderAsync(reminder);
+        await storage.ScheduleReminderAsync(reminder, ct: TestContext.Current.CancellationToken);
 
         var missing = CreateTestReminder(
             CreateTestEntity("missing", "entity"),
@@ -42,19 +42,21 @@ public class InMemoryReminderStorageSpecs : ReminderStorageSpecBase
                 missing.Key,
                 missing.DueTimeUtc,
                 DateTimeOffset.UtcNow,
-                DateTimeOffset.UtcNow.AddMinutes(1))]));
+                DateTimeOffset.UtcNow.AddMinutes(1))]), ct: TestContext.Current.CancellationToken);
 
         Assert.False(committed);
         var status = await storage.GetReminderOccurrenceStatusAsync(
             reminder.Entity,
             reminder.Key,
-            reminder.DueTimeUtc);
+            reminder.DueTimeUtc,
+            ct: TestContext.Current.CancellationToken);
         Assert.NotNull(status);
         Assert.Equal(ReminderCompletionStatus.Pending, status.CompletionStatus);
         Assert.Null(await storage.GetReminderOccurrenceStatusAsync(
             missing.Entity,
             missing.Key,
-            missing.DueTimeUtc));
+            missing.DueTimeUtc,
+            ct: TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -68,23 +70,25 @@ public class InMemoryReminderStorageSpecs : ReminderStorageSpecBase
             LastFailureReason = "prior failure",
             DeliveryDeadlineUtc = now.AddMinutes(1)
         };
-        await storage.ScheduleReminderAsync(reminder);
+        await storage.ScheduleReminderAsync(reminder, ct: TestContext.Current.CancellationToken);
         await storage.CommitReminderMutationsAsync(new ReminderMutationBatch(
             [],
             [],
-            [new AwaitingAckReminder(reminder.Entity, reminder.Key, reminder.DueTimeUtc, now, now.AddMinutes(1))]));
+            [new AwaitingAckReminder(reminder.Entity, reminder.Key, reminder.DueTimeUtc, now, now.AddMinutes(1))]), ct: TestContext.Current.CancellationToken);
 
         var ack = await storage.AcknowledgeReminderAsync(
             reminder.Entity,
             reminder.Key,
             reminder.DueTimeUtc,
-            now.AddMinutes(2));
+            now.AddMinutes(2),
+            ct: TestContext.Current.CancellationToken);
         Assert.Equal(ReminderAckStorageStatus.NotFound, ack.Status);
 
         var status = await storage.GetReminderOccurrenceStatusAsync(
             reminder.Entity,
             reminder.Key,
-            reminder.DueTimeUtc);
+            reminder.DueTimeUtc,
+            ct: TestContext.Current.CancellationToken);
         Assert.NotNull(status);
         Assert.Equal(ReminderCompletionStatus.Expired, status.CompletionStatus);
         Assert.Equal(2, status.AttemptCount);

--- a/src/Akka.Reminders.Tests/Storage/ReminderStorageSpecBase.cs
+++ b/src/Akka.Reminders.Tests/Storage/ReminderStorageSpecBase.cs
@@ -27,12 +27,12 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
 
     protected IReminderStorage? Storage { get; private set; }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         Storage = await CreateStorage();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         if (Storage != null)
         {
@@ -72,7 +72,7 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var reminder = CreateTestReminder();
 
         // Act
-        var result = await Storage!.ScheduleReminderAsync(reminder);
+        var result = await Storage!.ScheduleReminderAsync(reminder, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
@@ -92,16 +92,16 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var reminder1 = CreateTestReminder(entity, key, DateTimeOffset.UtcNow.AddMinutes(5), "message1");
         var reminder2 = CreateTestReminder(entity, key, DateTimeOffset.UtcNow.AddMinutes(10), "message2");
 
-        await Storage!.ScheduleReminderAsync(reminder1);
+        await Storage!.ScheduleReminderAsync(reminder1, TestContext.Current.CancellationToken);
 
         // Act - schedule different reminder with same entity and key (should overwrite)
-        var result = await Storage.ScheduleReminderAsync(reminder2);
+        var result = await Storage.ScheduleReminderAsync(reminder2, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
 
         // Verify only the new reminder exists
-        var reminders = await Storage.GetRemindersForEntityAsync(entity);
+        var reminders = await Storage.GetRemindersForEntityAsync(entity, ct: TestContext.Current.CancellationToken);
         Assert.Single(reminders);
         // Allow for microsecond precision differences (PostgreSQL has 6 decimals, .NET has 7)
         var timeDiff = Math.Abs((reminder2.When - reminders[0].When).TotalMilliseconds);
@@ -118,8 +118,8 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var reminder2 = CreateTestReminder(CreateTestEntity("type2", "id2"), key);
 
         // Act
-        var result1 = await Storage!.ScheduleReminderAsync(reminder1);
-        var result2 = await Storage.ScheduleReminderAsync(reminder2);
+        var result1 = await Storage!.ScheduleReminderAsync(reminder1, TestContext.Current.CancellationToken);
+        var result2 = await Storage.ScheduleReminderAsync(reminder2, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(ReminderScheduleResponseCode.Success, result1.ResponseCode);
@@ -140,13 +140,13 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             RepeatInterval: TimeSpan.FromHours(1));
 
         // Act
-        var result = await Storage!.ScheduleReminderAsync(recurringReminder);
+        var result = await Storage!.ScheduleReminderAsync(recurringReminder, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
 
         // Verify the recurring reminder was stored with repeat interval
-        var reminders = await Storage.GetRemindersForEntityAsync(entity);
+        var reminders = await Storage.GetRemindersForEntityAsync(entity, ct: TestContext.Current.CancellationToken);
         Assert.Single(reminders);
         Assert.Equal(TimeSpan.FromHours(1), reminders[0].RepeatInterval);
     }
@@ -167,13 +167,13 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             LastFailureReason: "ShardRegion not found");
 
         // Act
-        var result = await Storage!.ScheduleReminderAsync(reminderWithRetry);
+        var result = await Storage!.ScheduleReminderAsync(reminderWithRetry, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(ReminderScheduleResponseCode.Success, result.ResponseCode);
 
         // Verify retry tracking was preserved
-        var reminders = await Storage.GetRemindersForEntityAsync(entity);
+        var reminders = await Storage.GetRemindersForEntityAsync(entity, ct: TestContext.Current.CancellationToken);
         Assert.Single(reminders);
         Assert.Equal(2, reminders[0].AttemptCount);
         Assert.Equal("ShardRegion not found", reminders[0].LastFailureReason);
@@ -188,10 +188,10 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
     {
         // Arrange
         var reminder = CreateTestReminder();
-        await Storage!.ScheduleReminderAsync(reminder);
+        await Storage!.ScheduleReminderAsync(reminder, TestContext.Current.CancellationToken);
 
         // Act
-        var result = await Storage.CancelReminderAsync(reminder.Entity, reminder.Key);
+        var result = await Storage.CancelReminderAsync(reminder.Entity, reminder.Key, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(ReminderCancelResponseCode.Success, result.ResponseCode);
@@ -206,7 +206,7 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var key = CreateTestKey();
 
         // Act
-        var result = await Storage!.CancelReminderAsync(entity, key);
+        var result = await Storage!.CancelReminderAsync(entity, key, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(ReminderCancelResponseCode.NotFound, result.ResponseCode);
@@ -220,14 +220,14 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var key1 = CreateTestKey("reminder1");
         var key2 = CreateTestKey("reminder2");
 
-        await Storage!.ScheduleReminderAsync(CreateTestReminder(entity, key1));
-        await Storage.ScheduleReminderAsync(CreateTestReminder(entity, key2));
+        await Storage!.ScheduleReminderAsync(CreateTestReminder(entity, key1), TestContext.Current.CancellationToken);
+        await Storage.ScheduleReminderAsync(CreateTestReminder(entity, key2), TestContext.Current.CancellationToken);
 
         // Act
-        await Storage.CancelReminderAsync(entity, key1);
+        await Storage.CancelReminderAsync(entity, key1, TestContext.Current.CancellationToken);
 
         // Assert - key2 should still exist
-        var reminders = await Storage.GetRemindersForEntityAsync(entity);
+        var reminders = await Storage.GetRemindersForEntityAsync(entity, ct: TestContext.Current.CancellationToken);
         Assert.Single(reminders);
         Assert.Equal(key2, reminders[0].Key);
     }
@@ -244,11 +244,11 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var key1 = CreateTestKey("reminder1");
         var key2 = CreateTestKey("reminder2");
 
-        await Storage!.ScheduleReminderAsync(CreateTestReminder(entity, key1));
-        await Storage.ScheduleReminderAsync(CreateTestReminder(entity, key2));
+        await Storage!.ScheduleReminderAsync(CreateTestReminder(entity, key1), TestContext.Current.CancellationToken);
+        await Storage.ScheduleReminderAsync(CreateTestReminder(entity, key2), TestContext.Current.CancellationToken);
 
         // Act
-        var result = await Storage.CancelAllRemindersForEntityAsync(entity);
+        var result = await Storage.CancelAllRemindersForEntityAsync(entity, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(ReminderCancelResponseCode.Success, result.ResponseCode);
@@ -264,7 +264,7 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var entity = CreateTestEntity();
 
         // Act
-        var result = await Storage!.CancelAllRemindersForEntityAsync(entity);
+        var result = await Storage!.CancelAllRemindersForEntityAsync(entity, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(ReminderCancelResponseCode.NotFound, result.ResponseCode);
@@ -277,14 +277,14 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var entity1 = CreateTestEntity("type1", "id1");
         var entity2 = CreateTestEntity("type2", "id2");
 
-        await Storage!.ScheduleReminderAsync(CreateTestReminder(entity1));
-        await Storage.ScheduleReminderAsync(CreateTestReminder(entity2));
+        await Storage!.ScheduleReminderAsync(CreateTestReminder(entity1), TestContext.Current.CancellationToken);
+        await Storage.ScheduleReminderAsync(CreateTestReminder(entity2), TestContext.Current.CancellationToken);
 
         // Act
-        await Storage.CancelAllRemindersForEntityAsync(entity1);
+        await Storage.CancelAllRemindersForEntityAsync(entity1, TestContext.Current.CancellationToken);
 
         // Assert - entity2 reminders should still exist
-        var reminders = await Storage.GetRemindersForEntityAsync(entity2);
+        var reminders = await Storage.GetRemindersForEntityAsync(entity2, ct: TestContext.Current.CancellationToken);
         Assert.Single(reminders);
     }
 
@@ -299,7 +299,7 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var entity = CreateTestEntity();
 
         // Act
-        var result = await Storage!.GetRemindersForEntityAsync(entity);
+        var result = await Storage!.GetRemindersForEntityAsync(entity, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(result);
@@ -313,11 +313,11 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var reminder1 = CreateTestReminder(entity, CreateTestKey("r1"));
         var reminder2 = CreateTestReminder(entity, CreateTestKey("r2"));
 
-        await Storage!.ScheduleReminderAsync(reminder1);
-        await Storage.ScheduleReminderAsync(reminder2);
+        await Storage!.ScheduleReminderAsync(reminder1, TestContext.Current.CancellationToken);
+        await Storage.ScheduleReminderAsync(reminder2, TestContext.Current.CancellationToken);
 
         // Act
-        var result = await Storage.GetRemindersForEntityAsync(entity);
+        var result = await Storage.GetRemindersForEntityAsync(entity, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -330,11 +330,11 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var entity1 = CreateTestEntity("type1", "id1");
         var entity2 = CreateTestEntity("type2", "id2");
 
-        await Storage!.ScheduleReminderAsync(CreateTestReminder(entity1));
-        await Storage.ScheduleReminderAsync(CreateTestReminder(entity2));
+        await Storage!.ScheduleReminderAsync(CreateTestReminder(entity1), TestContext.Current.CancellationToken);
+        await Storage.ScheduleReminderAsync(CreateTestReminder(entity2), TestContext.Current.CancellationToken);
 
         // Act
-        var result = await Storage.GetRemindersForEntityAsync(entity1);
+        var result = await Storage.GetRemindersForEntityAsync(entity1, ct: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -349,12 +349,12 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         for (int i = 0; i < 20; i++)
         {
             await Storage!.ScheduleReminderAsync(
-                CreateTestReminder(entity, CreateTestKey($"reminder-{i}")));
+                CreateTestReminder(entity, CreateTestKey($"reminder-{i}")), TestContext.Current.CancellationToken);
         }
 
         // Act
-        var page1 = await Storage!.GetRemindersForEntityAsync(entity, take: 10, skip: 0);
-        var page2 = await Storage.GetRemindersForEntityAsync(entity, take: 10, skip: 10);
+        var page1 = await Storage!.GetRemindersForEntityAsync(entity, take: 10, skip: 0, TestContext.Current.CancellationToken);
+        var page2 = await Storage.GetRemindersForEntityAsync(entity, take: 10, skip: 10, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(10, page1.Count);
@@ -373,7 +373,7 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
     public async Task GetRemindersOverview_ShouldReturnZero_WhenNoRemindersExist()
     {
         // Act
-        var overview = await Storage!.GetRemindersOverviewAsync(DateTimeOffset.UtcNow);
+        var overview = await Storage!.GetRemindersOverviewAsync(DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(0, overview.TotalPendingReminders);
@@ -390,7 +390,7 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
 
         // Arrange - get overview from empty database
         var now = DateTimeOffset.UtcNow;
-        var emptyOverview = await Storage!.GetRemindersOverviewAsync(now);
+        var emptyOverview = await Storage!.GetRemindersOverviewAsync(now, TestContext.Current.CancellationToken);
 
         // Act - apply a new reminder scheduled for 5 minutes in the future
         var futureReminder = CreateTestReminder(when: now.AddMinutes(5));
@@ -412,11 +412,11 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             await Storage!.ScheduleReminderAsync(
                 CreateTestReminder(
                     CreateTestEntity("type", $"id-{i}"),
-                    CreateTestKey($"key-{i}")));
+                    CreateTestKey($"key-{i}")), TestContext.Current.CancellationToken);
         }
 
         // Act
-        var overview = await Storage!.GetRemindersOverviewAsync(DateTimeOffset.UtcNow);
+        var overview = await Storage!.GetRemindersOverviewAsync(DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(5, overview.TotalPendingReminders);
@@ -430,11 +430,11 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var nearFuture = now.AddMinutes(5);
         var farFuture = now.AddHours(1);
 
-        await Storage!.ScheduleReminderAsync(CreateTestReminder(when: farFuture));
-        await Storage.ScheduleReminderAsync(CreateTestReminder(CreateTestEntity("type2", "id2"), when: nearFuture));
+        await Storage!.ScheduleReminderAsync(CreateTestReminder(when: farFuture), TestContext.Current.CancellationToken);
+        await Storage.ScheduleReminderAsync(CreateTestReminder(CreateTestEntity("type2", "id2"), when: nearFuture), TestContext.Current.CancellationToken);
 
         // Act
-        var overview = await Storage.GetRemindersOverviewAsync(DateTimeOffset.UtcNow);
+        var overview = await Storage.GetRemindersOverviewAsync(DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(overview.TimeUntilNext <= TimeSpan.FromMinutes(6));
@@ -450,11 +450,11 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
     {
         // Arrange
         var futureTime = DateTimeOffset.UtcNow.AddHours(1);
-        await Storage!.ScheduleReminderAsync(CreateTestReminder(when: futureTime));
+        await Storage!.ScheduleReminderAsync(CreateTestReminder(when: futureTime), TestContext.Current.CancellationToken);
 
         // Act
         var now = DateTimeOffset.UtcNow;
-        var result = await Storage.GetNextRemindersAsync(now, now, DefaultBatchSize);
+        var result = await Storage.GetNextRemindersAsync(now, now, DefaultBatchSize, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(result.Reminders);
@@ -470,12 +470,12 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var nearFuture = now.AddMinutes(5);
         var farFuture = now.AddHours(1);
 
-        await Storage!.ScheduleReminderAsync(CreateTestReminder(CreateTestEntity("t1", "i1"), when: past));
-        await Storage.ScheduleReminderAsync(CreateTestReminder(CreateTestEntity("t2", "i2"), when: nearFuture));
-        await Storage.ScheduleReminderAsync(CreateTestReminder(CreateTestEntity("t3", "i3"), when: farFuture));
+        await Storage!.ScheduleReminderAsync(CreateTestReminder(CreateTestEntity("t1", "i1"), when: past), TestContext.Current.CancellationToken);
+        await Storage.ScheduleReminderAsync(CreateTestReminder(CreateTestEntity("t2", "i2"), when: nearFuture), TestContext.Current.CancellationToken);
+        await Storage.ScheduleReminderAsync(CreateTestReminder(CreateTestEntity("t3", "i3"), when: farFuture), TestContext.Current.CancellationToken);
 
         // Act - get reminders due up until nearFuture
-        var result = await Storage.GetNextRemindersAsync(nearFuture, nearFuture, DefaultBatchSize);
+        var result = await Storage.GetNextRemindersAsync(nearFuture, nearFuture, DefaultBatchSize, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(2, result.Reminders.Count); // past and nearFuture
@@ -487,12 +487,12 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
     {
         // Arrange
         var now = DateTimeOffset.UtcNow;
-        await Storage!.ScheduleReminderAsync(CreateTestReminder(when: now.AddMinutes(1)));
-        await Storage.ScheduleReminderAsync(CreateTestReminder(CreateTestEntity("t2", "i2"), when: now.AddMinutes(10)));
+        await Storage!.ScheduleReminderAsync(CreateTestReminder(when: now.AddMinutes(1)), TestContext.Current.CancellationToken);
+        await Storage.ScheduleReminderAsync(CreateTestReminder(CreateTestEntity("t2", "i2"), when: now.AddMinutes(10)), TestContext.Current.CancellationToken);
 
         // Act
         var deadline = now.AddMinutes(5);
-        var result = await Storage.GetNextRemindersAsync(deadline, deadline, DefaultBatchSize);
+        var result = await Storage.GetNextRemindersAsync(deadline, deadline, DefaultBatchSize, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result.Reminders);
@@ -515,11 +515,11 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
                 CreateTestReminder(
                     CreateTestEntity($"batch-type", $"batch-id-{i}"),
                     CreateTestKey($"batch-key-{i}"),
-                    when: past));
+                    when: past), TestContext.Current.CancellationToken);
         }
 
         // Act - fetch with maxCount
-        var result = await Storage!.GetNextRemindersAsync(now, now, maxCount: new ReminderBatchSize(maxCount));
+        var result = await Storage!.GetNextRemindersAsync(now, now, maxCount: new ReminderBatchSize(maxCount), TestContext.Current.CancellationToken);
 
         // Assert - should only return maxCount reminders
         Assert.Equal(maxCount, result.Reminders.Count);
@@ -542,7 +542,7 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
     {
         var now = DateTimeOffset.UtcNow;
         var reminder = CreateTestReminder(when: now.AddMinutes(5));
-        await Storage!.ScheduleReminderAsync(reminder);
+        await Storage!.ScheduleReminderAsync(reminder, TestContext.Current.CancellationToken);
 
         // Transition to AwaitingAck — simulates what the scheduler does after delivering
         // the reminder via Tell. The ackDeadline is when the scheduler will retry if no
@@ -554,12 +554,12 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             now,           // deliveredAt
             now.AddMinutes(1)); // ackDeadline
 
-        var result = await Storage.MarkRemindersAsAwaitingAckAsync([awaitingAck]);
+        var result = await Storage.MarkRemindersAsAwaitingAckAsync([awaitingAck], TestContext.Current.CancellationToken);
         Assert.True(result);
 
         // The overview only counts Pending rows. AwaitingAck rows are invisible to the
         // fetch loop — they're tracked by the ack-timeout checker instead.
-        var overview = await Storage.GetRemindersOverviewAsync(now);
+        var overview = await Storage.GetRemindersOverviewAsync(now, TestContext.Current.CancellationToken);
         Assert.Equal(0, overview.TotalPendingReminders);
     }
 
@@ -574,7 +574,7 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
     {
         var now = DateTimeOffset.UtcNow;
         var reminder = CreateTestReminder(when: now.AddMinutes(5));
-        await Storage!.ScheduleReminderAsync(reminder);
+        await Storage!.ScheduleReminderAsync(reminder, TestContext.Current.CancellationToken);
 
         var awaitingAck = new AwaitingAckReminder(
             reminder.Entity,
@@ -582,7 +582,7 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             reminder.DueTimeUtc,
             now,
             now.AddMinutes(1));
-        await Storage.MarkRemindersAsAwaitingAckAsync([awaitingAck]);
+        await Storage.MarkRemindersAsAwaitingAckAsync([awaitingAck], TestContext.Current.CancellationToken);
 
         // Ack with wrong DueTimeUtc — off by 1 second. This simulates a late ack
         // arriving for a superseded occurrence of a recurring reminder.
@@ -590,7 +590,7 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             reminder.Entity,
             reminder.Key,
             reminder.DueTimeUtc.AddSeconds(1), // wrong occurrence
-            now.AddSeconds(10));
+            now.AddSeconds(10), TestContext.Current.CancellationToken);
 
         Assert.False(wrongAck.Success);
         Assert.Equal(ReminderAckStorageStatus.NotFound, wrongAck.Status);
@@ -600,7 +600,7 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             reminder.Entity,
             reminder.Key,
             reminder.DueTimeUtc,
-            now.AddSeconds(10));
+            now.AddSeconds(10), TestContext.Current.CancellationToken);
 
         Assert.True(correctAck.Success);
         Assert.Equal(ReminderAckStorageStatus.Success, correctAck.Status);
@@ -630,7 +630,7 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             RepeatInterval: TimeSpan.FromMinutes(1),
             OccurrenceDueTimeUtc: now.AddMinutes(1));
 
-        await Storage!.ScheduleReminderAsync(reminder);
+        await Storage!.ScheduleReminderAsync(reminder, TestContext.Current.CancellationToken);
 
         // Create the next recurring occurrence — due 1 interval later.
         // In production, CreateNextRecurringOccurrence does this.
@@ -653,24 +653,24 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var result = await Storage.CommitReminderMutationsAsync(new ReminderMutationBatch(
             [nextOccurrence],  // PendingUpserts: next recurring occurrence
             [],                // CompletedReminders: none
-            [awaiting]));      // AwaitingAckReminders: current occurrence
+            [awaiting]), TestContext.Current.CancellationToken);      // AwaitingAckReminders: current occurrence
 
         Assert.True(result);
 
         // Only the next occurrence is Pending — the current one is AwaitingAck
         // and excluded from the overview.
-        var overview = await Storage.GetRemindersOverviewAsync(now);
+        var overview = await Storage.GetRemindersOverviewAsync(now, TestContext.Current.CancellationToken);
         Assert.Equal(1, overview.TotalPendingReminders);
 
         // GetRemindersForEntityAsync returns both Pending and AwaitingAck rows,
         // so both occurrences should be visible (two different DueTimeUtc values).
-        var reminders = await Storage.GetRemindersForEntityAsync(reminder.Entity);
+        var reminders = await Storage.GetRemindersForEntityAsync(reminder.Entity, ct: TestContext.Current.CancellationToken);
         Assert.Equal(2, reminders.Count);
         Assert.Contains(reminders, r => Math.Abs((r.DueTimeUtc - reminder.DueTimeUtc).TotalMilliseconds) < 0.001);
         Assert.Contains(reminders, r => Math.Abs((r.DueTimeUtc - nextOccurrence.DueTimeUtc).TotalMilliseconds) < 0.001);
 
         // The AwaitingAck occurrence should be ackable by its original DueTimeUtc.
-        var ack = await Storage.AcknowledgeReminderAsync(reminder.Entity, reminder.Key, reminder.DueTimeUtc, now.AddSeconds(5));
+        var ack = await Storage.AcknowledgeReminderAsync(reminder.Entity, reminder.Key, reminder.DueTimeUtc, now.AddSeconds(5), TestContext.Current.CancellationToken);
         Assert.True(ack.Success);
     }
 
@@ -685,13 +685,13 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
     {
         var now = DateTimeOffset.UtcNow;
         var reminder = CreateTestReminder(when: now.AddMinutes(5));
-        await Storage!.ScheduleReminderAsync(reminder);
+        await Storage!.ScheduleReminderAsync(reminder, TestContext.Current.CancellationToken);
 
         // Move to AwaitingAck so there's something to acknowledge.
         await Storage.CommitReminderMutationsAsync(new ReminderMutationBatch(
             [],
             [],
-            [new AwaitingAckReminder(reminder.Entity, reminder.Key, reminder.DueTimeUtc, now, now.AddMinutes(1))]));
+            [new AwaitingAckReminder(reminder.Entity, reminder.Key, reminder.DueTimeUtc, now, now.AddMinutes(1))]), TestContext.Current.CancellationToken);
 
         // Ack two occurrences in a single batch: one that exists (correct DueTimeUtc)
         // and one that doesn't (DueTimeUtc + 1 minute — no such occurrence).
@@ -699,7 +699,7 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var results = await Storage.AcknowledgeRemindersAsync([
             new ReminderAcknowledgement(reminder.Entity, reminder.Key, reminder.DueTimeUtc, now.AddSeconds(5)),
             new ReminderAcknowledgement(reminder.Entity, reminder.Key, missingDueTime, now.AddSeconds(5))
-        ]);
+        ], TestContext.Current.CancellationToken);
 
         // Results are positional — one per ack in the input batch.
         Assert.Equal(2, results.Count);
@@ -720,8 +720,8 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var first = CreateTestReminder(CreateTestEntity("a", "1"), CreateTestKey("first"), now.AddMinutes(1));
         var second = CreateTestReminder(CreateTestEntity("a", "2"), CreateTestKey("second"), now.AddMinutes(2));
 
-        await Storage!.ScheduleReminderAsync(first);
-        await Storage.ScheduleReminderAsync(second);
+        await Storage!.ScheduleReminderAsync(first, TestContext.Current.CancellationToken);
+        await Storage.ScheduleReminderAsync(second, TestContext.Current.CancellationToken);
 
         // Move both to AwaitingAck with different deadlines.
         // "first" has a later deadline (20s), "second" has an earlier one (10s).
@@ -732,9 +732,9 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             [
                 new AwaitingAckReminder(first.Entity, first.Key, first.DueTimeUtc, now, now.AddSeconds(20)),
                 new AwaitingAckReminder(second.Entity, second.Key, second.DueTimeUtc, now, now.AddSeconds(10))
-            ]));
+            ]), TestContext.Current.CancellationToken);
 
-        var deadline = await Storage.GetNextAwaitingAckDeadlineAsync();
+        var deadline = await Storage.GetNextAwaitingAckDeadlineAsync(TestContext.Current.CancellationToken);
 
         // Should be the earlier deadline (now + 10s), not the first-inserted one (now + 20s).
         Assert.NotNull(deadline);
@@ -765,18 +765,18 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             DeliveryDeadlineUtc: dueTime.AddMinutes(1),           // deadline was 1 minute ago
             OccurrenceDueTimeUtc: dueTime);
 
-        await Storage!.ScheduleReminderAsync(reminder);
+        await Storage!.ScheduleReminderAsync(reminder, TestContext.Current.CancellationToken);
 
         // Expire should find this reminder because now > dueTime + 1 minute.
-        var expiredCount = await Storage.ExpireRemindersAsync(now);
+        var expiredCount = await Storage.ExpireRemindersAsync(now, TestContext.Current.CancellationToken);
         Assert.True(expiredCount >= 1);
 
         // The reminder is gone from the pending set — it won't be fetched or delivered.
-        var overview = await Storage.GetRemindersOverviewAsync(now);
+        var overview = await Storage.GetRemindersOverviewAsync(now, TestContext.Current.CancellationToken);
         Assert.Equal(0, overview.TotalPendingReminders);
 
         // GetRemindersForEntityAsync also excludes expired reminders.
-        var reminders = await Storage.GetRemindersForEntityAsync(reminder.Entity);
+        var reminders = await Storage.GetRemindersForEntityAsync(reminder.Entity, ct: TestContext.Current.CancellationToken);
         Assert.Empty(reminders);
     }
 
@@ -789,12 +789,12 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
     {
         // Arrange
         var reminder = CreateTestReminder();
-        await Storage!.ScheduleReminderAsync(reminder);
+        await Storage!.ScheduleReminderAsync(reminder, TestContext.Current.CancellationToken);
 
         var completed = new CompletedReminder(reminder.Entity, reminder.Key, reminder.DueTimeUtc, DateTimeOffset.UtcNow);
 
         // Act
-        var result = await Storage.MarkRemindersAsCompletedAsync(new[] { completed });
+        var result = await Storage.MarkRemindersAsCompletedAsync(new[] { completed }, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
@@ -805,13 +805,13 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
     {
         // Arrange
         var reminder = CreateTestReminder();
-        await Storage!.ScheduleReminderAsync(reminder);
+        await Storage!.ScheduleReminderAsync(reminder, TestContext.Current.CancellationToken);
 
         var completed = new CompletedReminder(reminder.Entity, reminder.Key, reminder.DueTimeUtc, DateTimeOffset.UtcNow);
-        await Storage.MarkRemindersAsCompletedAsync(new[] { completed });
+        await Storage.MarkRemindersAsCompletedAsync(new[] { completed }, TestContext.Current.CancellationToken);
 
         // Act
-        var overview = await Storage.GetRemindersOverviewAsync(DateTimeOffset.UtcNow);
+        var overview = await Storage.GetRemindersOverviewAsync(DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(0, overview.TotalPendingReminders);
@@ -825,18 +825,18 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var reminder1 = CreateTestReminder(entity, CreateTestKey("r1"));
         var reminder2 = CreateTestReminder(entity, CreateTestKey("r2"));
 
-        await Storage!.ScheduleReminderAsync(reminder1);
-        await Storage.ScheduleReminderAsync(reminder2);
+        await Storage!.ScheduleReminderAsync(reminder1, TestContext.Current.CancellationToken);
+        await Storage.ScheduleReminderAsync(reminder2, TestContext.Current.CancellationToken);
 
         var completed1 = new CompletedReminder(reminder1.Entity, reminder1.Key, reminder1.DueTimeUtc, DateTimeOffset.UtcNow);
         var completed2 = new CompletedReminder(reminder2.Entity, reminder2.Key, reminder2.DueTimeUtc, DateTimeOffset.UtcNow);
 
         // Act
-        var result = await Storage.MarkRemindersAsCompletedAsync(new[] { completed1, completed2 });
+        var result = await Storage.MarkRemindersAsCompletedAsync(new[] { completed1, completed2 }, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
-        var overview = await Storage.GetRemindersOverviewAsync(DateTimeOffset.UtcNow);
+        var overview = await Storage.GetRemindersOverviewAsync(DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
         Assert.Equal(0, overview.TotalPendingReminders);
     }
 
@@ -849,14 +849,14 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
     {
         // Arrange
         var reminder = CreateTestReminder();
-        await Storage!.ScheduleReminderAsync(reminder);
+        await Storage!.ScheduleReminderAsync(reminder, TestContext.Current.CancellationToken);
 
         var completedTime = DateTimeOffset.UtcNow.AddDays(-10);
         var completed = new CompletedReminder(reminder.Entity, reminder.Key, reminder.DueTimeUtc, completedTime);
-        await Storage.MarkRemindersAsCompletedAsync(new[] { completed });
+        await Storage.MarkRemindersAsCompletedAsync(new[] { completed }, TestContext.Current.CancellationToken);
 
         // Act
-        var result = await Storage.CleanUpCompletedRemindersAsync(DateTimeOffset.UtcNow.AddDays(-5));
+        var result = await Storage.CleanUpCompletedRemindersAsync(DateTimeOffset.UtcNow.AddDays(-5), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
@@ -867,14 +867,14 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
     {
         // Arrange
         var reminder = CreateTestReminder();
-        await Storage!.ScheduleReminderAsync(reminder);
+        await Storage!.ScheduleReminderAsync(reminder, TestContext.Current.CancellationToken);
 
         var recentCompletedTime = DateTimeOffset.UtcNow.AddDays(-3);
         var completed = new CompletedReminder(reminder.Entity, reminder.Key, reminder.DueTimeUtc, recentCompletedTime);
-        await Storage.MarkRemindersAsCompletedAsync(new[] { completed });
+        await Storage.MarkRemindersAsCompletedAsync(new[] { completed }, TestContext.Current.CancellationToken);
 
         // Act - cleanup reminders older than 5 days
-        var result = await Storage.CleanUpCompletedRemindersAsync(DateTimeOffset.UtcNow.AddDays(-5));
+        var result = await Storage.CleanUpCompletedRemindersAsync(DateTimeOffset.UtcNow.AddDays(-5), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);

--- a/src/Akka.Reminders.Tests/Storage/ReminderStorageSpecBase.cs
+++ b/src/Akka.Reminders.Tests/Storage/ReminderStorageSpecBase.cs
@@ -718,12 +718,13 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             DeliveryDeadlineUtc = now.AddHours(1),
             OccurrenceDueTimeUtc = now.AddMinutes(5)
         };
-        await Storage!.ScheduleReminderAsync(reminder);
+        await Storage!.ScheduleReminderAsync(reminder, ct: TestContext.Current.CancellationToken);
 
         var pending = await Storage.GetReminderOccurrenceStatusAsync(
             reminder.Entity,
             reminder.Key,
-            reminder.DueTimeUtc);
+            reminder.DueTimeUtc,
+            ct: TestContext.Current.CancellationToken);
         Assert.NotNull(pending);
         Assert.Equal(ReminderCompletionStatus.Pending, pending.CompletionStatus);
         Assert.Equal(2, pending.AttemptCount);
@@ -733,12 +734,13 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         await Storage.CommitReminderMutationsAsync(new ReminderMutationBatch(
             [],
             [],
-            [new AwaitingAckReminder(reminder.Entity, reminder.Key, reminder.DueTimeUtc, now, now.AddMinutes(1))]));
+            [new AwaitingAckReminder(reminder.Entity, reminder.Key, reminder.DueTimeUtc, now, now.AddMinutes(1))]), ct: TestContext.Current.CancellationToken);
 
         var awaiting = await Storage.GetReminderOccurrenceStatusAsync(
             reminder.Entity,
             reminder.Key,
-            reminder.DueTimeUtc);
+            reminder.DueTimeUtc,
+            ct: TestContext.Current.CancellationToken);
         Assert.NotNull(awaiting);
         Assert.Equal(ReminderCompletionStatus.AwaitingAck, awaiting.CompletionStatus);
         Assert.Null(awaiting.NextAttemptAtUtc);
@@ -749,13 +751,15 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             reminder.Entity,
             reminder.Key,
             reminder.DueTimeUtc,
-            now.AddSeconds(5));
+            now.AddSeconds(5),
+            ct: TestContext.Current.CancellationToken);
         Assert.True(ack.Success);
 
         var delivered = await Storage.GetReminderOccurrenceStatusAsync(
             reminder.Entity,
             reminder.Key,
-            reminder.DueTimeUtc);
+            reminder.DueTimeUtc,
+            ct: TestContext.Current.CancellationToken);
         Assert.NotNull(delivered);
         Assert.Equal(ReminderCompletionStatus.Delivered, delivered.CompletionStatus);
         Assert.Null(delivered.NextAttemptAtUtc);
@@ -773,23 +777,25 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             DeliveryDeadlineUtc = now.AddHours(1),
             OccurrenceDueTimeUtc = now.AddMinutes(5)
         };
-        await Storage!.ScheduleReminderAsync(reminder);
+        await Storage!.ScheduleReminderAsync(reminder, ct: TestContext.Current.CancellationToken);
 
         var missingBeforeDelivery = await Storage.GetAwaitingAckReminderAsync(
             reminder.Entity,
             reminder.Key,
-            reminder.DueTimeUtc);
+            reminder.DueTimeUtc,
+            ct: TestContext.Current.CancellationToken);
         Assert.Null(missingBeforeDelivery);
 
         await Storage.CommitReminderMutationsAsync(new ReminderMutationBatch(
             [],
             [],
-            [new AwaitingAckReminder(reminder.Entity, reminder.Key, reminder.DueTimeUtc, now, now.AddMinutes(1))]));
+            [new AwaitingAckReminder(reminder.Entity, reminder.Key, reminder.DueTimeUtc, now, now.AddMinutes(1))]), ct: TestContext.Current.CancellationToken);
 
         var found = await Storage.GetAwaitingAckReminderAsync(
             reminder.Entity,
             reminder.Key,
-            reminder.DueTimeUtc);
+            reminder.DueTimeUtc,
+            ct: TestContext.Current.CancellationToken);
         Assert.NotNull(found);
         Assert.Equal(2, found.AttemptCount);
         Assert.Equal("prior failure", found.LastFailureReason);
@@ -800,7 +806,8 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
         var stale = await Storage.GetAwaitingAckReminderAsync(
             reminder.Entity,
             reminder.Key,
-            reminder.DueTimeUtc.AddSeconds(1));
+            reminder.DueTimeUtc.AddSeconds(1),
+            ct: TestContext.Current.CancellationToken);
         Assert.Null(stale);
     }
 
@@ -814,7 +821,7 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             LastFailureReason = "final failure",
             DeliveryDeadlineUtc = now.AddHours(1)
         };
-        await Storage!.ScheduleReminderAsync(reminder);
+        await Storage!.ScheduleReminderAsync(reminder, ct: TestContext.Current.CancellationToken);
         await Storage.MarkRemindersAsCompletedAsync([
             new CompletedReminder(
                 reminder.Entity,
@@ -822,12 +829,13 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
                 reminder.DueTimeUtc,
                 now,
                 ReminderCompletionStatus.Failed)
-        ]);
+        ], ct: TestContext.Current.CancellationToken);
 
         var status = await Storage.GetReminderOccurrenceStatusAsync(
             reminder.Entity,
             reminder.Key,
-            reminder.DueTimeUtc);
+            reminder.DueTimeUtc,
+            ct: TestContext.Current.CancellationToken);
 
         Assert.NotNull(status);
         Assert.Equal(ReminderCompletionStatus.Failed, status.CompletionStatus);
@@ -848,13 +856,14 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             AttemptCount = 2,
             LastFailureReason = "prior failure"
         };
-        await Storage!.ScheduleReminderAsync(reminder);
-        await Storage.CancelReminderAsync(reminder.Entity, reminder.Key);
+        await Storage!.ScheduleReminderAsync(reminder, ct: TestContext.Current.CancellationToken);
+        await Storage.CancelReminderAsync(reminder.Entity, reminder.Key, ct: TestContext.Current.CancellationToken);
 
         var status = await Storage.GetReminderOccurrenceStatusAsync(
             reminder.Entity,
             reminder.Key,
-            reminder.DueTimeUtc);
+            reminder.DueTimeUtc,
+            ct: TestContext.Current.CancellationToken);
 
         Assert.NotNull(status);
         Assert.Equal(ReminderCompletionStatus.Cancelled, status.CompletionStatus);
@@ -873,13 +882,14 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             LastFailureReason = "prior failure",
             DeliveryDeadlineUtc = now.AddMinutes(-1)
         };
-        await Storage!.ScheduleReminderAsync(reminder);
-        Assert.Equal(1, await Storage.ExpireRemindersAsync(now));
+        await Storage!.ScheduleReminderAsync(reminder, ct: TestContext.Current.CancellationToken);
+        Assert.Equal(1, await Storage.ExpireRemindersAsync(now, ct: TestContext.Current.CancellationToken));
 
         var status = await Storage.GetReminderOccurrenceStatusAsync(
             reminder.Entity,
             reminder.Key,
-            reminder.DueTimeUtc);
+            reminder.DueTimeUtc,
+            ct: TestContext.Current.CancellationToken);
 
         Assert.NotNull(status);
         Assert.Equal(ReminderCompletionStatus.Expired, status.CompletionStatus);
@@ -897,19 +907,20 @@ public abstract class ReminderStorageSpecBase : IAsyncLifetime
             AttemptCount = 2,
             LastFailureReason = "prior failure"
         };
-        await Storage!.ScheduleReminderAsync(original);
+        await Storage!.ScheduleReminderAsync(original, ct: TestContext.Current.CancellationToken);
         await Storage.ScheduleReminderAsync(original with
         {
             When = now.AddMinutes(10),
             OccurrenceDueTimeUtc = now.AddMinutes(10),
             AttemptCount = 0,
             LastFailureReason = null
-        });
+        }, ct: TestContext.Current.CancellationToken);
 
         var status = await Storage.GetReminderOccurrenceStatusAsync(
             original.Entity,
             original.Key,
-            original.DueTimeUtc);
+            original.DueTimeUtc,
+            ct: TestContext.Current.CancellationToken);
 
         Assert.NotNull(status);
         Assert.Equal(ReminderCompletionStatus.Cancelled, status.CompletionStatus);

--- a/src/Akka.Reminders.Tests/Storage/SqlCompatibilitySpecs.cs
+++ b/src/Akka.Reminders.Tests/Storage/SqlCompatibilitySpecs.cs
@@ -11,7 +11,7 @@ public sealed class SqlCompatibilitySpecs : IAsyncLifetime
     private SqlReminderStorage? _storage;
     private string? _databasePath;
 
-    public Task InitializeAsync()
+    public ValueTask InitializeAsync()
     {
         _system = ActorSystem.Create("compatibility-system");
         _databasePath = Path.Combine(Path.GetTempPath(), $"akka-reminders-compat-{Guid.NewGuid():N}.db");
@@ -20,10 +20,10 @@ public sealed class SqlCompatibilitySpecs : IAsyncLifetime
         var settings = SqlReminderStorageSettings.CreateSqlite(connectionString);
 
         _storage = new SqlReminderStorage(settings, _system);
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         if (_system != null)
         {
@@ -43,8 +43,8 @@ public sealed class SqlCompatibilitySpecs : IAsyncLifetime
         var key = new ReminderKey("compat-key");
         var reminder = new ScheduledReminder(entity, key, DateTimeOffset.UtcNow.AddMinutes(5), "hello");
 
-        var scheduled = await _storage!.ScheduleReminderAsync(reminder);
-        var reminders = await _storage.GetRemindersForEntityAsync(entity);
+        var scheduled = await _storage!.ScheduleReminderAsync(reminder, TestContext.Current.CancellationToken);
+        var reminders = await _storage.GetRemindersForEntityAsync(entity, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(ReminderScheduleResponseCode.Success, scheduled.ResponseCode);
         Assert.Single(reminders);

--- a/src/Akka.Reminders.Tests/StrictSerializationSpecs.cs
+++ b/src/Akka.Reminders.Tests/StrictSerializationSpecs.cs
@@ -43,8 +43,17 @@ public class StrictSerializationSpecs : Akka.Hosting.TestKit.TestKit
                 akka.actor.serialize-messages = on
                 akka.actor.serialization-settings.allow-unregistered-types = off
                 akka.actor.serialization-bindings {
-                    ""Akka.Actor.Identify"" = hyperion
-                    ""Akka.Hosting.TestKit.TestKit+StableTestProbeRef+UpdateTarget, Akka.Hosting.TestKit"" = hyperion
+                    # TestKit-internal control messages (not part of the system under test).
+                    # Akka.Hosting.TestKit 1.5.70 sends Akka.Actor.Identify (ResolveOne during
+                    # shard-region resolution) and StableTestProbeRef+UpdateTarget (probe retargeting
+                    # across host startup). Bind both to the built-in json serializer so strict mode
+                    # (allow-unregistered-types = off) has a serializer for them.
+                    ""Akka.Actor.Identify"" = json
+                    ""Akka.Hosting.TestKit.TestKit+StableTestProbeRef+UpdateTarget, Akka.Hosting.TestKit"" = json
+                    # The user-supplied reminder payload used by these specs. A real app running
+                    # strict serialization would register a serializer for its own payload types;
+                    # bind it to json here so the reminder can round-trip through delivery.
+                    ""Akka.Reminders.Tests.StrictSerializationSpecs+StrictSerialTestMsg, Akka.Reminders.Tests"" = json
                 }
             "), HoconAddMode.Prepend);
     }
@@ -104,16 +113,16 @@ public class StrictSerializationSpecs : Akka.Hosting.TestKit.TestKit
         var result = await client.ScheduleSingleReminderAsync(
             key,
             when,
-            new StrictSerialTestMsg("retry"));
+            new StrictSerialTestMsg("retry"), ct: TestContext.Current.CancellationToken);
         result.ResponseCode.Should().Be(ReminderScheduleResponseCode.Success);
 
         var first = await targetActor.ExpectMsgAsync<ReminderEnvelope<StrictSerialTestMsg>>(
-            TimeSpan.FromSeconds(2));
-        var nack = await client.NackAsync(first, "test failure");
+            TimeSpan.FromSeconds(2), cancellationToken: TestContext.Current.CancellationToken);
+        var nack = await client.NackAsync(first, "test failure", ct: TestContext.Current.CancellationToken);
         nack.ResponseCode.Should().Be(ReminderNackResponseCode.RetryScheduled);
 
         var retry = await targetActor.ExpectMsgAsync<ReminderEnvelope<StrictSerialTestMsg>>(
-            TimeSpan.FromSeconds(2));
+            TimeSpan.FromSeconds(2), cancellationToken: TestContext.Current.CancellationToken);
         retry.DueTimeUtc.Should().Be(first.DueTimeUtc);
     }
 

--- a/src/Akka.Reminders.Tests/StrictSerializationSpecs.cs
+++ b/src/Akka.Reminders.Tests/StrictSerializationSpecs.cs
@@ -42,6 +42,10 @@ public class StrictSerializationSpecs : Akka.Hosting.TestKit.TestKit
             .AddHocon(ConfigurationFactory.ParseString(@"
                 akka.actor.serialize-messages = on
                 akka.actor.serialization-settings.allow-unregistered-types = off
+                akka.actor.serialization-bindings {
+                    ""Akka.Actor.Identify"" = hyperion
+                    ""Akka.Hosting.TestKit.TestKit+StableTestProbeRef+UpdateTarget, Akka.Hosting.TestKit"" = hyperion
+                }
             "), HoconAddMode.Prepend);
     }
 

--- a/src/Akka.Reminders.Tests/StrictSerializationSpecs.cs
+++ b/src/Akka.Reminders.Tests/StrictSerializationSpecs.cs
@@ -4,7 +4,6 @@ using Akka.Hosting;
 using Akka.Reminders.Sharding;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Reminders.Tests;
 
@@ -76,14 +75,14 @@ public class StrictSerializationSpecs : Akka.Hosting.TestKit.TestKit
         // Act - if internal messages aren't marked INoSerializationVerificationNeeded,
         // this ScheduleSingleReminderAsync call will throw SerializationException
         // because InitResult is returned via Tell to the caller.
-        var result = await client.ScheduleSingleReminderAsync(key, when, message);
+        var result = await client.ScheduleSingleReminderAsync(key, when, message, ct: TestContext.Current.CancellationToken);
 
         // Assert
         result.ResponseCode.Should().Be(ReminderScheduleResponseCode.Success);
 
         // The reminder should be delivered through the scheduler pipeline
         // without any serialization errors
-        var envelope = await targetActor.ExpectMsgAsync<ReminderEnvelope<StrictSerialTestMsg>>(TimeSpan.FromSeconds(2));
+        var envelope = await targetActor.ExpectMsgAsync<ReminderEnvelope<StrictSerialTestMsg>>(TimeSpan.FromSeconds(2), cancellationToken: TestContext.Current.CancellationToken);
         envelope.Message.Content.Should().Be("hello");
     }
 
@@ -101,10 +100,10 @@ public class StrictSerializationSpecs : Akka.Hosting.TestKit.TestKit
         var message = new StrictSerialTestMsg("cancel");
         var when = DateTimeOffset.UtcNow.AddMilliseconds(200);
 
-        await client.ScheduleSingleReminderAsync(key, when, message);
+        await client.ScheduleSingleReminderAsync(key, when, message, ct: TestContext.Current.CancellationToken);
 
         // Act - CancelReminder is also internal and should not break strict serialization
-        var cancelResult = await client.CancelReminderAsync(key);
+        var cancelResult = await client.CancelReminderAsync(key, TestContext.Current.CancellationToken);
 
         // Assert
         cancelResult.ResponseCode.Should().Be(ReminderCancelResponseCode.Success);
@@ -121,7 +120,7 @@ public class StrictSerializationSpecs : Akka.Hosting.TestKit.TestKit
         var client = extension.CreateClient("billing-shard", "customer-123");
 
         // Act
-        var result = await client.CancelAllRemindersAsync();
+        var result = await client.CancelAllRemindersAsync(TestContext.Current.CancellationToken);
 
         // Assert - CancelAllReminders is internal, should not break
         // NotFound is fine since there are no reminders to cancel

--- a/src/Akka.Reminders.Tests/WriteCircuitBreakerSpecs.cs
+++ b/src/Akka.Reminders.Tests/WriteCircuitBreakerSpecs.cs
@@ -4,7 +4,6 @@ using Akka.Hosting.TestKit;
 using Akka.Reminders.Sharding;
 using Akka.Reminders.Storage;
 using Akka.TestKit;
-using Xunit.Abstractions;
 
 namespace Akka.Reminders.Tests;
 
@@ -103,7 +102,7 @@ public class WriteCircuitBreakerSpecs : Akka.Hosting.TestKit.TestKit
 
         // Tick 1: delivery-tracking write fails before any reminders are sent -> circuit opens.
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
-        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
+        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -124,7 +123,7 @@ public class WriteCircuitBreakerSpecs : Akka.Hosting.TestKit.TestKit
         Assert.Equal(5, messages.Count);
 
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
-        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
+        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -143,7 +142,7 @@ public class WriteCircuitBreakerSpecs : Akka.Hosting.TestKit.TestKit
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
 
         // Failed writes now prevent delivery entirely, reducing the first-failure blast radius to zero.
-        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
+        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -162,13 +161,13 @@ public class WriteCircuitBreakerSpecs : Akka.Hosting.TestKit.TestKit
 
         // Outage tick: failed writes prevent any delivery.
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
-        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
+        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500), TestContext.Current.CancellationToken);
 
         // Database recovers: the probe succeeds, closes the circuit, and the same run resumes full-batch processing.
         _storage.FailWrites = false;
 
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
         await CollectMessages(testProbe, 6, TimeSpan.FromSeconds(5));
-        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
+        await testProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500), TestContext.Current.CancellationToken);
     }
 }

--- a/src/Akka.Reminders.Tests/WriteCircuitBreakerSpecs.cs
+++ b/src/Akka.Reminders.Tests/WriteCircuitBreakerSpecs.cs
@@ -193,17 +193,17 @@ public class WriteCircuitBreakerSpecs : Akka.Hosting.TestKit.TestKit
         await WaitForSchedulerReady(scheduler);
 
         scheduler.Tell(new ReminderProtocol.ScheduleReminder(entity, key, dueTime, "payload"), responseProbe.Ref);
-        var scheduled = await responseProbe.ExpectMsgAsync<ReminderProtocol.ReminderScheduled>(TimeSpan.FromSeconds(1));
+        var scheduled = await responseProbe.ExpectMsgAsync<ReminderProtocol.ReminderScheduled>(TimeSpan.FromSeconds(1), cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal(ReminderScheduleResponseCode.Success, scheduled.ResponseCode);
 
         testScheduler.Advance(TimeSpan.FromSeconds(2));
-        await target.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5));
+        await target.ExpectMsgAsync<ReminderEnvelope<string>>(TimeSpan.FromSeconds(5), cancellationToken: TestContext.Current.CancellationToken);
         _storage.FailWrites = true;
         testScheduler.Advance(TimeSpan.FromMilliseconds(100));
 
-        await _storage.FirstCommitMutationFailure.WaitAsync(TimeSpan.FromSeconds(5));
+        await _storage.FirstCommitMutationFailure.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         var attemptsAfterFailure = _storage.CommitMutationAttempts;
-        await target.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+        await target.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
         Assert.Equal(attemptsAfterFailure, _storage.CommitMutationAttempts);
 
         _storage.FailWrites = false;
@@ -215,7 +215,7 @@ public class WriteCircuitBreakerSpecs : Akka.Hosting.TestKit.TestKit
             Assert.Equal(ReminderCompletionStatus.Pending, status.CompletionStatus);
             Assert.Equal(1, status.AttemptCount);
             Assert.Equal("Ack timeout", status.LastFailureReason);
-        }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(50));
+        }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -226,11 +226,11 @@ public class WriteCircuitBreakerSpecs : Akka.Hosting.TestKit.TestKit
         var entity = new ReminderEntity("test-region", "read-failure");
         var key = new ReminderKey("read-failure");
         var reminder = new ScheduledReminder(entity, key, now.AddHours(1), "payload");
-        await _innerStorage.ScheduleReminderAsync(reminder);
+        await _innerStorage.ScheduleReminderAsync(reminder, ct: TestContext.Current.CancellationToken);
         await _innerStorage.CommitReminderMutationsAsync(new ReminderMutationBatch(
             [],
             [],
-            [new AwaitingAckReminder(entity, key, reminder.DueTimeUtc, now, now.AddMinutes(1))]));
+            [new AwaitingAckReminder(entity, key, reminder.DueTimeUtc, now, now.AddMinutes(1))]), ct: TestContext.Current.CancellationToken);
 
         var scheduler = CreateScheduler();
         await WaitForSchedulerReady(scheduler);
@@ -243,14 +243,14 @@ public class WriteCircuitBreakerSpecs : Akka.Hosting.TestKit.TestKit
             "payload");
         _storage.FailReads = true;
 
-        var nack = await client.NackAsync(envelope, "failed");
-        var status = await client.GetOccurrenceStatusAsync(key, reminder.DueTimeUtc);
+        var nack = await client.NackAsync(envelope, "failed", ct: TestContext.Current.CancellationToken);
+        var status = await client.GetOccurrenceStatusAsync(key, reminder.DueTimeUtc, ct: TestContext.Current.CancellationToken);
 
         Assert.Equal(ReminderNackResponseCode.Error, nack.ResponseCode);
         Assert.Equal(ReminderOccurrenceStatusResponseCode.Error, status.ResponseCode);
 
         _storage.FailReads = false;
-        var unchanged = await _innerStorage.GetReminderOccurrenceStatusAsync(entity, key, reminder.DueTimeUtc);
+        var unchanged = await _innerStorage.GetReminderOccurrenceStatusAsync(entity, key, reminder.DueTimeUtc, ct: TestContext.Current.CancellationToken);
         Assert.NotNull(unchanged);
         Assert.Equal(ReminderCompletionStatus.AwaitingAck, unchanged.CompletionStatus);
         Assert.Equal(0, unchanged.AttemptCount);

--- a/src/Akka.Reminders/ReminderProtocol.cs
+++ b/src/Akka.Reminders/ReminderProtocol.cs
@@ -266,15 +266,15 @@ public static class ReminderProtocol
             MaxDeliveryWindow: MaxDeliveryWindow);
     }
 
-    public sealed record CancelReminder(ReminderEntity Entity, ReminderKey Key) : IReminderCommand;
+    public sealed record CancelReminder(ReminderEntity Entity, ReminderKey Key) : IReminderCommand, IReminderWireMessage;
 
-    public sealed record CancelAllReminders(ReminderEntity Entity) : IReminderCommand;
+    public sealed record CancelAllReminders(ReminderEntity Entity) : IReminderCommand, IReminderWireMessage;
 
     public sealed record RemindersCancelled(
         ReminderEntity Entity,
         ReminderCancelResponseCode ResponseCode,
         IReadOnlyList<ReminderKey> Keys,
-        string? Message = null) : IReminderResponse;
+        string? Message = null) : IReminderResponse, IReminderWireMessage;
 
     public sealed record ReminderScheduled(
         ScheduleReminder OriginalCommand,
@@ -295,7 +295,7 @@ public static class ReminderProtocol
         public DateTimeOffset When => OriginalCommand.When;
     }
 
-    public sealed record GetReminders(ReminderEntity Entity) : IReminderQuery;
+    public sealed record GetReminders(ReminderEntity Entity) : IReminderQuery, IReminderWireMessage;
 
     public sealed record RemindersForEntity(
         ReminderEntity Entity,

--- a/src/Akka.Reminders/Serialization/ReminderSerializer.cs
+++ b/src/Akka.Reminders/Serialization/ReminderSerializer.cs
@@ -130,6 +130,10 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
     private const string ReminderNackResponseManifest = "rnr";
     private const string GetReminderOccurrenceStatusManifest = "rosq";
     private const string ReminderOccurrenceStatusResponseManifest = "rosr";
+    private const string CancelReminderManifest = "cr";
+    private const string CancelAllRemindersManifest = "car";
+    private const string RemindersCancelledManifest = "rc";
+    private const string GetRemindersManifest = "gr";
 
     private static readonly Type ReminderEnvelopeOpenGenericType = typeof(ReminderEnvelope<>);
 
@@ -165,6 +169,10 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
         ReminderProtocol.ReminderNackResponse => ReminderNackResponseManifest,
         ReminderProtocol.GetReminderOccurrenceStatus => GetReminderOccurrenceStatusManifest,
         ReminderProtocol.ReminderOccurrenceStatusResponse => ReminderOccurrenceStatusResponseManifest,
+        ReminderProtocol.CancelReminder => CancelReminderManifest,
+        ReminderProtocol.CancelAllReminders => CancelAllRemindersManifest,
+        ReminderProtocol.RemindersCancelled => RemindersCancelledManifest,
+        ReminderProtocol.GetReminders => GetRemindersManifest,
         _ => throw new ArgumentException($"{nameof(ReminderSerializer)} does not support serializing [{o.GetType().FullName}]", nameof(o))
     };
 
@@ -181,6 +189,10 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
         ReminderProtocol.ReminderNackResponse nackResponse => SerializeReminderNackResponse(nackResponse),
         ReminderProtocol.GetReminderOccurrenceStatus query => SerializeGetReminderOccurrenceStatus(query),
         ReminderProtocol.ReminderOccurrenceStatusResponse statusResponse => SerializeReminderOccurrenceStatusResponse(statusResponse),
+        ReminderProtocol.CancelReminder cancel => SerializeCancelReminder(cancel),
+        ReminderProtocol.CancelAllReminders cancelAll => SerializeCancelAllReminders(cancelAll),
+        ReminderProtocol.RemindersCancelled cancelled => SerializeRemindersCancelled(cancelled),
+        ReminderProtocol.GetReminders getReminders => SerializeGetReminders(getReminders),
         _ => throw new ArgumentException($"{nameof(ReminderSerializer)} does not support serializing [{obj.GetType().FullName}]", nameof(obj))
     };
 
@@ -197,6 +209,10 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
         ReminderNackResponseManifest => DeserializeReminderNackResponse(bytes),
         GetReminderOccurrenceStatusManifest => DeserializeGetReminderOccurrenceStatus(bytes),
         ReminderOccurrenceStatusResponseManifest => DeserializeReminderOccurrenceStatusResponse(bytes),
+        CancelReminderManifest => DeserializeCancelReminder(bytes),
+        CancelAllRemindersManifest => DeserializeCancelAllReminders(bytes),
+        RemindersCancelledManifest => DeserializeRemindersCancelled(bytes),
+        GetRemindersManifest => DeserializeGetReminders(bytes),
         _ => throw new ArgumentException($"{nameof(ReminderSerializer)} does not recognize manifest [{manifest}]", nameof(manifest))
     };
 
@@ -452,6 +468,115 @@ public sealed class ReminderSerializer : SerializerWithStringManifest
             responseCode,
             status,
             string.IsNullOrEmpty(message) ? null : message);
+    }
+
+    private static byte[] SerializeCancelReminder(ReminderProtocol.CancelReminder cancel)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+
+        writer.Write(cancel.Entity.ShardRegionName);
+        writer.Write(cancel.Entity.EntityId);
+        writer.Write(cancel.Key.Name);
+
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    private static ReminderProtocol.CancelReminder DeserializeCancelReminder(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes);
+        using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+
+        var entity = new ReminderEntity(reader.ReadString(), reader.ReadString());
+        var key = new ReminderKey(reader.ReadString());
+
+        return new ReminderProtocol.CancelReminder(entity, key);
+    }
+
+    private static byte[] SerializeCancelAllReminders(ReminderProtocol.CancelAllReminders cancelAll)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+
+        writer.Write(cancelAll.Entity.ShardRegionName);
+        writer.Write(cancelAll.Entity.EntityId);
+
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    private static ReminderProtocol.CancelAllReminders DeserializeCancelAllReminders(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes);
+        using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+
+        var entity = new ReminderEntity(reader.ReadString(), reader.ReadString());
+
+        return new ReminderProtocol.CancelAllReminders(entity);
+    }
+
+    private static byte[] SerializeRemindersCancelled(ReminderProtocol.RemindersCancelled cancelled)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+
+        writer.Write(cancelled.Entity.ShardRegionName);
+        writer.Write(cancelled.Entity.EntityId);
+        writer.Write((int)cancelled.ResponseCode);
+
+        writer.Write(cancelled.Keys.Count);
+        foreach (var key in cancelled.Keys)
+            writer.Write(key.Name);
+
+        writer.Write(cancelled.Message ?? string.Empty);
+
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    private static ReminderProtocol.RemindersCancelled DeserializeRemindersCancelled(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes);
+        using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+
+        var entity = new ReminderEntity(reader.ReadString(), reader.ReadString());
+        var responseCode = (ReminderCancelResponseCode)reader.ReadInt32();
+
+        var count = reader.ReadInt32();
+        var keys = new List<ReminderKey>(count);
+        for (var i = 0; i < count; i++)
+            keys.Add(new ReminderKey(reader.ReadString()));
+
+        var message = reader.ReadString();
+
+        return new ReminderProtocol.RemindersCancelled(
+            entity,
+            responseCode,
+            keys,
+            string.IsNullOrEmpty(message) ? null : message);
+    }
+
+    private static byte[] SerializeGetReminders(ReminderProtocol.GetReminders getReminders)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+
+        writer.Write(getReminders.Entity.ShardRegionName);
+        writer.Write(getReminders.Entity.EntityId);
+
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    private static ReminderProtocol.GetReminders DeserializeGetReminders(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes);
+        using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+
+        var entity = new ReminderEntity(reader.ReadString(), reader.ReadString());
+
+        return new ReminderProtocol.GetReminders(entity);
     }
 
     private static void WriteOccurrenceIdentity(


### PR DESCRIPTION
## Changes

Upgrades all Akka dependencies to **1.5.70** (latest stable) and migrates the test project to xunit v3.

- **Akka.Cluster.Hosting / Akka.Hosting.TestKit: 1.5.62 → 1.5.70** (brings in core Akka 1.5.70 transitively)
- **Tests migrate from xunit v2 to xunit v3** (3.2.2) — Akka.Hosting.TestKit 1.5.70 switched to `Akka.TestKit.Xunit` + xunit.v3, so keeping v2 produced duplicate-type conflicts (CS0433). `Akka.Reminders.Migration.Tests` stays on xunit v2 since it doesn't use the TestKit.
- **Explicit FluentAssertions reference (8.10.0)** — Akka.TestKit 1.5.70 no longer pulls it transitively.
- **xUnit1051 fixes** — threaded `TestContext.Current.CancellationToken` through test call sites (enforced as errors by `TreatWarningsAsErrors`), including named `ct`/named-`cancellationToken` argument forms where the token isn't the next positional param.
- Updated `IAsyncLifetime`/`IAsyncDisposable` overrides to `ValueTask` (xunit v3 contract).
- Removed obsolete `using Xunit.Abstractions;` directives.

Verified: `dotnet build -c Release` succeeds with 0 warnings / 0 errors.